### PR TITLE
feat(be/upcie-cuda): implement mem_map and mem_unmap

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -37,4 +37,14 @@ if conf_data.get('XNVME_BE_UPCIE_CUDA_ENABLED')
     install_rpath: xnvmelib_rpath,
     install: true,
   )
+  executable(
+    'xnvme_cuda_mem_map',
+    'xnvme_cuda_mem_map.cu',
+    include_directories: [conf_inc, xnvme_inc],
+    link_with: xnvmelib,
+    dependencies: [cuda_dep],
+    link_args: link_args_hardening,
+    install_rpath: xnvmelib_rpath,
+    install: true,
+  )
 endif

--- a/examples/xnvme_cuda_mem_map.cu
+++ b/examples/xnvme_cuda_mem_map.cu
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <errno.h>
+#include <stdint.h>
+#include <libxnvme.h>
+
+/**
+ * GPU-resident NVMe IO into a cudaMalloc'd, mem_map'd buffer
+ *
+ * Variant of xnvme_cuda.cu that registers an externally-allocated CUDA
+ * buffer via xnvme_mem_map() instead of using xnvme_buf_alloc()'s
+ * pre-built dma-buf heap. The remaining flow (GPU-resident queue,
+ * CUDA-kernel submission, completion drain) is identical.
+ *
+ * Usage: xnvme_cuda_mem_map <pci-id>
+ *   e.g: xnvme_cuda_mem_map 0000:01:00.0
+ */
+
+/*
+ * upcie-cuda's cudamem_config.device_pagesize. mem_map requires vaddr and
+ * nbytes to be a multiple of this; cudaMalloc does not guarantee that
+ * alignment, so we over-allocate and round up.
+ */
+#define UPCIE_CUDA_DEVICE_PAGESIZE 65536u
+
+__global__ static void
+xnvme_cuda_io_kernel(struct xnvme_cuda_queue *qp, struct xnvme_spec_cmd *cmds, size_t batch_size,
+		     int *errors)
+{
+	size_t tid = threadIdx.x;
+	errors[tid] = xnvme_cuda_cmd_io(qp, &cmds[tid], tid, batch_size);
+}
+
+int
+main(int argc, char **argv)
+{
+	struct xnvme_opts opts = xnvme_opts_default();
+	struct xnvme_dev *dev = NULL;
+	struct xnvme_spec_cmd *h_cmds = NULL, *d_cmds = NULL;
+	struct xnvme_cuda_queue *gpu_queue = NULL;
+	uint64_t phys;
+	uint32_t nsid;
+	size_t qdepth, lba_nbytes, buf_nbytes;
+	void *raw = NULL;
+	char *buf = NULL;
+	int *h_errors = NULL, *d_errors = NULL;
+	cudaError_t cerr;
+	int err = 0;
+	int mapped = 0;
+
+	if (argc < 2) {
+		err = -EINVAL;
+		xnvme_cli_perr("Usage: %s <pci-id>", err);
+		return err;
+	}
+
+	opts.be = "upcie-cuda";
+	dev = xnvme_dev_open(argv[1], &opts);
+	if (!dev) {
+		err = -errno;
+		xnvme_cli_perr("xnvme_dev_open()", err);
+		return err;
+	}
+
+	qdepth = 64;
+	lba_nbytes = xnvme_dev_get_geo(dev)->lba_nbytes;
+	nsid = xnvme_dev_get_nsid(dev);
+
+	/* mem_map demands a device-pagesize-aligned vaddr and length. */
+	buf_nbytes = ((qdepth * lba_nbytes + UPCIE_CUDA_DEVICE_PAGESIZE - 1) /
+		      UPCIE_CUDA_DEVICE_PAGESIZE) *
+		     UPCIE_CUDA_DEVICE_PAGESIZE;
+
+	/* Over-allocate by one page so we can hand mem_map an aligned start. */
+	cerr = cudaMalloc(&raw, buf_nbytes + UPCIE_CUDA_DEVICE_PAGESIZE);
+	if (cerr) {
+		xnvme_cli_perr("cudaMalloc(buf), cudaError_t: %d", cerr);
+		err = -ENOMEM;
+		goto exit;
+	}
+	buf = (char *)(((uintptr_t)raw + UPCIE_CUDA_DEVICE_PAGESIZE - 1) &
+		       ~((uintptr_t)UPCIE_CUDA_DEVICE_PAGESIZE - 1));
+
+	err = xnvme_mem_map(dev, buf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_mem_map()", err);
+		goto exit;
+	}
+	mapped = 1;
+
+	h_cmds = (struct xnvme_spec_cmd *)calloc(qdepth, sizeof(*h_cmds));
+	if (!h_cmds) {
+		err = -errno;
+		xnvme_cli_perr("calloc(h_cmds)", err);
+		goto exit;
+	}
+
+	/*
+	 * vtophys resolves through the mapping registry's chunk LUT; one
+	 * lookup per LBA, no contiguity assumption.
+	 */
+	for (size_t i = 0; i < qdepth; i++) {
+		err = xnvme_buf_vtophys(dev, buf + i * lba_nbytes, &phys);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_vtophys()", err);
+			goto exit;
+		}
+
+		h_cmds[i].common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		h_cmds[i].nvm.slba = i;
+		h_cmds[i].common.nsid = nsid;
+		h_cmds[i].common.dptr.prp.prp1 = phys;
+		h_cmds[i].nvm.nlb = 0;
+	}
+
+	cerr = cudaMalloc((void **)&d_cmds, qdepth * sizeof(*d_cmds));
+	if (cerr) {
+		xnvme_cli_perr("cudaMalloc(d_cmds), cudaError_t: %d", cerr);
+		err = -ENOMEM;
+		goto exit;
+	}
+	cudaMemcpy(d_cmds, h_cmds, qdepth * sizeof(*d_cmds), cudaMemcpyHostToDevice);
+
+	cerr = cudaMalloc((void **)&d_errors, qdepth * sizeof(int));
+	if (cerr) {
+		xnvme_cli_perr("cudaMalloc(d_errors), cudaError_t: %d", cerr);
+		err = -ENOMEM;
+		goto exit;
+	}
+	cudaMemset(d_errors, 0, qdepth * sizeof(int));
+
+	err = xnvme_cuda_queue_create(dev, qdepth, &gpu_queue);
+	if (err) {
+		xnvme_cli_perr("xnvme_cuda_queue_create()", err);
+		goto exit;
+	}
+
+	xnvme_cuda_io_kernel<<<1, qdepth>>>(gpu_queue, d_cmds, qdepth, d_errors);
+	cudaDeviceSynchronize();
+
+	h_errors = (int *)calloc(qdepth, sizeof(int));
+	if (!h_errors) {
+		err = -errno;
+		xnvme_cli_perr("calloc(h_errors)", err);
+		goto exit;
+	}
+	cudaMemcpy(h_errors, d_errors, qdepth * sizeof(int), cudaMemcpyDeviceToHost);
+
+	for (size_t i = 0; i < qdepth; i++) {
+		if (h_errors[i]) {
+			fprintf(stderr, "thread %zu failed: %d\n", i, h_errors[i]);
+			err = h_errors[i];
+		}
+	}
+	if (!err) {
+		printf("OK: %zu GPU-submitted NVMe reads into mem_map'd cudaMalloc buffer\n",
+		       qdepth);
+	}
+
+exit:
+	if (gpu_queue) {
+		xnvme_cuda_queue_destroy(dev, gpu_queue);
+	}
+	cudaFree(d_errors);
+	cudaFree(d_cmds);
+	free(h_errors);
+	free(h_cmds);
+	if (mapped) {
+		xnvme_mem_unmap(dev, buf);
+	}
+	if (raw) {
+		cudaFree(raw);
+	}
+	xnvme_dev_close(dev);
+
+	return err;
+}

