### PR TITLE
fix(cli,opts): remove option for css

### DIFF
--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -120,8 +120,6 @@ struct xnvme_cli_args {
 	uint32_t main_core;
 	const char *core_mask;
 
-	struct xnvme_opts_css css; ///< SPDK controller-setup: do command-set-selection
-
 	uint32_t use_cmb_sqs;
 	const char *adrfam;
 
@@ -278,7 +276,6 @@ enum xnvme_cli_opt {
 	XNVME_CLI_OPT_CORE_MASK = 81, ///< XNVME_CLI_OPT_CORE_MASK
 
 	XNVME_CLI_OPT_USE_CMB_SQS = 82, ///< XNVME_CLI_OPT_USE_CMB_SQS
-	XNVME_CLI_OPT_CSS         = 83, ///< XNVME_CLI_OPT_CSS
 
 	XNVME_CLI_OPT_POLL_IO          = 84, ///< XNVME_CLI_OPT_POLL_IO
 	XNVME_CLI_OPT_POLL_SQ          = 85, ///< XNVME_CLI_OPT_POLL_SQ

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -6,11 +6,6 @@
  * @headerfile libxnvme_adm.h
  */
 
-struct xnvme_opts_css {
-	uint32_t value;
-	uint32_t given;
-};
-
 /**
  * xNVMe options
  *
@@ -19,35 +14,34 @@ struct xnvme_opts_css {
  * @struct xnvme_opts
  */
 struct xnvme_opts {
-	const char *be;            ///< Backend/system interface to use
-	const char *dev;           ///< Device manager/enumerator
-	const char *mem;           ///< Memory allocator to use for buffers
-	const char *sync;          ///< Synchronous Command-interface
-	const char *async;         ///> Asynchronous Command-interface
-	const char *admin;         ///< Administrative Command-interface
-	uint32_t nsid;             ///< Namespace identifier
-	uint8_t rdonly;            ///< OS open; for read only
-	uint8_t wronly;            ///< OS open; for write only
-	uint8_t rdwr;              ///< OS open; for read and write
-	uint8_t create;            ///< OS open; create if it does not exist
-	uint8_t truncate;          ///< OS open; truncate content
-	uint8_t direct;            ///< OS open; bypass OS-managed caching
-	uint32_t create_mode;      ///< OS file creation-mode
-	uint8_t poll_io;           ///< io_uring: enable io-polling
-	uint8_t poll_sq;           ///< io_uring: enable sqthread-polling
-	uint8_t register_files;    ///< io_uring: enable file-regirations
-	uint8_t register_buffers;  ///< io_uring: enable buffer-registration
-	struct xnvme_opts_css css; ///< SPDK controller-setup: do command-set-selection
-	uint32_t use_cmb_sqs;      ///< SPDK controller-setup: use controller-memory-buffer for sq
-	uint32_t shm_id;           ///< SPDK multi-processing: shared-memory-id
-	uint32_t main_core;        ///< SPDK multi-processing: main-core
-	const char *core_mask;     ///< SPDK multi-processing: core-mask
-	const char *adrfam;        ///< SPDK fabrics: address-family, IPv4/IPv6
-	const char *subnqn;        ///< SPDK fabrics: Subsystem NQN
-	const char *hostnqn;       ///< SPDK fabrics: Host NQN
-	uint32_t admin_timeout;    ///< SPDK fabrics: enable admin command timeout
-	uint32_t command_timeout;  ///< SPDK fabrics: enable io command timeout
-	uint32_t spdk_fabrics;     ///< Is assigned a value by backend if SPDK uses fabrics
+	const char *be;           ///< Backend/system interface to use
+	const char *dev;          ///< Device manager/enumerator
+	const char *mem;          ///< Memory allocator to use for buffers
+	const char *sync;         ///< Synchronous Command-interface
+	const char *async;        ///> Asynchronous Command-interface
+	const char *admin;        ///< Administrative Command-interface
+	uint32_t nsid;            ///< Namespace identifier
+	uint8_t rdonly;           ///< OS open; for read only
+	uint8_t wronly;           ///< OS open; for write only
+	uint8_t rdwr;             ///< OS open; for read and write
+	uint8_t create;           ///< OS open; create if it does not exist
+	uint8_t truncate;         ///< OS open; truncate content
+	uint8_t direct;           ///< OS open; bypass OS-managed caching
+	uint32_t create_mode;     ///< OS file creation-mode
+	uint8_t poll_io;          ///< io_uring: enable io-polling
+	uint8_t poll_sq;          ///< io_uring: enable sqthread-polling
+	uint8_t register_files;   ///< io_uring: enable file-regirations
+	uint8_t register_buffers; ///< io_uring: enable buffer-registration
+	uint32_t use_cmb_sqs;     ///< SPDK controller-setup: use controller-memory-buffer for sq
+	uint32_t shm_id;          ///< SPDK multi-processing: shared-memory-id
+	uint32_t main_core;       ///< SPDK multi-processing: main-core
+	const char *core_mask;    ///< SPDK multi-processing: core-mask
+	const char *adrfam;       ///< SPDK fabrics: address-family, IPv4/IPv6
+	const char *subnqn;       ///< SPDK fabrics: Subsystem NQN
+	const char *hostnqn;      ///< SPDK fabrics: Host NQN
+	uint32_t admin_timeout;   ///< SPDK fabrics: enable admin command timeout
+	uint32_t command_timeout; ///< SPDK fabrics: enable io command timeout
+	uint32_t spdk_fabrics;    ///< Is assigned a value by backend if SPDK uses fabrics
 };
 
 /**

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -362,8 +362,8 @@ _spdk_setup_controller_opts(struct xnvme_opts *opts, const struct spdk_nvme_tran
 #ifdef XNVME_DEBUG_ENABLED
 	_spdk_nvme_transport_id_pr(trid);
 #endif
-
-	ctrlr_opts->command_set = opts->css.given ? opts->css.value : SPDK_NVME_CC_CSS_IOCS;
+	// Always support one or more IO command sets
+	ctrlr_opts->command_set = SPDK_NVME_CC_CSS_IOCS;
 
 	switch (trid->trtype) {
 	case SPDK_NVME_TRANSPORT_PCIE:

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -632,12 +632,6 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "For be=spdk, use controller-memory-buffer for sqs",
 	},
 	{
-		.opt = XNVME_CLI_OPT_CSS,
-		.vtype = XNVME_CLI_OPT_VTYPE_HEX,
-		.name = "css",
-		.descr = "For be=spdk, ctrl.config. command-set-selection",
-	},
-	{
 		.opt = XNVME_CLI_OPT_ADRFAM,
 		.vtype = XNVME_CLI_OPT_VTYPE_STR,
 		.name = "adrfam",
@@ -1390,11 +1384,6 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 	case XNVME_CLI_OPT_USE_CMB_SQS:
 		args->use_cmb_sqs = arg ? num : 0;
 		break;
-	case XNVME_CLI_OPT_CSS:
-		args->css.value = arg ? num : 0;
-		args->css.given = arg ? 1 : 0;
-		break;
-
 	case XNVME_CLI_OPT_POLL_IO:
 		args->poll_io = arg ? num : 0;
 		break;
@@ -1921,9 +1910,6 @@ xnvme_cli_to_opts(const struct xnvme_cli *cli, struct xnvme_opts *opts)
 	opts->register_buffers = cli->given[XNVME_CLI_OPT_REGISTER_BUFFERS]
 					 ? cli->args.register_buffers
 					 : opts->register_buffers;
-
-	opts->css.value = cli->given[XNVME_CLI_OPT_CSS] ? cli->args.css.value : opts->css.value;
-	opts->css.given = cli->given[XNVME_CLI_OPT_CSS] ? cli->args.css.given : opts->css.given;
 
 	opts->use_cmb_sqs =
 		cli->given[XNVME_CLI_OPT_USE_CMB_SQS] ? cli->args.use_cmb_sqs : opts->use_cmb_sqs;

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -72,9 +72,6 @@ xnvme_opts_yaml(FILE *stream, const struct xnvme_opts *opts, int indent, const c
 	wrtn += fprintf(stream, "%*sregister_buffers: %" PRIu8 "%s", indent, "",
 			opts->register_buffers, sep);
 
-	wrtn += fprintf(stream, "%*scss.given: %" PRIu32 "%s", indent, "", opts->css.given, sep);
-	wrtn += fprintf(stream, "%*scss.value: 0x%" PRIx32 "%s", indent, "", opts->css.value, sep);
-
 	wrtn += fprintf(stream, "%*suse_cmb_sqs: 0x%" PRIx32 "%s", indent, "", opts->use_cmb_sqs,
 			sep);
 	wrtn += fprintf(stream, "%*sshm_id: 0x%" PRIx32 "%s", indent, "", opts->shm_id, sep);


### PR DESCRIPTION
The SPDK option for selecting command set is entirely unused in our code. This means that it has always been set to "one or more io command sets". This makes sense for our use case, and there seems to be nothing to gain, in limiting the IO to only NVM or even no IO (only admin).

As such, remove this unused opt and struct.

(Additionally, this opt follows an outdated convention and is generally just an eye-sore.)