### PR TITLE
fix(cijoe/qemu): prolong timeout for guest.is_up()

### DIFF
--- a/cijoe/scripts/xnvme_guest_start_nvme.py
+++ b/cijoe/scripts/xnvme_guest_start_nvme.py
@@ -277,7 +277,7 @@ def main(args, cijoe, step):
         log.error(f"guest.start() : err({err})")
         return err
 
-    started = guest.is_up()
+    started = guest.is_up(timeout=240)
     if not started:
         log.error("guest.is_up() : False")
         return errno.EAGAIN


### PR DESCRIPTION
verify freebsd script keeps failing without this