### PR TITLE
Adjust website / docs. deployment script to the new theme

### DIFF
--- a/docs/autogen/dest.py
+++ b/docs/autogen/dest.py
@@ -1,4 +1,56 @@
 #!/usr/bin/env python3
+"""
+    This script organizes the website and documentation for xnvme.io
+
+    When running ``make`` inside of ``<xnvme_repository>/docs/autogen/`` then an
+    instance of the website / documentation is emitted at::
+
+        <xnvme_repository>/docs/autogen/builddir/html
+
+    This path is given to the script via ``<args.docs>`.
+
+    The documention/website lives in a repository dedicated to GitHUB pages, a path
+    to this repository is given to the script via ``<args.site>``.
+
+    The intent of the organization is two-fold:
+
+    * Provide a preview of website/documentation of the current state of the 'next'
+      branch, as well as other in-development branches
+
+    * Keep a bit of history on the project documentation available online, e.g. for
+      those not on the latest release.
+
+    Supported refs. are on the form:
+
+        refs/heads/<branch_name>
+        refs/tags/<tag_name>
+
+    The organization is as follows, for all refs, then the folder ``<args.docs>`` is
+    renamed to ``<args.ref>`` and is placed in ``<args.site>/docs/<args.ref>``, here are
+    a couple of examples::
+
+        <args.site>/docs/main
+        <args.site>/docs/next
+        <args.site>/docs/v1.2.3
+
+    This is the archive/history part of the organization. The latest version of the
+    website and documentation lives in the root of ``<args.site>``:
+
+        <args.site>/.
+
+    In addition to the things emitted by sphinx-doc, then there are a couple of files
+    specific to GitHub pages, things like ``.nojekyll``, a README.md and stuff like
+    that, these files and the folder ``docs`` are recorded in a ``KEEPLIST``.
+
+    This organization is done by:
+
+    * Removing everything in ``<args.site>`` that is not in KEEPLIST
+    * Copy ``<args.docs>`` to ``<args.site>/docs/<args.ref>``
+    * Copy ``<args.site>/docs/main/.`` to ``<args.site>/.``
+
+    It is left to another script to commit / push the GitHUB pages repository.
+"""
+
 import argparse
 import shutil
 import sys
@@ -15,11 +67,11 @@ KEEPLIST = [
 
 
 def parse_args():
-    """Parse command-line arguments for cij_extractor"""
+    """Parse command-line arguments for docs destination script"""
 
     # Parse the Command-Line
     prsr = argparse.ArgumentParser(
-        description="cij_extractor - CIJOE Test data extractor",
+        description="xNVMe documentation organizer",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     prsr.add_argument(

--- a/docs/autogen/dest.py
+++ b/docs/autogen/dest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import argparse
-import os
 import shutil
 import sys
+from pathlib import Path
 
 
 def parse_args():
@@ -14,14 +14,18 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     prsr.add_argument(
-        "--docs", help="Path SphinxDoc generated HTML", default=os.getcwd()
+        "--docs",
+        help="Path to SphinxDoc generated HTML",
+        default=Path.cwd(),
+        type=Path,
     )
     prsr.add_argument(
         "--site",
         help="Path to xNVMe.io GitHUB Repository",
-        default=os.getcwd(),
+        type=Path,
+        default=Path.cwd(),
     )
-    prsr.add_argument("--ref", help="xNVMe repository reference", default=os.getcwd())
+    prsr.add_argument("--ref", help="xNVMe repository reference")
     args = prsr.parse_args()
 
     return args
@@ -45,8 +49,8 @@ def main(args):
 
     ref = "-".join(args.ref.split("/")[2:])
 
-    ref_path = os.path.join(args.site, "docs", ref)
-    if os.path.exists(ref_path):
+    ref_path = Path(args.site) / "docs" / ref
+    if ref_path.exists():
         print(f"Removing: '{ref_path}'")
         shutil.rmtree(ref_path)
 
@@ -56,8 +60,8 @@ def main(args):
     if not is_tag:
         return 0
 
-    latest_path = os.path.join(args.site, "docs", "latest")
-    if os.path.exists(latest_path):
+    latest_path = Path(args.site) / "docs" / "latest"
+    if latest_path.exists():
         print(f"Removing: '{latest_path}'")
         shutil.rmtree(latest_path)
 


### PR DESCRIPTION
The theme introduced in https://github.com/xnvme/xnvme/pull/430 combines the website and the sphinx-doc emitted generation into a single site. Thus, to manage this, then the deployment script needs to handle organizing not just ``docs/<branch>/<tag>`` but also the root of the GItHub pages repository / website.