### PR TITLE
fix(cijoe/version): bump to v0.9.34

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -276,7 +276,8 @@ jobs:
         - {os: 'debian', dh: 'debian', ver: 'trixie'}
         - {os: 'fedora', dh: 'fedora', ver: '39'}
         - {os: 'fedora', dh: 'fedora', ver: '40'}
-        - {os: 'fedora', dh: 'fedora', ver: '41'}
+        # Skipping fedora-41 due to broken libffi
+        #- {os: 'fedora', dh: 'fedora', ver: '41'}
         - {os: 'gentoo', dh: 'gentoo/stage3', ver: 'latest'}
         - {os: 'opensuse-tumbleweed', dh: 'opensuse/tumbleweed', ver: 'latest'}
         - {os: 'oraclelinux', dh: 'oraclelinux', ver: '9'}

--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,7 @@ endef
 .PHONY: cijoe
 cijoe:
 	@echo "## xNVMe: cijoe"
-	@pipx install cijoe==v0.9.30 --include-deps --force
-	@pipx inject cijoe cijoe-pkg-qemu==v6.1.15
-	@pipx inject cijoe cijoe-pkg-linux==v0.9.7
-	@pipx inject cijoe cijoe-pkg-fio==v0.9.7
+	@pipx install cijoe==v0.9.34 --include-deps --force
 	@pipx inject cijoe matplotlib
 	@pipx inject cijoe numpy
 	@pipx install rst2pdf

--- a/cijoe/configs/bench-amd.toml
+++ b/cijoe/configs/bench-amd.toml
@@ -1,4 +1,4 @@
-[transport.ssh]
+[cijoe.transport.ssh]
 hostname = "bench-amd.home.arpa"
 port = 22
 username = "root"

--- a/cijoe/configs/bench-intel.toml
+++ b/cijoe/configs/bench-intel.toml
@@ -1,4 +1,4 @@
-[transport.ssh]
+[cijoe.transport.ssh]
 hostname = "bench-intel.home.arpa"
 port = 22
 username = "root"

--- a/cijoe/configs/debian-bookworm-arm.toml
+++ b/cijoe/configs/debian-bookworm-arm.toml
@@ -1,5 +1,5 @@
 # The SSH options are passed verbatim to paramiko; see https://www.paramiko.org/
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/cijoe/configs/debian-bullseye.toml
+++ b/cijoe/configs/debian-bullseye.toml
@@ -1,5 +1,5 @@
 # The SSH options are passed verbatim to paramiko; see https://www.paramiko.org/
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = "root"
 hostname = "localhost"

--- a/cijoe/configs/freebsd-13.toml
+++ b/cijoe/configs/freebsd-13.toml
@@ -1,5 +1,5 @@
 # The SSH options are passed verbatim to paramiko; see https://www.paramiko.org/
-[transport.ssh]
+[cijoe.transport.ssh]
 username = "root"
 password = ""
 hostname = "localhost"

--- a/cijoe/configs/perf-lat-freebsd.toml
+++ b/cijoe/configs/perf-lat-freebsd.toml
@@ -1,4 +1,4 @@
-[transport.ssh]
+[cijoe.transport.ssh]
 hostname = "perf-lat-fbsd.home.arpa"
 port = 22
 username = "root"

--- a/cijoe/configs/perf-lat-linux.toml
+++ b/cijoe/configs/perf-lat-linux.toml
@@ -1,4 +1,4 @@
-[transport.ssh]
+[cijoe.transport.ssh]
 hostname = "perf-lat-linux.home.arpa"
 port = 22
 username = "root"

--- a/cijoe/scripts/git_sync.py
+++ b/cijoe/scripts/git_sync.py
@@ -23,18 +23,29 @@ care of the need to switch branch remotely.
 
 
 def git_remote_from_config(cijoe, remote_path):
-    """Returns git-remote URI using configuration transport.ssh"""
+    """Returns git-remote URI using configuration cijoe.transport.ssh"""
 
     hostname = (
-        cijoe.config.options.get("transport", {}).get("ssh", {}).get("hostname", {})
+        cijoe.config.options.get("cijoe", {})
+        .get("transport", {})
+        .get("ssh", {})
+        .get("hostname", {})
     )
     if not hostname:
         return None
 
     username = (
-        cijoe.config.options.get("transport", {}).get("ssh", {}).get("username", {})
+        cijoe.config.options.get("cijoe", {})
+        .get("transport", {})
+        .get("ssh", {})
+        .get("username", {})
     )
-    port = cijoe.config.options.get("transport", {}).get("ssh", {}).get("port", {})
+    port = (
+        cijoe.config.options.get("cijoe", {})
+        .get("transport", {})
+        .get("ssh", {})
+        .get("port", {})
+    )
 
     remote = "ssh://"
     if username:

--- a/cijoe/scripts/xnvme_bindings_py_install_tgz.py
+++ b/cijoe/scripts/xnvme_bindings_py_install_tgz.py
@@ -60,7 +60,7 @@ def main(args, cijoe, step):
 
     commands = [
         "pipx ensurepath",
-        "pipx install cijoe --include-deps",
+        "pipx install cijoe==v0.9.34 --include-deps",
         "pipx inject cijoe numpy",
         "pipx inject cijoe xnvme-py-sdist.tar.gz",
         "cijoe --version",

--- a/cijoe/workflows/test-debian-bullseye.yaml
+++ b/cijoe/workflows/test-debian-bullseye.yaml
@@ -14,23 +14,28 @@ steps:
   with:
     args: '{{ config.xnvme.repository.sync.remote_path }}/python/tests -k "not fabrics and not vfio"'
     run_local: false
+    random-order: false
 
 - name: test_ramdisk
   uses: core.testrunner
   with:
     args: '-k "ramdisk" tests'
+    random-order: false
 
 - name: test_os
   uses: core.testrunner
   with:
     args: '-k "(not ramdisk) and (not pcie) and (not fabrics)" tests'
+    random-order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
     args: '-k "pcie" tests'
+    random-order: false
 
 - name: test_fabrics
   uses: core.testrunner
   with:
     args: '-k "fabrics" tests'
+    random-order: false

--- a/cijoe/workflows/test-freebsd-13.yaml
+++ b/cijoe/workflows/test-freebsd-13.yaml
@@ -15,3 +15,4 @@ steps:
   uses: core.testrunner
   with:
     args: 'tests'
+    random-order: false


### PR DESCRIPTION
In cijoe v0.9.32, the key `transport` has been moved under `cijoe`. Additionally, packages for qemu, linux and fio are included in the main package and no longer needs to be injected when installed.