### PR TITLE
Fix FreeBSD build errors

### DIFF
--- a/toolbox/pkgs/emitter/deps.yaml
+++ b/toolbox/pkgs/emitter/deps.yaml
@@ -94,7 +94,7 @@ deps:
       default: [pipx] # apt, pip, dnf
       pacman: [python-pipx]
       pip: [pipx]
-      pkg: [py39-pipx]
+      pkg: [devel/py-pipx]
       zypper: [python3-pipx]
 
   archive:

--- a/toolbox/pkgs/freebsd-13.sh
+++ b/toolbox/pkgs/freebsd-13.sh
@@ -11,6 +11,7 @@ pkg install -qy \
  automake \
  bash \
  cunit \
+ devel/py-pipx \
  devel/py-pyelftools \
  e2fsprogs-libuuid \
  findutils \
@@ -24,7 +25,6 @@ pkg install -qy \
  openssl \
  patch \
  pkgconf \
- py39-pipx \
  python3 \
  wget
 


### PR DESCRIPTION
Currently, the FreeBSD build fails because it tries to install pipx using the wrong pkg-name. This fixes the issue