### PR TITLE
Run latency benchmarking on Windows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -843,6 +843,7 @@ jobs:
         guest:
         - {os: 'freebsd', labels: [self-hosted, X64, perf-lat, perf-lat-fbsd]}
         - {os: 'linux', labels: [self-hosted, X64, perf-lat, perf-lat-linux]}
+        - {os: 'windows', labels: [self-hosted, X64, perf-lat, perf-lat-win]}
     runs-on: ${{ matrix.guest.labels }}
 
     container:

--- a/cijoe/auxiliary/plot-latency-legends.yaml
+++ b/cijoe/auxiliary/plot-latency-legends.yaml
@@ -40,3 +40,16 @@ xnvme_null:
 
 "null":
   legend: 'null'
+
+# Windows
+xnvme_io_ring:
+  legend: 'xnvme(ioring)'
+
+xnvme_iocp:
+  legend: 'xnvme(iocp)'
+
+xnvme_iocp_th:
+  legend: 'xnvme(iocp_th)'
+
+windowsaio:
+  legend: 'windowsaio'

--- a/cijoe/configs/perf-lat-windows.toml
+++ b/cijoe/configs/perf-lat-windows.toml
@@ -1,0 +1,52 @@
+[cijoe.transport.ssh]
+hostname = "perf-lat-win.home.arpa"
+port = 22
+username = "root"
+password = "root"
+
+[os]
+name = "windows"
+prettyname = "Windows"
+version = "11"
+
+[cijoe.run]
+shell = "bash"
+
+[xnvme.repository]
+remote = "https://github.com/xnvme/xnvme.git"
+path = "C:/Users/root/git/xnvme"
+branch = "next"
+
+[xnvme.build]
+type = "debug"
+
+[fio]
+bin = "C:/Users/root/git/fio/fio.exe"
+
+[fio.repository]
+remote = "https://github.com/axboe/fio.git"
+path = "C:/Users/root/git/fio"
+tag = "fio-3.36"
+
+[fio.engines]
+
+null = {type = "builtin", group = "null", device = "bdev"}
+windowsaio = {type = "builtin", group = "windowsaio", device = "bdev"}
+
+xnvme_null = {type = "builtin", group = "null", be = "windows", async = "nil", device = "bdev"}
+xnvme_ioring = {type = "builtin", group = "windowsaio", be = "windows", async = "io_ring", device = "bdev"}
+xnvme_iocp = {type = "builtin", group = "windowsaio", be = "windows", async = "iocp", device = "bdev"}
+xnvme_iocpth = {type = "builtin", group = "windowsaio", be = "windows", async = "iocp_th", device = "bdev"}
+  
+[[devices]] 
+key = "bdev"
+uri = "\\\\.\\PhysicalDrive1" # backslashes need to be escaped
+nsid = 1
+labels = ["dev", "bdev", "nvm"]
+driver_attachment = "kernel"
+
+[[duts]]
+pcie = "0000:03:00.0"
+os = "0n1"
+sn = "PHBT718003QR016D"
+label = "INTELM1016G"

--- a/cijoe/scripts/fio_prep.py
+++ b/cijoe/scripts/fio_prep.py
@@ -19,8 +19,9 @@ def main(args, cijoe, step):
     if not repos:
         return 1
 
