### PR TITLE
feat(dev): add check of 'dev_uri' in xnvme_dev_open()

### DIFF
--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -568,6 +568,11 @@ xnvme_dev_open(const char *dev_uri, struct xnvme_opts *opts)
 	struct xnvme_dev *dev = NULL;
 	int err;
 
+	if (!dev_uri) { ///< Ensure a dev_uri is given
+		errno = EINVAL;
+		return NULL;
+	}
+
 	if (!opts) { ///< Set defaults when none are given
 		opts = &opts_default;
 	}


### PR DESCRIPTION
Add a check for 'dev_uri' in xnvme_dev_open() to prevent segmentation
faults.

This defensive check helps avoid potential crashes when 'dev_uri' is
not specified, such as when calling xnvme_dev_open(argv[1], ...) without
providing an argument. Arguably, improving the initial experience for
new users by ensuring a valid argument is provided.