--- a/lib/upcie/xnvme_be_upcie_cuda.h
+++ b/lib/upcie/xnvme_be_upcie_cuda.h
@@ -21,6 +21,7 @@ struct xnvme_be_upcie_cuda_rte {
 	CUcontext cu_ctx;
 	struct cudamem_config cuda_config;
 	struct cudamem_heap cuda_heap;
+	struct cudamem_mapping_registry mappings;
 	int is_initialized;
 };
 

--- a/lib/upcie/xnvme_be_upcie_cuda_admin.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_admin.c
@@ -30,8 +30,18 @@ xnvme_be_upcie_cuda_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t
 	cmd->cid = req->cid;
 
 	if (dbuf) {
-		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
-							   dbuf_nbytes, cmd);
+		if (cudamem_heap_contains(&g_upcie_cuda_rte.cuda_heap, dbuf)) {
+			nvme_request_prep_command_prps_contig_cuda(
+				req, &g_upcie_cuda_rte.cuda_heap, dbuf, dbuf_nbytes, cmd);
+		} else {
+			err = nvme_request_prep_command_prps_contig_cuda_mapped(
+				req, &g_upcie_cuda_rte.mappings, g_upcie_cuda_rte.cuda_heap.config,
+				dbuf, dbuf_nbytes, cmd);
+			if (err) {
+				XNVME_DEBUG("FAILED: prps_contig_cuda_mapped(); err(%d)", err);
+				goto exit;
+			}
+		}
 	}
 
 	err = nvme_qpair_enqueue(&ctrlr->aq, cmd);