-    err, _ = cijoe.run("gmake --version")
-    make = "make" if err else "gmake"
+    shell = cijoe.config.options.get("cijoe", {}).get("run", {}).get("shell", "sh")
+
+    make = "gmake" if shell == "csh" else "make"
 
     commands = [
         (f"git clone {repos['remote']} {repos['path']} || true", "/tmp"),

--- a/cijoe/scripts/fio_prep_windows.py
+++ b/cijoe/scripts/fio_prep_windows.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+clone and build fio
+=======================================
+
+Clone fio from fio.repository.remote into fio.repository.path, checkout
+fio.repository.tag, and build it.
+
+Retargetable: True
+------------------
+"""
+
+
+def main(args, cijoe, step):
+    """Build fio in the repository"""
+
+    repos = cijoe.config.options.get("fio", {}).get("repository", {})
+    if not repos:
+        return 1
+
+    commands = [
+        (f"git clone {repos['remote']} {repos['path']} || true", "/tmp"),
+        ("git clean -fdX", repos["path"]),
+        (f"git checkout {repos['tag']} || true", repos["path"]),
+        ("git rev-parse --short HEAD || true", repos["path"]),
+        ("make", repos["path"]),
+    ]
+
+    for cmd, cwd in commands:
+        err, _ = cijoe.run(cmd, cwd=cwd)
+        if err:
+            return err
+
+    return err

--- a/cijoe/scripts/latency_plotter.py
+++ b/cijoe/scripts/latency_plotter.py
@@ -118,7 +118,12 @@ def draw_bar_plot(data, plot_attributes, xlabel=None, ylabel=None, y_limit=None)
 
     multiplier = 0
 
-    for i, samples in enumerate(data.values()):
+    # Sort to ensure engines will get the same colours across
+    # different plots
+    datavalues = list(data.values())
+    datavalues.sort(key=lambda samples: samples["label"])
+
+    for i, samples in enumerate(datavalues):
         label = samples["label"]
         attrs = plot_attributes["legends"].get(label, None)
         if attrs is None:

--- a/cijoe/scripts/xnvme_build.py
+++ b/cijoe/scripts/xnvme_build.py
@@ -23,11 +23,16 @@ def main(args, cijoe, step):
         return errno.EINVAL
 
     xnvme_source = step.get("with", {}).get("xnvme_source", conf["repository"]["path"])
+    os_name = cijoe.config.options.get("os", {}).get("name", "")
 
     commands = [
         "git rev-parse --short HEAD || true",
         "rm -r builddir || true",
-        "meson setup builddir",
+        (
+            'meson setup builddir --prefix "C:/tools/msys64/usr" --default-library=static'
+            if os_name == "windows"
+            else "meson setup builddir"
+        ),
         "meson compile -C builddir",
         "cat builddir/meson-logs/meson-log.txt",
     ]

--- a/cijoe/scripts/xnvme_install.py
+++ b/cijoe/scripts/xnvme_install.py
@@ -23,14 +23,14 @@ def main(args, cijoe, step):
     xnvme_source = step.get("with", {}).get("xnvme_source", conf["repository"]["path"])
 
     commands = [
-        "cd builddir && meson compile",
-        "cd builddir && meson install",
-        "cd builddir && meson --internal uninstall",
-        "cd builddir && meson install",
-        "cat builddir/meson-logs/meson-log.txt",
+        "meson compile",
+        "meson install",
+        "meson --internal uninstall",
+        "meson install",
+        "cat meson-logs/meson-log.txt",
     ]
     for cmd in commands:
-        err, _ = cijoe.run(cmd, cwd=xnvme_source)
+        err, _ = cijoe.run(cmd, cwd=f"{xnvme_source}/builddir")
         if err:
             return err
 

--- a/cijoe/workflows/benchmark-provisioning-windows.yaml
+++ b/cijoe/workflows/benchmark-provisioning-windows.yaml
@@ -1,0 +1,33 @@
+---
+doc: |
+  Environment prep for Windows
+  =================================================================
+
+  Environment preparation consists of
+
+  * Retrieving and updating repositories for xnvme, and fio
+  * Configure, build and install xnvme, and fio
+  * Generate bdev-configs for all CIJOE "duts"
+
+
+steps:
+
+- name: sysinfo
+  uses: sysinfo_report
+
+- name: repository
+  uses: core.repository_prep
+
+- name: xnvme_build
+  uses: xnvme_build
+
+- name: xnvme_install
+  uses: xnvme_install
+
+- name: fio
+  uses: fio_prep_windows
+
+- name: kldconfig
+  uses: xnvme_kldconfig
+  with:
+    xnvme_source: '{{ config.xnvme.repository.path }}'

--- a/lib/xnvme_be_windows.c
+++ b/lib/xnvme_be_windows.c
@@ -153,6 +153,14 @@ static struct xnvme_be_mixin g_xnvme_be_mixin_windows[] = {
 	},
 
 	{
+		.mtype = XNVME_BE_ASYNC,
+		.name = "nil",
+		.descr = "Use nil-io; For introspective perf. evaluation",
+		.async = &g_xnvme_be_cbi_async_nil,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
 		.mtype = XNVME_BE_SYNC,
 		.name = "nvme",
 		.descr = "Use Windows NVMe Driver ioctl() for synchronous I/O",


### PR DESCRIPTION
Run latency benchmarking on Windows, comparing the three backends `ioring`, `iocp` and `iocp_th` from the xNVMe engine to the fio engine `windowsaio`.

[latency-windows.pdf](https://github.com/user-attachments/files/16611980/latency-windows.pdf)