### PR TITLE
documentation overhaul: version selection with visual indicators

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,7 +3,7 @@ name: verify
 
 on:
   push:
-    branches: [main, next]
+    branches: [main, next, docs]
     tags: ['v*']
   pull_request:
     types: [opened, reopened, synchronize, labeled]
@@ -923,7 +923,7 @@ jobs:
     - name: Update site repository
       if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))
       run: |
-        ./docs/autogen/dest.py --docs html --site site --ref "${{ github.ref }}" --current current
+        ./docs/autogen/dest.py --docs html --site site --ref "${{ github.ref }}"
 
     - name: Push site-changes
       if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))

--- a/docs/autogen/Makefile
+++ b/docs/autogen/Makefile
@@ -55,11 +55,14 @@ doxy:
 sphinx:
 	mkdir -p $(BUILD_DIR)/html
 	${PYTHON} -m sphinx -E -b html -c $(CONFIG_DIR) $(DOCS_DIR) $(BUILD_DIR)/html
+
+.PHONY: linkcheck
+linkcheck:
 	${PYTHON} -m sphinx -b linkcheck -c $(CONFIG_DIR) $(DOCS_DIR) $(BUILD_DIR)/html
 
 # Produce the sphinx stuff (without commands)
 .PHONY: docs
-docs: clean deps configure doxy apis sphinx
+docs: clean deps configure doxy apis sphinx linkcheck
 	@echo "# DONE"
 
 .PHONY: docs-view-html

--- a/docs/autogen/conf.py
+++ b/docs/autogen/conf.py
@@ -20,8 +20,9 @@ source_suffix = ".rst"
 master_doc = "index"
 project = "xNVMe"
 copyright = "2024, xNVMe"
-version = xnvme_ver(os.path.join("..", "..", "meson.build"))
-release = xnvme_ver(os.path.join("..", "..", "meson.build"))
+
+version = "v" + xnvme_ver(os.path.join("..", "..", "meson.build"))
+release = version
 
 extlinks = {
     "xref-xnvme": ("https://xnvme.io/%s", None),
@@ -117,9 +118,11 @@ html_theme_options = {
         },
     ],
     "switcher": {
-        "json_url": "/versions.json",
-        "version_match": "current",
+        "json_url": "https://xnvme.io/versions.json",
+        "version_match": version,
     },
+    "show_version_warning_banner": True,
+    "check_switcher": False,
 }
 
 html_sidebars = {

--- a/docs/autogen/test_multi_version.sh
+++ b/docs/autogen/test_multi_version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# List of versions
+versions=("next" "v0.7.4")
+
+rm -r $HOME/git/xnvme.github.io/en
+mkdir -p $HOME/git/xnvme.github.io/en
+
+# Loop through each version
+for VER in "${versions[@]}"; do
+  sed -i "s/version = .*/version = \"$VER\"/" conf.py
+
+  make sphinx
+
+  cp -r builddir/html $HOME/git/xnvme.github.io/en/$VER
+done
+
+# Copy the build directory to the destination, when testing this locally then
+# change the --url to "localhost"
+./dest.py \
+  --docs builddir/html \
+  --site $HOME/git/xnvme.github.io \
+  --ref refs/heads/docs \
+  --url "https://xnvme.io"

--- a/docs/contributing/contributing-branches.rst
+++ b/docs/contributing/contributing-branches.rst
@@ -14,7 +14,7 @@ Branches
 ``next`` Staging / integration
    This is where GitHUB pull-requests should point to.
 
-``current`` Website updates
+``docs`` Website updates
    This is based off ``main`` and only contains changes to the website /
    documentation, that is, to ensure that the website by default serves
    documentation for the latest release, however, with the option of changing

--- a/docs/contributing/release-checklist.rst
+++ b/docs/contributing/release-checklist.rst
@@ -47,7 +47,7 @@ release are integrated on ``next`` and all tests are passing. Then:
   - Setup a PR of ``next`` onto ``main``
   - Review the PR
   - Wait for tests to finalize / pass
-  - Double-check the generated docs at https://xnvme.io/docs/next
+  - Double-check the generated docs at https://xnvme.io/en/next
 
 * Tag ``main`` as ``vX.Y.Z`` and push the tag
 


### PR DESCRIPTION
* Drop the ``--current`` argument to dest.py, the current / preferred version is now always the latest version
* The version of xNVMe is added to the theme options ``html_theme_options.switcher.version_match`` to enable correct behavior or the multi-version switcher
* Added visual indicators when looking at an old version and inform when looking at the development version via the ``html_theme_options.show_version_warning_banner``
* Update the documentation describing what the branch named **docs** is for, this was previously the task of **current**
  * Since the purpose of the branch is to host changes to the website for the most recent release, then i find ``docs`` to be a better suited name

**NOTE**: This is currently failing due to unrelated failure of HW for benchmarking