--- a/lib/upcie/xnvme_be_upcie_cuda_async.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_async.c
@@ -46,8 +46,19 @@ xnvme_be_upcie_cuda_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t d
 	cmd->cid = req->cid;
 
 	if (dbuf) {
-		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
-							   dbuf_nbytes, cmd);
+		if (cudamem_heap_contains(&g_upcie_cuda_rte.cuda_heap, dbuf)) {
+			nvme_request_prep_command_prps_contig_cuda(
+				req, &g_upcie_cuda_rte.cuda_heap, dbuf, dbuf_nbytes, cmd);
+		} else {
+			err = nvme_request_prep_command_prps_contig_cuda_mapped(
+				req, &g_upcie_cuda_rte.mappings, g_upcie_cuda_rte.cuda_heap.config,
+				dbuf, dbuf_nbytes, cmd);
+			if (err) {
+				XNVME_DEBUG("FAILED: prps_contig_cuda_mapped(); err(%d)", err);
+				nvme_request_free(upcie_queue->qpair.rpool, req->cid);
+				return err;
+			}
+		}
 	}
 
 	if (mbuf) {
@@ -103,8 +114,20 @@ xnvme_be_upcie_cuda_async_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec,
 	cmd->cid = req->cid;
 
 	if (dvec) {
-		nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap, dvec,
-							dvec_cnt, cmd);
+		if (dvec_cnt > 0 &&
+		    cudamem_heap_contains(&g_upcie_cuda_rte.cuda_heap, dvec[0].iov_base)) {
+			nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+								dvec, dvec_cnt, cmd);
+		} else {
+			err = nvme_request_prep_command_prps_iov_cuda_mapped(
+				req, &g_upcie_cuda_rte.mappings, g_upcie_cuda_rte.cuda_heap.config,
+				dvec, dvec_cnt, cmd);
+			if (err) {
+				XNVME_DEBUG("FAILED: prps_iov_cuda_mapped(); err(%d)", err);
+				nvme_request_free(upcie_queue->qpair.rpool, req->cid);
+				return err;
+			}
+		}
 	}
 
 	if (mbuf) {

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -19,6 +19,7 @@ _cuda_rte_term(void)
 		return;
 	}
 
