### PR TITLE
feat(cijoe/bench): add resource utilization plots to report

### DIFF
--- a/cijoe/templates/perf_report/bench.jinja2.rst
+++ b/cijoe/templates/perf_report/bench.jinja2.rst
@@ -107,6 +107,14 @@ Establish roofline:
 With all the above, we can observe/compare how far the different IO
 storage-paths are from the HW-roofline.
 
+CPU usage
+---------
+We use the Linux ``perf`` tool to record the events of running
+``bdevperf``. With ``perf report``, we find the CPU usage of the 
+``bdev`` polling on the two cores. The usage is summed to gain the 
+total CPU usage in percent.
+
+
 .. raw:: pdf
 
    PageBreak
@@ -114,36 +122,50 @@ storage-paths are from the HW-roofline.
 Results
 =======
 
-The line plots, in this section, display the relationship between iodepth on the x-axis and
+The plots, in this section, display the relationship between iodepth on the x-axis and
 IOPS (Input/Output Operations Per Second) on the y-axis, illustrating how IOPS
 performance varies with different iodepth values.
+
+Additionally, there are plots displaying the relationship between iodepth and CPU usage.
+These illustrate how resource utilization varies with different iodepth values.
+
+.. raw:: pdf
+
+   PageBreak
 
 libaio
 ------
 
 Comparing ``bdev_xnvme``, with ``io_mechanism=libaio``, to ``bdev_aio``.
 
-.. image:: bdevperf_barplot_libaio.png
+.. image:: bdevperf_iops_barplot_libaio.png
    :align: center
-   :width: 100%
+   :width: 80%
 
 For ``libaio``, as shown above, the two lines overlap closely on the plot,
-indicating similar IOPS performance for ``bdev_xnvme`` with ``io_mechanism=libaio`` and ``bdev_aio`` across various iodepth
-values
+indicating similar IOPS performance for ``bdev_xnvme`` with ``io_mechanism=libaio`` and 
+``bdev_aio`` across various iodepth values.
+
+CPU usage
+~~~~~~~~~
+
+.. image:: bdevperf_cpu_barplot_libaio.png
+   :align: center
+   :width: 70%
 
 .. raw:: pdf
 
    PageBreak
+
 
 io_uring
 --------
 
 Comparing ``bdev_xnvme``, using ``io_mechanism=io_uring``, to ``bdev_uring``.
 
-
-.. image:: bdevperf_barplot_io_uring.png
+.. image:: bdevperf_iops_barplot_io_uring.png
    :align: center
-   :width: 100%
+   :width: 80%
 
 For ``io_uring``, as shown above, The plot reveals that **without** IO-polling
 (``conserve_cpu=1``), then ``bdev_xnvme`` exhibits slightly lower IOPS than the
@@ -151,10 +173,17 @@ reference implementation. However, when IO-polling is enabled
 (``conserve_cpu=0``), there's a noticeable boost in IOPS, showcasing its
 distinct advantage.
 
+CPU usage
+~~~~~~~~~
+
+.. image:: bdevperf_cpu_barplot_io_uring.png
+   :align: center
+   :width: 70%
 
 .. raw:: pdf
 
    PageBreak
+
 
 io_uring_cmd
 ------------
@@ -162,16 +191,24 @@ io_uring_cmd
 For ``io_uring_cmd``, there is no reference bdev-implementation, thus ``bdev_xnvme``, using ``io_mechanism=io_uring_cmd``, stands alone.
 
 
-.. image:: bdevperf_barplot_io_uring_cmd.png
+.. image:: bdevperf_iops_barplot_io_uring_cmd.png
    :align: center
-   :width: 100%
+   :width: 80%
 
 Comparing this graph to the graphs for ``libaio`` and ``io_uring``, ``io_uring_cmd`` shows a modest but clear
 advantage over the others, indicating that ``io_uring_cmd`` provides an improved IOPS performance in this scenario.
 
+CPU usage
+~~~~~~~~~
+
+.. image:: bdevperf_cpu_barplot_io_uring_cmd.png
+   :align: center
+   :width: 70%
+
 .. raw:: pdf
 
    PageBreak
+
 
 Latency at IO depth 1
 =====================

--- a/cijoe/templates/perf_report/style.yaml
+++ b/cijoe/templates/perf_report/style.yaml
@@ -35,6 +35,36 @@ styles:
     - 60%
     - 20%
     commands: []
+  picturetable:
+    parent: table
+    commands:
+    - - VALIGN
+      - - 0
+        - 0
+      - - -1
+        - -1
+      - TOP
+    - - INNERGRID
+      - - 0
+        - 0
+      - - -1
+        - -1
+      - 0.25
+      - white
+    - - ROWBACKGROUNDS
+      - - 0
+        - 0
+      - - -1
+        - -1
+      - - white
+        - white
+    - - BOX
+      - - 0
+        - 0
+      - - -1
+        - -1
+      - 0.25
+      - white
   bullet-list:
     parent: bodytext
     spaceBefore: 2


### PR DESCRIPTION
Add graphs for CPU usage (in percent) to the "xNVMe in SPDK" report.

Let's talk about how they should be visualized:
[xnvme-in-spdk.pdf](https://github.com/user-attachments/files/16507554/xnvme-in-spdk.pdf)


Memory utilization has been dropped. 
I could use some feedback on the Methodology section I've added.