### PR TITLE
fix(cijoe/latency): remove redundant git pull command

### DIFF
--- a/cijoe/scripts/spdk_build_modded.py
+++ b/cijoe/scripts/spdk_build_modded.py
@@ -54,7 +54,6 @@ def main(args, cijoe, step):
     commands = [
         "make clean || true",
         "git clean -dfx",
-        "git pull --rebase",
         "git rev-parse --short HEAD",
         "git status",
         "git submodule deinit -f .",

--- a/cijoe/scripts/spdk_build_modded_freebsd.py
+++ b/cijoe/scripts/spdk_build_modded_freebsd.py
@@ -54,7 +54,6 @@ def main(args, cijoe, step):
     commands = [
         "gmake clean || true",
         "git clean -dfx",
-        "git pull --rebase",
         "git rev-parse --short HEAD",
         "git status",
         "git submodule deinit -f .",


### PR DESCRIPTION
After we changed the latency workflows to use upstream SPDK at tag v24.05, we cannot do `git pull --rebase`, as we are not in a branch. The `repository_prep` script makes sure that the repository is up to date with the tag, so the command is redundant and can be removed without problems.