+	cudamem_mapping_registry_term(&g_upcie_cuda_rte.mappings);
 	cudamem_heap_term(&g_upcie_cuda_rte.cuda_heap);
 	cuCtxDestroy(g_upcie_cuda_rte.cu_ctx);
 
@@ -80,6 +81,15 @@ _cuda_rte_init(size_t heap_size, uint32_t gpu_id)
 		XNVME_DEBUG("FAILED: cudamem_heap_init(); err(%d)", err);
 		cuCtxDestroy(g_upcie_cuda_rte.cu_ctx);
 		return -ENOMEM;
+	}
+
+	err = cudamem_mapping_registry_init(&g_upcie_cuda_rte.mappings,
+					    &g_upcie_cuda_rte.cuda_config);
+	if (err) {
+		XNVME_DEBUG("FAILED: cudamem_mapping_registry_init(); err(%d)", err);
+		cudamem_heap_term(&g_upcie_cuda_rte.cuda_heap);
+		cuCtxDestroy(g_upcie_cuda_rte.cu_ctx);
+		return err;
 	}
 
 	g_upcie_cuda_rte.is_initialized = 1;

--- a/lib/upcie/xnvme_be_upcie_cuda_mem.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_mem.c
@@ -37,7 +37,44 @@ int
 xnvme_be_upcie_cuda_buf_vtophys(const struct xnvme_dev *XNVME_UNUSED(dev), void *buf,
 				uint64_t *phys)
 {
-	return cudamem_heap_block_virt_to_phys(&g_upcie_cuda_rte.cuda_heap, buf, phys);
+	struct cudamem_heap *heap = &g_upcie_cuda_rte.cuda_heap;
+
+	if (cudamem_heap_contains(heap, buf)) {
+		return cudamem_heap_block_virt_to_phys(heap, buf, phys);
+	}
+
+	return cudamem_mapping_virt_to_phys(&g_upcie_cuda_rte.mappings, buf, phys);
+}
+
+int
+xnvme_be_upcie_cuda_mem_map(const struct xnvme_dev *XNVME_UNUSED(dev), void *vaddr, size_t nbytes,
+			    uint64_t *phys)
+{
+	int err;
+
+	err = cudamem_mapping_add(&g_upcie_cuda_rte.mappings, &g_upcie_cuda_rte.cuda_config, vaddr,
+				  nbytes, NULL);
+	if (err) {
+		XNVME_DEBUG("FAILED: cudamem_mapping_add(), err: %d", err);
+		return err;
+	}
+
+	if (phys) {
+		err = cudamem_mapping_virt_to_phys(&g_upcie_cuda_rte.mappings, vaddr, phys);
+		if (err) {
+			XNVME_DEBUG("FAILED: cudamem_mapping_virt_to_phys(), err: %d", err);
+			cudamem_mapping_remove(&g_upcie_cuda_rte.mappings, vaddr);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+int
+xnvme_be_upcie_cuda_mem_unmap(const struct xnvme_dev *XNVME_UNUSED(dev), void *buf)
+{
+	return cudamem_mapping_remove(&g_upcie_cuda_rte.mappings, buf);
 }
 
 #endif
@@ -49,8 +86,8 @@ struct xnvme_be_mem g_xnvme_be_upcie_cuda_mem = {
 	.buf_realloc = xnvme_be_nosys_buf_realloc,
 	.buf_free = xnvme_be_upcie_cuda_buf_free,
 	.buf_vtophys = xnvme_be_upcie_cuda_buf_vtophys,
-	.mem_map = xnvme_be_nosys_mem_map,
-	.mem_unmap = xnvme_be_nosys_mem_unmap,
+	.mem_map = xnvme_be_upcie_cuda_mem_map,
+	.mem_unmap = xnvme_be_upcie_cuda_mem_unmap,
 #else
 	.buf_alloc = xnvme_be_nosys_buf_alloc,
 	.buf_realloc = xnvme_be_nosys_buf_realloc,

--- a/lib/upcie/xnvme_be_upcie_cuda_sync.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_sync.c
@@ -42,8 +42,18 @@ xnvme_be_upcie_cuda_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t db
 	cmd->cid = req->cid;
 
 	if (dbuf) {
-		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
-							   dbuf_nbytes, cmd);
+		if (cudamem_heap_contains(&g_upcie_cuda_rte.cuda_heap, dbuf)) {
+			nvme_request_prep_command_prps_contig_cuda(
+				req, &g_upcie_cuda_rte.cuda_heap, dbuf, dbuf_nbytes, cmd);
+		} else {
+			err = nvme_request_prep_command_prps_contig_cuda_mapped(
+				req, &g_upcie_cuda_rte.mappings, g_upcie_cuda_rte.cuda_heap.config,
+				dbuf, dbuf_nbytes, cmd);
+			if (err) {
+				XNVME_DEBUG("FAILED: prps_contig_cuda_mapped(); err(%d)", err);
+				goto exit;
+			}
+		}
 	}
 
 	if (mbuf) {
@@ -109,8 +119,19 @@ xnvme_be_upcie_cuda_sync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, 
 	cmd->cid = req->cid;
 
 	if (dvec) {
-		nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap, dvec,
-							dvec_cnt, cmd);
+		if (dvec_cnt > 0 &&
+		    cudamem_heap_contains(&g_upcie_cuda_rte.cuda_heap, dvec[0].iov_base)) {
+			nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+								dvec, dvec_cnt, cmd);
+		} else {
+			err = nvme_request_prep_command_prps_iov_cuda_mapped(
+				req, &g_upcie_cuda_rte.mappings, g_upcie_cuda_rte.cuda_heap.config,
+				dvec, dvec_cnt, cmd);
+			if (err) {
+				XNVME_DEBUG("FAILED: prps_iov_cuda_mapped(); err(%d)", err);
+				goto exit;
+			}
+		}
 	}
 
 	if (mbuf) {


### PR DESCRIPTION
Depends on https://github.com/safl/upcie/pull/25.

Wire the upcie-cuda backend's `.mem_map` and `.mem_unmap` hooks, previously stubbed with nosys, so callers can register externally-allocated CUDA buffers (`cuMemAlloc`, `cuMemCreate`/`cuMemMap`, `cudaMalloc`) for NVMe DMA in addition to the pre-built heap used by `xnvme_buf_alloc`.

Mappings are tracked on a per-runtime linked list of `cudamem_mapping` entries; `mem_map` appends one via `cudamem_mapping_add()` and `mem_unmap` removes the matching entry via `cudamem_mapping_remove()`. The add path obtains a dma-buf fd through `cuMemGetHandleForAddressRange`, attaches it, and builds a per-device-page LUT. `_cuda_rte_term()` drains any mappings still alive via `cudamem_mapping_clear()` when the last controller is closed.

`buf_vtophys` and the per-command PRP build paths dispatch on buffer provenance via `cudamem_heap_contains()`: heap-backed buffers resolve through `cudamem_heap_block_virt_to_phys`, mapped buffers through the list-walking `cudamem_mapping_virt_to_phys`. Command paths use the unsuffixed `nvme_request_prep_command_prps_{contig,iov}_cuda` dispatcher which routes to the heap or mapped variant. A resolution failure on a mapped buffer is reported as `-EINVAL` up to the cmd dispatchers rather than silently producing a PRP pointing at physical address 0.

`vaddr` and `nbytes` passed to `mem_map` must be aligned to `device_pagesize`; unaligned inputs return `-EINVAL`. `mem_unmap` matches by the exact `vaddr` that was passed to `mem_map`.

An accompanying example (`examples/xnvme_cuda_mem_map.cu`) demonstrates `cudaMalloc` + `xnvme_mem_map` + GPU-resident NVMe IO end to end.
