### PR TITLE
Documentation overhaul: add user-selectable versions and current site

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -800,21 +800,25 @@ jobs:
   #
   # * push of branches and tags
   # * manual 'workflow_dispatch'
+  # * pull-request changes, thus, we can catch whether a PR breaks documentation
   #
-  # When triggered on push to branch, then the documentation is deployed to:
+  # When triggered by 'push' or 'workflow_dispatch', then the documentation is
+  # deployed to:
   #
-  #   githubpages/docs/<branch>
+  #   githubpages/docs/<github.ref>
   #
-  # For example: githubpages/docs/next
+  # A couple of examples:
   #
-  # When triggered on push of tag, then the documentation is deployed to:
+  # * githubpages/docs/next
+  # * githubpages/docs/current
+  # * githubpages/docs/foo
+  # * githubpages/docs/v1.2.3
+  # * githubpages/docs/v1.2.4
   #
-  #   githubpages/docs/<tag>
-  #   githubpages/docs/latest
+  # Thus, upon push/dispatch then the archive/history is updated
+  # The root of the site is always synced with githubpages/docs/current in case
+  # there are no changes to "docs/current", then there is nothing to commit
   #
-  # For example: githubpages/docs/v0.5.0
-  # Note that latest is always populated when pushing as tag. It is assumed
-  # that tags are used exclusively for releases
   docgen:
     needs: [source-archive-with-subprojects, source-format-check, build-python]
     runs-on: [self-hosted, linux, verify]
@@ -910,12 +914,16 @@ jobs:
       run: |
         git config --global --add safe.directory $(pwd)/site
 
-    - name: Add docgen to site
+    - name: Extract the website
       if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))
       run: |
         cp cijoe/docgen-${{ matrix.guest.os }}-${{ matrix.guest.ver }}/artifacts/docs.tar.gz .
         tar xzf docs.tar.gz
-        ./docs/autogen/dest.py --docs html --site site --ref "${{ github.ref }}"
+
+    - name: Update site repository
+      if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))
+      run: |
+        ./docs/autogen/dest.py --docs html --site site --ref "${{ github.ref }}" --current current
 
     - name: Push site-changes
       if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))

--- a/docs/autogen/conf.py
+++ b/docs/autogen/conf.py
@@ -97,6 +97,7 @@ html_theme_options = {
     "navigation_depth": 4,
     "navigation_with_keys": False,
     "navbar_align": "left",
+    "navbar_end": ["version-switcher"],
     "header_links_before_dropdown": 7,
     "secondary_sidebar_items": {
         "material/index": [],
@@ -115,6 +116,10 @@ html_theme_options = {
             "icon": "fa-brands fa-discord",
         },
     ],
+    "switcher": {
+        "json_url": "/versions.json",
+        "version_match": "current",
+    },
 }
 
 html_sidebars = {

--- a/docs/contributing/contributing-branches.rst
+++ b/docs/contributing/contributing-branches.rst
@@ -14,6 +14,12 @@ Branches
 ``next`` Staging / integration
    This is where GitHUB pull-requests should point to.
 
+``current`` Website updates
+   This is based off ``main`` and only contains changes to the website /
+   documentation, that is, to ensure that the website by default serves
+   documentation for the latest release, however, with the option of changing
+   the rest of the documentation around that release.
+
 ``rc`` Release candidate prepping
    This provides the "maintenance" changes when no more
    features are going in, this includes:
@@ -21,7 +27,7 @@ Branches
    version-bump
    man-pages
    bash-completions
-   documentation-generation (API and Command output)
+   documentation-generation (API and Command output) - integrate ``current``
    CHANGELOG.rst
    CONTRIBUTORS.md
 

--- a/docs/contributing/contributing-branches.rst
+++ b/docs/contributing/contributing-branches.rst
@@ -29,5 +29,3 @@ Branches
    ``rc`` is integrated on ``next``
    ``next`` is integrated on ``main``
    ``main`` is tagged with the version-number (``vX.Y.Z``)
-
-``docker`` Consumed by GitHUB Actions producing xNVMe docker images


### PR DESCRIPTION
* Add an option to dest.py to select which instance of the website / documentation to add to the site-root and set as "current" in versions.json

  - Previously, this would always be 'main', however, this implies that the website can only be updated with releases of xNVMe, this is not practical. Thus this to provide pushes to e.g. the 'website' branch to update the site-root.
  - Care should be taken to then have such a 'docs' branch be based on top of 'main' such that changes in e.g. api or otherwise does not trickle into the docs.

* Extend the autogen/dest.py script to emit versions.json for the PyData theme to consume

* Adjust conf.py; set html-theme options for the PyData config to consume the generated versions.json