### PR TITLE
feat(tests/ioworker): add option for nlb 

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_ioworker.py
+++ b/cijoe/tests/logic/test_xnvme_tests_ioworker.py
@@ -8,10 +8,26 @@ def test_verify(cijoe, device, be_opts, cli_args):
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args}")
     assert not err
 
+    # small nlb
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1")
+    assert not err
+
+    # large nlb
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7")
+    assert not err
+
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
 def test_verify_sync(cijoe, device, be_opts, cli_args):
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args}")
+    assert not err
+
+    # small nlb
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1")
+    assert not err
+
+    # large nlb
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7")
     assert not err
 
 
@@ -33,6 +49,18 @@ def test_verify_iovec(cijoe, device, be_opts, cli_args):
     else:
         assert not err
 
+    # small nlb: sub-page segments require an SGL, rejected on nosgl
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --vec-cnt 4")
+
+    if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
+        assert err
+    else:
+        assert not err
+
+    # large nlb: page-sized segments are PRP-expressible
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7 --vec-cnt 4")
+    assert not err
+
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
 def test_verify_sync_iovec(cijoe, device, be_opts, cli_args):
@@ -50,16 +78,52 @@ def test_verify_sync_iovec(cijoe, device, be_opts, cli_args):
     else:
         assert not err
 
+    # small nlb: sub-page segments require an SGL, rejected on nosgl
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1 --vec-cnt 4"
+    )
+
+    if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
+        assert err
+    else:
+        assert not err
+
+    # large nlb: page-sized segments are PRP-expressible
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7 --vec-cnt 4"
+    )
+    assert not err
+
 
 @xnvme_parametrize(labels=["bdev"], opts=["be", "sync", "async", "admin"])
 def test_verify_direct(cijoe, device, be_opts, cli_args):
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --direct 1")
     assert not err
 
+    # small nlb
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --direct 1")
+    assert not err
+
+    # large nlb
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7  --direct 1")
+    assert not err
+
 
 @xnvme_parametrize(labels=["bdev"], opts=["be", "sync", "admin"])
 def test_verify_sync_direct(cijoe, device, be_opts, cli_args):
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --direct 1")
+    assert not err
+
+    # small nlb
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1 --direct 1"
+    )
+    assert not err
+
+    # large nlb
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7  --direct 1"
+    )
     assert not err
 
 
@@ -81,6 +145,22 @@ def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
     else:
         assert not err
 
+    # small nlb: sub-page segments require an SGL, rejected on nosgl
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --vec-cnt 4 --direct 1"
+    )
+
+    if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
+        assert err
+    else:
+        assert not err
+
+    # large nlb: page-sized segments are PRP-expressible
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify {cli_args} --nlb 7 --vec-cnt 4 --direct 1"
+    )
+    assert not err
+
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
 def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
@@ -99,3 +179,19 @@ def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
         assert err
     else:
         assert not err
+
+    # small nlb: sub-page segments require an SGL, rejected on nosgl
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1 --vec-cnt 4 --direct 1"
+    )
+
+    if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
+        assert err
+    else:
+        assert not err
+
+    # large nlb: page-sized segments are PRP-expressible
+    err, _ = cijoe.run(
+        f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7 --vec-cnt 4 --direct 1"
+    )
+    assert not err

--- a/lib/xnvme_be_linux_async_libaio.c
+++ b/lib/xnvme_be_linux_async_libaio.c
@@ -160,7 +160,8 @@ _linux_libaio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, 
 	struct xnvme_be_linux_state *state = (void *)queue->base.dev->be.state;
 	const uint64_t ssw = queue->base.dev->geo.ssw;
 
-	struct iocb *iocb = (void *)&ctx->cmd;
+	struct iocb iocb;
+	struct iocb *iocbs[] = {&iocb};
 	int err;
 
 	if (mbuf || mbuf_nbytes) {
@@ -172,19 +173,19 @@ _linux_libaio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, 
 	///< NOTE: opcode-dispatch (io)
 	switch (ctx->cmd.common.opcode) {
 	case XNVME_SPEC_NVM_OPC_WRITE:
-		io_prep_pwrite(iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
+		io_prep_pwrite(&iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
 		break;
 
 	case XNVME_SPEC_NVM_OPC_READ:
-		io_prep_pread(iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
+		io_prep_pread(&iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
 		break;
 
 	case XNVME_SPEC_FS_OPC_WRITE:
-		io_prep_pwrite(iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
+		io_prep_pwrite(&iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
 		break;
 
 	case XNVME_SPEC_FS_OPC_READ:
-		io_prep_pread(iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
+		io_prep_pread(&iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
 		break;
 
 		// TODO: determine how to handle fsync
@@ -194,13 +195,13 @@ _linux_libaio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, 
 		return -ENOSYS;
 	}
 
-	iocb->data = (unsigned long *)ctx;
+	iocb.data = (unsigned long *)ctx;
 
 	if (queue->efd != -1) {
-		io_set_eventfd(iocb, queue->efd);
+		io_set_eventfd(&iocb, queue->efd);
 	}
 
-	err = io_submit(queue->aio_ctx, 1, &iocb);
+	err = io_submit(queue->aio_ctx, 1, iocbs);
 	if (err == 1) {
 		ctx->async.queue->base.outstanding += 1;
 		return 0;
@@ -219,7 +220,8 @@ _linux_libaio_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec
 	struct xnvme_be_linux_state *state = (void *)queue->base.dev->be.state;
 	const uint64_t ssw = queue->base.dev->geo.ssw;
 
-	struct iocb *iocb = (void *)&ctx->cmd;
+	struct iocb iocb;
+	struct iocb *iocbs[] = {&iocb};
 	int err;
 
 	if (queue->base.outstanding == queue->base.capacity) {
@@ -235,19 +237,19 @@ _linux_libaio_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec
 	///< NOTE: opcode-dispatch (io)
 	switch (ctx->cmd.common.opcode) {
 	case XNVME_SPEC_NVM_OPC_WRITE:
-		io_prep_pwritev(iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
+		io_prep_pwritev(&iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
 		break;
 
 	case XNVME_SPEC_NVM_OPC_READ:
-		io_prep_preadv(iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
+		io_prep_preadv(&iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
 		break;
 
 	case XNVME_SPEC_FS_OPC_WRITE:
-		io_prep_pwritev(iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
+		io_prep_pwritev(&iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
 		break;
 
 	case XNVME_SPEC_FS_OPC_READ:
-		io_prep_preadv(iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
+		io_prep_preadv(&iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
 		break;
 
 		// TODO: determine how to handle fsync
@@ -258,12 +260,12 @@ _linux_libaio_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec
 	}
 
 	if (queue->efd != -1) {
-		io_set_eventfd(iocb, queue->efd);
+		io_set_eventfd(&iocb, queue->efd);
 	}
 
-	iocb->data = (unsigned long *)ctx;
+	iocb.data = (unsigned long *)ctx;
 
-	err = io_submit(queue->aio_ctx, 1, &iocb);
+	err = io_submit(queue->aio_ctx, 1, iocbs);
 	if (err == 1) {
 		ctx->async.queue->base.outstanding += 1;
 		return 0;

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -314,7 +314,7 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 	work->wbuf = xnvme_buf_alloc(cli->args.dev, work->range.nbytes);
 	if (!work->wbuf) {
 		err = -errno;
-		XNVME_DEBUG("FAILED: xnvme_buf_alloc(data), err: %d", errno);
+		XNVME_DEBUG("FAILED: xnvme_buf_alloc(wbuf), err: %d", errno);
 		goto failed;
 	}
 
@@ -327,11 +327,11 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 	work->rbuf = xnvme_buf_alloc(cli->args.dev, work->range.nbytes);
 	if (!work->rbuf) {
 		err = -errno;
-		XNVME_DEBUG("FAILED: xnvme_buf_alloc(buf), err: %d", errno);
+		XNVME_DEBUG("FAILED: xnvme_buf_alloc(rbuf), err: %d", errno);
 		goto failed;
 	}
 
-	err = xnvme_buf_fill(work->rbuf, work->io.nbytes, "zero");
+	err = xnvme_buf_fill(work->rbuf, work->range.nbytes, "zero");
 	if (err) {
 		XNVME_DEBUG("FAILED: xnvme_buf_fill(), err: %d", err);
 		goto failed;

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -23,10 +23,8 @@ iowork_stats_reset(struct iowork_stats *stats)
 
 struct iowork_range {
 	uint32_t slba;   ///< First LBA of the range
-	uint32_t elba;   ///< Last LBA of the range
 	uint64_t nbytes; ///< Number of bytes in range
 	uint64_t naddr;  ///< Number of addresses (count-from-1)
-	uint64_t nlb;    ///< Number of LBAs (count-from-0)
 };
 
 /**
@@ -66,11 +64,7 @@ struct iowork {
 
 	char *wbuf;
 	char *rbuf;
-
-	struct {
-		char *data;
-		uint64_t slba;
-	} cur;
+	char *buf;
 
 	int vectored; ///< Whether or not the vectored I/O path is used
 	int vec_cnt;
@@ -102,7 +96,6 @@ iowork_pp(struct iowork *work)
 	printf("  range.nbytes: %" PRIu64 "\n", work->range.nbytes);
 	printf("  range.naddr: %" PRIu64 "\n", work->range.naddr);
 	printf("  range.slba: %" PRIu32 "\n", work->range.slba);
-	printf("  range.elba: %" PRIu32 "\n", work->range.elba);
 	printf("  nio: %" PRIu64 "\n", work->nio);
 
 	return 0;
@@ -114,9 +107,8 @@ _submit(struct iowork *work, struct ioworker *worker, struct xnvme_cmd_ctx *ctx)
 	int err;
 	if (work->vectored) {
 		for (int j = 0; j < work->vec_cnt; ++j) {
-			work->cur.slba = ctx->cmd.nvm.slba + j * (work->io.nlb + 1);
-			worker->vec[j].iov_base =
-				work->cur.data + work->cur.slba * work->geo->lba_nbytes;
+			uint64_t vec_slba = ctx->cmd.nvm.slba + j * (work->io.nlb + 1);
+			worker->vec[j].iov_base = work->buf + vec_slba * work->geo->lba_nbytes;
 			worker->vec[j].iov_len = (work->io.nlb + 1) * work->geo->lba_nbytes;
 		}
 
@@ -140,8 +132,7 @@ submitv:
 			return err;
 		}
 	} else {
-		work->cur.slba = ctx->cmd.nvm.slba;
-		void *dbuf = work->cur.data + work->cur.slba * work->geo->lba_nbytes;
+		void *dbuf = work->buf + ctx->cmd.nvm.slba * work->geo->lba_nbytes;
 		size_t dbuf_nbytes = work->io.nbytes;
 submit:
 		err = xnvme_cmd_pass(ctx, dbuf, dbuf_nbytes, NULL, 0);
@@ -174,17 +165,16 @@ _submit_sync(struct iowork *work)
 	ctx.cmd.common.nsid = work->nsid;
 	ctx.cmd.common.opcode = work->opc;
 	ctx.cmd.nvm.nlb = work->io.naddr - 1;
-	work->cur.slba = work->range.slba;
+	ctx.cmd.nvm.slba = work->range.slba;
 
 	if (work->vectored) {
 		for (uint64_t i = 0; i < work->nio; ++i) {
-			ctx.cmd.nvm.slba = work->cur.slba;
 			for (int j = 0; j < work->vec_cnt; ++j) {
+				uint64_t vec_slba = ctx.cmd.nvm.slba + j * (work->io.nlb + 1);
 				worker->vec[j].iov_base =
-					work->cur.data + work->cur.slba * work->geo->lba_nbytes;
+					work->buf + vec_slba * work->geo->lba_nbytes;
 				worker->vec[j].iov_len =
 					(work->io.nlb + 1) * work->geo->lba_nbytes;
-				work->cur.slba += work->io.nlb + 1;
 			}
 
 			err = xnvme_cmd_pass_iov(&ctx, worker->vec, worker->vec_cnt,
@@ -195,12 +185,12 @@ _submit_sync(struct iowork *work)
 			} else {
 				work->stats.nsubmissions += 1;
 				work->stats.ncompletions += 1;
+				ctx.cmd.nvm.slba += work->io.naddr;
 			}
 		}
 	} else {
 		for (uint64_t i = 0; i < work->nio; ++i) {
-			ctx.cmd.nvm.slba = work->cur.slba;
-			void *dbuf = work->cur.data + work->cur.slba * work->geo->lba_nbytes;
+			void *dbuf = work->buf + ctx.cmd.nvm.slba * work->geo->lba_nbytes;
 			size_t dbuf_nbytes = work->io.nbytes;
 			err = xnvme_cmd_pass(&ctx, dbuf, dbuf_nbytes, NULL, 0);
 			if (err) {
@@ -209,7 +199,7 @@ _submit_sync(struct iowork *work)
 			} else {
 				work->stats.nsubmissions += 1;
 				work->stats.ncompletions += 1;
-				work->cur.slba += work->io.nlb + 1;
+				ctx.cmd.nvm.slba += work->io.naddr;
 			}
 		}
 	}
@@ -236,7 +226,10 @@ on_completion(struct xnvme_cmd_ctx *ctx, void *cb_arg)
 		goto error;
 	}
 
-	if (work->cur.slba + work->io.naddr > work->range.elba) {
+	// Workers interleave, each striding by 'nworkers * io.naddr'; stop this worker when its
+	// next I/O would fall outside the range.
+	if (ctx->cmd.nvm.slba + (work->nworkers + 1) * work->io.naddr >
+	    work->range.slba + work->range.naddr) {
 		xnvme_queue_put_cmd_ctx(work->queue, ctx);
 		return;
 	}
@@ -245,7 +238,7 @@ on_completion(struct xnvme_cmd_ctx *ctx, void *cb_arg)
 	ctx->cmd.common.nsid = work->nsid;
 	ctx->cmd.common.opcode = work->opc;
 	ctx->cmd.nvm.nlb = work->io.naddr - 1;
-	ctx->cmd.nvm.slba = work->cur.slba + (work->io.nlb + 1);
+	ctx->cmd.nvm.slba += work->nworkers * work->io.naddr;
 
 	_submit(work, worker, ctx);
 
@@ -306,16 +299,15 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 	work->io.nbytes = work->vec_cnt * (work->io.nlb + 1) * work->geo->lba_nbytes;
 	work->io.naddr = work->vec_cnt * (work->io.nlb + 1);
 
-	if (!work->io.naddr || work->range.naddr % work->io.naddr) {
-		XNVME_DEBUG("FAILED: io.naddr must divide range.naddr");
-		return -EINVAL;
-	}
-
 	// work->range.nbytes = 1 << 27;
 	work->range.nbytes = 1 << 24;
 	work->range.naddr = work->range.nbytes / work->geo->lba_nbytes;
 	work->range.slba = 0;
-	work->range.elba = work->range.slba + work->range.naddr - 1;
+
+	if (!work->io.naddr || work->range.naddr % work->io.naddr) {
+		XNVME_DEBUG("FAILED: io.naddr must divide range.naddr");
+		return -EINVAL;
+	}
 
 	work->nio = work->range.naddr / work->io.naddr;
 	work->nworkers = work->nio > work->qdepth ? work->qdepth : work->nio;
@@ -446,7 +438,7 @@ test_verify(struct xnvme_cli *cli)
 	for (int i = 0; i < 2; i++) {
 
 		iowork_stats_reset(&work.stats);
-		work.cur.data = i ? work.rbuf : work.wbuf;
+		work.buf = i ? work.rbuf : work.wbuf;
 		work.opc = i ? XNVME_SPEC_NVM_OPC_READ : XNVME_SPEC_NVM_OPC_WRITE;
 
 		// Fill queue with commands
@@ -497,7 +489,7 @@ test_verify_sync(struct xnvme_cli *cli)
 	for (int i = 0; i < 2; i++) {
 
 		iowork_stats_reset(&work.stats);
-		work.cur.data = i ? work.rbuf : work.wbuf;
+		work.buf = i ? work.rbuf : work.wbuf;
 		work.opc = i ? XNVME_SPEC_NVM_OPC_READ : XNVME_SPEC_NVM_OPC_WRITE;
 
 		err = _submit_sync(&work);

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -94,7 +94,9 @@ iowork_pp(struct iowork *work)
 
 	printf("\n");
 	printf("  io.nbytes: %zu\n", work->io.nbytes);
-	printf("  io.naddr: %zu\n", work->io.naddr);
+	printf("  io.nlb: %zu\n", work->io.nlb);
+	printf("  vec-cnt: %d\n", work->vec_cnt);
+	printf("  io.naddr (vec-cnt * (io.nlb + 1)): %zu\n", work->io.naddr);
 	printf("  vectored: %d\n", work->vectored);
 	printf("  nworkers: %" PRIu32 "\n", work->nworkers);
 	printf("  range.nbytes: %" PRIu64 "\n", work->range.nbytes);
@@ -112,10 +114,10 @@ _submit(struct iowork *work, struct ioworker *worker, struct xnvme_cmd_ctx *ctx)
 	int err;
 	if (work->vectored) {
 		for (int j = 0; j < work->vec_cnt; ++j) {
-			work->cur.slba = ctx->cmd.nvm.slba + j;
+			work->cur.slba = ctx->cmd.nvm.slba + j * (work->io.nlb + 1);
 			worker->vec[j].iov_base =
 				work->cur.data + work->cur.slba * work->geo->lba_nbytes;
-			worker->vec[j].iov_len = work->geo->lba_nbytes;
+			worker->vec[j].iov_len = (work->io.nlb + 1) * work->geo->lba_nbytes;
 		}
 
 submitv:
@@ -139,7 +141,7 @@ submitv:
 		}
 	} else {
 		work->cur.slba = ctx->cmd.nvm.slba;
-		void *dbuf = work->cur.data + work->cur.slba * work->io.nbytes;
+		void *dbuf = work->cur.data + work->cur.slba * work->geo->lba_nbytes;
 		size_t dbuf_nbytes = work->io.nbytes;
 submit:
 		err = xnvme_cmd_pass(ctx, dbuf, dbuf_nbytes, NULL, 0);
@@ -171,18 +173,20 @@ _submit_sync(struct iowork *work)
 	int err;
 	ctx.cmd.common.nsid = work->nsid;
 	ctx.cmd.common.opcode = work->opc;
-	ctx.cmd.nvm.nlb = work->io.nlb;
+	ctx.cmd.nvm.nlb = work->io.naddr - 1;
+	work->cur.slba = work->range.slba;
 
 	if (work->vectored) {
 		for (uint64_t i = 0; i < work->nio; ++i) {
+			ctx.cmd.nvm.slba = work->cur.slba;
 			for (int j = 0; j < work->vec_cnt; ++j) {
-				work->cur.slba = work->range.slba + j + i * work->vec_cnt;
 				worker->vec[j].iov_base =
 					work->cur.data + work->cur.slba * work->geo->lba_nbytes;
-				worker->vec[j].iov_len = work->geo->lba_nbytes;
+				worker->vec[j].iov_len =
+					(work->io.nlb + 1) * work->geo->lba_nbytes;
+				work->cur.slba += work->io.nlb + 1;
 			}
 
-			ctx.cmd.nvm.slba = work->range.slba + i * work->vec_cnt;
 			err = xnvme_cmd_pass_iov(&ctx, worker->vec, worker->vec_cnt,
 						 work->io.nbytes, NULL, 0);
 			if (err) {
@@ -195,9 +199,8 @@ _submit_sync(struct iowork *work)
 		}
 	} else {
 		for (uint64_t i = 0; i < work->nio; ++i) {
-			work->cur.slba = work->range.slba + i;
 			ctx.cmd.nvm.slba = work->cur.slba;
-			void *dbuf = work->cur.data + work->cur.slba * work->io.nbytes;
+			void *dbuf = work->cur.data + work->cur.slba * work->geo->lba_nbytes;
 			size_t dbuf_nbytes = work->io.nbytes;
 			err = xnvme_cmd_pass(&ctx, dbuf, dbuf_nbytes, NULL, 0);
 			if (err) {
@@ -206,6 +209,7 @@ _submit_sync(struct iowork *work)
 			} else {
 				work->stats.nsubmissions += 1;
 				work->stats.ncompletions += 1;
+				work->cur.slba += work->io.nlb + 1;
 			}
 		}
 	}
@@ -232,7 +236,7 @@ on_completion(struct xnvme_cmd_ctx *ctx, void *cb_arg)
 		goto error;
 	}
 
-	if (work->cur.slba >= work->range.elba) {
+	if (work->cur.slba + work->io.naddr > work->range.elba) {
 		xnvme_queue_put_cmd_ctx(work->queue, ctx);
 		return;
 	}
@@ -240,8 +244,8 @@ on_completion(struct xnvme_cmd_ctx *ctx, void *cb_arg)
 	// Recreate context
 	ctx->cmd.common.nsid = work->nsid;
 	ctx->cmd.common.opcode = work->opc;
-	ctx->cmd.nvm.nlb = work->io.nlb;
-	ctx->cmd.nvm.slba = ++(work->cur.slba);
+	ctx->cmd.nvm.nlb = work->io.naddr - 1;
+	ctx->cmd.nvm.slba = work->cur.slba + (work->io.nlb + 1);
 
 	_submit(work, worker, ctx);
 
@@ -290,6 +294,7 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 	work->nsid = xnvme_dev_get_nsid(work->dev);
 	work->geo = xnvme_dev_get_geo(work->dev);
 	work->qdepth = cli->given[XNVME_CLI_OPT_QDEPTH] ? cli->args.qdepth : QDEPTH_DEF;
+	work->io.nlb = cli->given[XNVME_CLI_OPT_NLB] ? cli->args.nlb : 0;
 	work->vectored = cli->given[XNVME_CLI_OPT_VEC_CNT] && cli->args.vec_cnt;
 	work->vec_cnt = work->vectored ? cli->args.vec_cnt : 1;
 
@@ -298,9 +303,13 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 		return -EINVAL;
 	}
 
-	work->io.nbytes = work->vec_cnt * work->geo->lba_nbytes;
-	work->io.naddr = work->vec_cnt;
-	work->io.nlb = work->io.naddr - 1;
+	work->io.nbytes = work->vec_cnt * (work->io.nlb + 1) * work->geo->lba_nbytes;
+	work->io.naddr = work->vec_cnt * (work->io.nlb + 1);
+
+	if (!work->io.naddr || work->range.naddr % work->io.naddr) {
+		XNVME_DEBUG("FAILED: io.naddr must divide range.naddr");
+		return -EINVAL;
+	}
 
 	// work->range.nbytes = 1 << 27;
 	work->range.nbytes = 1 << 24;
@@ -385,8 +394,8 @@ start_workers(struct iowork *work)
 		struct ioworker *worker = &work->workers[i];
 		ctx->cmd.common.nsid = work->nsid;
 		ctx->cmd.common.opcode = work->opc;
-		ctx->cmd.nvm.nlb = work->io.nlb;
-		ctx->cmd.nvm.slba = work->range.slba + i * work->vec_cnt;
+		ctx->cmd.nvm.nlb = work->io.naddr - 1;
+		ctx->cmd.nvm.slba = work->range.slba + i * work->io.naddr;
 		ctx->async.cb_arg = worker;
 		err = _submit(work, worker, ctx);
 		if (err) {
@@ -525,6 +534,7 @@ static struct xnvme_cli_sub g_subs[] = {
 
 			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_VEC_CNT, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_NLB, XNVME_CLI_LOPT},
 
 			XNVME_CLI_ASYNC_OPTS,
 		},
@@ -540,6 +550,7 @@ static struct xnvme_cli_sub g_subs[] = {
 
 			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_VEC_CNT, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_NLB, XNVME_CLI_LOPT},
 
 			XNVME_CLI_SYNC_OPTS,
 		},


### PR DESCRIPTION
`xnvme_tests_ioworker` could only do single-LBA I/O. This adds `--nlb` to
`verify` and `verify-sync` so the per-I/O size is configurable, and reworks the
SLBA bookkeeping to support it.

- **`--nlb`**: per-I/O geometry becomes `io.naddr = vec_cnt * (nlb + 1)`,
  `io.nbytes = io.naddr * lba_nbytes`. Defaults to `0`, i.e. previous
  behaviour. Each iovec segment now covers `nlb + 1` LBAs.

- **Drop the shared `work->cur` cursor**: replaced by `work->buf` plus
  per-command SLBA tracking via `ctx->cmd.nvm.slba`. Each async worker owns one
  context and a disjoint slice — worker `i` starts at `range.slba + i *
  io.naddr` and strides by `nworkers * io.naddr`. The sync path advances by
  `io.naddr` per iteration. Buffer offsets are now uniformly
  `buf + slba * lba_nbytes`.

- **Zero the full read buffer**: `rbuf` is diffed over `range.nbytes` but was
  only zero-filled for `io.nbytes`. Also fixes the `xnvme_buf_alloc()` debug
  labels.

- **cijoe**: every existing case also runs at `--nlb 1` and `--nlb 7`. For the
  iovec cases, small `nlb` keeps the `spdk` + `nosgl` failure expectation
  (sub-page segments need an SGL); large `nlb` is page-sized and expected to
  pass everywhere.