### PR TITLE
Multi-process support for xNVMe

### DIFF
--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -26,6 +26,28 @@ import pytest
 
 from .xnvme_be_combinations import get_backend_configurations
 
+_proc_role = 0
+_MPROC_SHM_ID = 1
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--proc_role",
+        type=int,
+        default=0,
+        help="Open devices with the given process role (0=single, 1=primary, 2=secondary)",
+    )
+
+
+def pytest_configure(config):
+    global _proc_role
+    try:
+        _proc_role = config.getoption("--proc_role", default=0)
+    except ValueError:
+        _proc_role = 0
+    if _proc_role == 2:
+        XnvmeDriver.IS_KERNEL_ATTACHED = False
+
 
 def get_osname():
     """Return normalized OS name from CIJOE config"""
@@ -128,6 +150,12 @@ def xnvme_cli_args(device, be_opts):
 
     if be_opts:
         args += [f"--{arg} {val}" for arg, val in be_opts.items() if arg != "label"]
+
+    if _proc_role:
+        args += [f"--proc_role {_proc_role}"]
+
+    if _proc_role == 2 and be_opts and be_opts.get("be") == "spdk":
+        args += [f"--shm_id {_MPROC_SHM_ID}"]
 
     return " ".join(args)
 
@@ -385,6 +413,14 @@ def device(cijoe, request):
     from within the testcase body itself.
     """
     if request.param:
+        if _proc_role == 2:
+            callspec = getattr(request.node, "callspec", None)
+            be_opts = callspec.params.get("be_opts") if callspec else None
+            if be_opts:
+                if be_opts.get("mproc"):
+                    MprocPrimary.start(cijoe, request.param, be_opts["be"])
+                else:
+                    pytest.skip(f"{be_opts.get('be')} does not support multi-process")
         XnvmeDriver.attach(cijoe, request.param)
 
     return request.param
@@ -422,6 +458,53 @@ def xnvme_parametrize(labels, opts):
         return inner
 
     return decorator
+
+
+class MprocPrimary:
+    """
+    Manages the lifecycle of an xnvme_tests_mproc primary daemon.
+
+    Tracks which backend's primary is currently running (similar to
+    XnvmeDriver.IS_KERNEL_ATTACHED) so tests sorted by backend share a single
+    primary per backend without restarting between tests.
+    """
+
+    RUNNING_BE = None
+    CIJOE = None
+
+    @staticmethod
+    def start(cijoe, device, be):
+        if MprocPrimary.RUNNING_BE == be:
+            return
+        MprocPrimary.stop(cijoe)
+        cijoe.run("xnvme-driver")
+        uri = device["uri"]
+        nsid = device["nsid"]
+        shm_arg = f"--shm_id {_MPROC_SHM_ID}" if be == "spdk" else ""
+        cijoe.run(
+            f"nohup xnvme_tests_mproc primary {uri} --be {be} "
+            f"--dev-nsid {nsid} --proc_role 1 {shm_arg} "
+            f"> /tmp/mproc_{be}.out 2>&1 &"
+        )
+        sleep(2)
+        MprocPrimary.RUNNING_BE = be
+        MprocPrimary.CIJOE = cijoe
+
+    @staticmethod
+    def stop(cijoe):
+        if MprocPrimary.RUNNING_BE is None:
+            return
+        cijoe.run("pkill -f xnvme_tests_mproc || true")
+        sleep(1)
+        MprocPrimary.RUNNING_BE = None
+        MprocPrimary.CIJOE = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mproc_teardown():
+    yield
+    if MprocPrimary.CIJOE is not None:
+        MprocPrimary.stop(MprocPrimary.CIJOE)
 
 
 # Sort order for pytest_collection_modifyitems. `be` first because backend

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -128,6 +128,7 @@ def get_backend_configurations():
             "admin": ["spdk"],
             "mem": ["spdk"],
             "label": ["pcie"],
+            "mproc": True,
         },
         {
             "be": ["spdk"],
@@ -144,6 +145,7 @@ def get_backend_configurations():
             "sync": ["upcie"],
             "admin": ["upcie"],
             "label": ["pcie"],
+            "mproc": True,
         },
         {
             "be": ["upcie-cuda"],

--- a/cijoe/workflows/test-debian-trixie.yaml
+++ b/cijoe/workflows/test-debian-trixie.yaml
@@ -45,3 +45,9 @@ steps:
   with:
     args: '-k "fabrics" tests'
     random_order: false
+
+- name: test_mproc
+  uses: core.testrunner
+  with:
+    args: '-k "pcie and not test_mem_map_unmap" tests --proc_role 2'
+    random_order: false

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -16,3 +16,4 @@ In the future, more tutorials will be added with the purpose of introducing the 
    dynamic_loading/index.rst
    fabrics/index.rst
    bdev_xnvme/index.rst
+   multi_process/index.rst

--- a/docs/tutorial/multi_process/index.rst
+++ b/docs/tutorial/multi_process/index.rst
@@ -1,0 +1,177 @@
+.. _sec-tutorials-multi-process:
+
+================
+ Multi-Process
+================
+
+**xNVMe** supports multiple processes accessing the same userspace NVMe
+device simultaneously. The primary process allocates all hardware queue pairs
+upfront; each process then claims one or more pairs exclusively for I/O.
+No queue pair is used by more than one process at a time.
+
+Roles
+=====
+
+Each process that opens a device declares one of three roles via
+``xnvme_opts.proc_role``:
+
+``XNVME_PROC_SINGLE``
+  Default. Single-process mode with no multi-process coordination. Queue pairs
+  are allocated on demand; no shared memory is created. Use this when only one
+  process will ever access the device.
+
+``XNVME_PROC_PRIMARY``
+  Initializes the hardware, pre-allocates the shared queue pool, and publishes
+  shared state. The primary must open the device before any secondary process
+  attempts to attach.
+
+``XNVME_PROC_SECONDARY``
+  Attaches to an already-initialized controller without touching the hardware.
+  Returns an error if no primary is running for the given device.
+
+Backends
+========
+
+Multi-process works across all backends. The difference is in how coordination
+happens:
+
+**Kernel-based backends** (e.g., ``linux``, ``io_uring``)
+  The OS handles concurrent device access natively. Multiple processes can
+  open the same device independently and ``proc_role`` has no effect.
+
+**vfio** (``libvfn``)
+  Single-process only. The VFIO group-based API allows a group to be in only
+  one IOMMU container at a time, so a second process cannot share the
+  primary's IOMMU domain. ``proc_role`` has no effect for this backend.
+
+**upcie** (``uio_pci_generic`` driver only)
+  Full multi-process support. The uPCIe backend programs the NVMe controller
+  directly and coordinates through POSIX shared memory. Setting ``proc_role``
+  tells the library which process should initialize the hardware and which
+  should attach to an already-running controller. Without this coordination,
+  a secondary process would reset the device and destroy in-flight I/O.
+
+  Devices bound to ``vfio-pci`` do not support secondary attachment;
+  ``XNVME_PROC_SECONDARY`` returns ``ENOTSUP`` for those devices.
+
+Usage
+=====
+
+The queue API is identical regardless of process role. Each process calls
+``xnvme_queue_init()`` to claim a queue pair and ``xnvme_queue_term()`` to
+release it. Queue pairs are drawn from a pool pre-allocated by the primary at
+device-open time.
+
+Primary process
+---------------
+
+.. code-block:: c
+
+   struct xnvme_opts opts = xnvme_opts_default();
+   opts.be = "upcie";
+   opts.proc_role = XNVME_PROC_PRIMARY;
+
+   struct xnvme_dev *dev = xnvme_dev_open("0000:01:00.0", &opts);
+   if (!dev) {
+       perror("xnvme_dev_open");
+       return 1;
+   }
+
+   struct xnvme_queue *queue;
+   if (xnvme_queue_init(dev, 256, 0, &queue)) {
+       perror("xnvme_queue_init");
+       return 1;
+   }
+
+   /* submit and poll I/O as normal */
+
+   xnvme_queue_term(queue);
+   xnvme_dev_close(dev);
+
+Secondary process
+-----------------
+
+.. code-block:: c
+
+   struct xnvme_opts opts = xnvme_opts_default();
+   opts.be = "upcie";
+   opts.proc_role = XNVME_PROC_SECONDARY;
+
+   struct xnvme_dev *dev = xnvme_dev_open("0000:01:00.0", &opts);
+   if (!dev) {
+       perror("xnvme_dev_open");
+       return 1;
+   }
+
+   struct xnvme_queue *queue;
+   if (xnvme_queue_init(dev, 256, 0, &queue)) {
+       perror("xnvme_queue_init");
+       return 1;
+   }
+
+   /* submit and poll I/O as normal */
+
+   xnvme_queue_term(queue);
+   xnvme_dev_close(dev);
+
+Note that the only difference between the two snippets is ``proc_role``. Once
+the device is open, all queue operations work identically.
+
+Each process may open the same device multiple times (for example, once per
+namespace) and init as many queues as needed, subject to the pool capacity
+described below.
+
+Queue pool
+==========
+
+The primary pre-allocates a fixed pool of NVMe I/O queue pairs at device-open
+time. Secondary processes claim pairs from this pool atomically; no admin
+commands are issued after primary initialization. The pool is released when
+the primary calls ``xnvme_dev_close()``.
+
+The pool holds at most 63 queue pairs per device. One of those pairs is
+reserved for the synchronous command path used internally by each process, so
+in practice each process that calls ``xnvme_dev_open()`` consumes one slot
+before any ``xnvme_queue_init()`` calls. This leaves at most 62 slots
+distributed across all attached processes.
+
+Device geometry
+===============
+
+Secondary processes can call ``xnvme_dev_get_geo()``, ``xnvme_dev_get_ctrlr()``,
+and related functions. The primary publishes its Identify data into shared
+memory the first time any of those functions is called, and secondaries read
+from shared memory instead of issuing admin commands.
+
+This means the primary must trigger at least one identify-dependent call (e.g.
+``xnvme_dev_get_geo()``) **before** any secondary calls those same functions.
+In practice this happens naturally: the primary warms up the device and starts
+I/O before launching secondary processes.
+
+Only the namespace that the primary opened first is published. Secondaries must
+open the same namespace ID as the primary. Attempting to derive geometry for a
+different namespace from a secondary returns an error.
+
+FS-interface I/O (byte-addressed reads and writes via ``XNVME_SPEC_FS_OPC_*``
+opcodes) works correctly on secondaries once geometry is available.
+
+Constraints
+===========
+
+* The primary must open the device before any secondary attempts to attach.
+  A secondary that finds no primary returns ``ENOENT``.
+
+* Secondaries must open the same namespace ID as the primary used for its
+  first identify call.
+
+* Each process is responsible for calling ``xnvme_queue_term()`` for every
+  queue it has initialized and ``xnvme_dev_close()`` for every device it has
+  opened, in order to return queue pairs to the pool.
+
+* Recovery from a crashed primary is the caller's responsibility. If the
+  primary exits without calling ``xnvme_dev_close()``, the hardware queue
+  state is lost and attached secondaries are left in an undefined condition.
+  The safest recovery path is to restart all processes.
+
+* Buffers allocated with ``xnvme_buf_alloc()`` are per-process and must not
+  be passed between processes.

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -6,11 +6,12 @@
  * @headerfile libxnvme_cli.h
  */
 
-#define XNVME_CLI_CORE_OPTS                                                                 \
-	{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP}, {XNVME_CLI_OPT_SUBNQN, XNVME_CLI_LOPT}, \
-		{XNVME_CLI_OPT_HOSTNQN, XNVME_CLI_LOPT},                                    \
-	{                                                                                   \
-		XNVME_CLI_OPT_BE, XNVME_CLI_LOPT                                            \
+#define XNVME_CLI_CORE_OPTS                                                                  \
+	{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP}, {XNVME_CLI_OPT_SUBNQN, XNVME_CLI_LOPT},  \
+		{XNVME_CLI_OPT_HOSTNQN, XNVME_CLI_LOPT}, {XNVME_CLI_OPT_BE, XNVME_CLI_LOPT}, \
+		{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT},                                      \
+	{                                                                                    \
+		XNVME_CLI_OPT_PROC_ROLE, XNVME_CLI_LOPT                                      \
 	}
 
 #define XNVME_CLI_ADMIN_OPTS                                                                \

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -172,6 +172,8 @@ struct xnvme_cli_args {
 	const char *cpumask;
 	uint32_t nqueues;
 
+	enum xnvme_proc_role proc_role;
+
 	const char **posn; //< Remaining positional args (points into argv)
 	int posn_count;    ///< Number of remaining positional args
 };
@@ -348,7 +350,9 @@ enum xnvme_cli_opt {
 	XNVME_CLI_OPT_CPUMASK   = 127, ///< XNVME_CLI_OPT_CPUMASK
 	XNVME_CLI_OPT_NQUEUES   = 128, ///< XNVME_CLI_OPT_NQUEUES
 
-	XNVME_CLI_OPT_END = 129, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_PROC_ROLE = 129, ///< XNVME_CLI_OPT_PROC_ROLE
+
+	XNVME_CLI_OPT_END = 130, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -12,6 +12,25 @@ struct xnvme_opts_css {
 };
 
 /**
+ * Process role for multi-process device access
+ *
+ * When multiple processes access the same device, one must take the PRIMARY role to initialize
+ * the hardware and publish shared state. Subsequent processes attach as SECONDARY. Each process
+ * owns and exclusively submits to its own queue pairs; no queues are shared between processes.
+ *
+ * Recovery from a crashed primary is the caller's responsibility. If the primary exits without
+ * calling xnvme_dev_close(), hardware queue state is lost and attached secondaries are left in
+ * an undefined condition.
+ *
+ * @enum xnvme_proc_role
+ */
+enum xnvme_proc_role {
+	XNVME_PROC_SINGLE  = 0, ///< Single-process mode (default). No multi-process coordination.
+	XNVME_PROC_PRIMARY = 1, ///< Initialize hardware and publish shared state for secondaries
+	XNVME_PROC_SECONDARY = 2, ///< Attach to an already-initialized controller
+};
+
+/**
  * xNVMe options
  *
  * @see xnvme_dev_open()
@@ -49,6 +68,7 @@ struct xnvme_opts {
 	uint32_t command_timeout;  ///< SPDK fabrics: enable io command timeout
 	uint32_t spdk_fabrics;     ///< Is assigned a value by backend if SPDK uses fabrics
 	uint32_t keep_alive_timeout_ms; ///< SPDK fabrics: set keep alive timeout
+	enum xnvme_proc_role proc_role; ///< Multi-process: role of this process
 };
 
 /**

--- a/include/xnvme_be.h
+++ b/include/xnvme_be.h
@@ -162,6 +162,7 @@ enum xnvme_be_cap {
 	XNVME_BE_CAP_NVME_PCIE = 0x1 << 5, ///< NVMe over PCIe (user-space driver)
 	XNVME_BE_CAP_NVME_TCP  = 0x1 << 6, ///< NVMe over TCP (user-space driver)
 	XNVME_BE_CAP_NVME_RDMA = 0x1 << 7, ///< NVMe over RDMA (user-space driver)
+	XNVME_BE_CAP_MPROC     = 0x1 << 8, ///< Multi-process mode
 };
 
 /**

--- a/include/xnvme_be.h
+++ b/include/xnvme_be.h
@@ -14,7 +14,7 @@
 #define XNVME_BE_ASYNC_NBYTES 64
 #define XNVME_BE_SYNC_NBYTES  24
 #define XNVME_BE_ADMIN_NBYTES 24
-#define XNVME_BE_DEV_NBYTES   40
+#define XNVME_BE_DEV_NBYTES   48
 #define XNVME_BE_MEM_NBYTES   56
 #define XNVME_BE_ATTR_NBYTES  24
 #define XNVME_BE_STATE_NBYTES 128
@@ -113,6 +113,15 @@ struct xnvme_be_dev {
 	 * Returns 0 on success, negative errno on error.
 	 */
 	int (*ctrlr_term)(void *ctrlr);
+
+	/**
+	 * Attach to an already-initialized controller as a secondary process.
+	 * Returns an opaque controller handle on success, or NULL on failure.
+	 * NULL errno == ENOENT signals no primary is running (AUTO role may fall back to
+	 * ctrlr_init). NULL pointer means the backend does not support secondary attachment; the
+	 * platform falls through to ctrlr_init.
+	 */
+	void *(*ctrlr_attach)(struct xnvme_dev *);
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_dev) == XNVME_BE_DEV_NBYTES, "Incorrect size")
 

--- a/lib/upcie/xnvme_be_upcie.c
+++ b/lib/upcie/xnvme_be_upcie.c
@@ -18,7 +18,7 @@ const struct xnvme_be_config g_xnvme_be_upcie = {
 		{
 			.name = "upcie",
 			.descr = "uPCIe userspace NVMe driver",
-			.caps = XNVME_BE_CAP_NVME_PCIE,
+			.caps = XNVME_BE_CAP_NVME_PCIE | XNVME_BE_CAP_MPROC,
 		},
 };
 

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -5,6 +5,7 @@
 #ifndef __INTERNAL_XNVME_BE_UPCIE_H
 #define __INTERNAL_XNVME_BE_UPCIE_H
 #include <pthread.h>
+#include <stdatomic.h>
 
 #include <xnvme_be.h>
 #include <xnvme_queue.h>
@@ -12,10 +13,66 @@
 #define _UPCIE_WITH_NVME
 #include <upcie/upcie.h>
 
+#define XNVME_BE_UPCIE_NQUEUES_MAX   64
+#define XNVME_BE_UPCIE_QSIZE_MAX     1024
+#define XNVME_BE_UPCIE_MAX_HUGEPAGES 128
+
+/**
+ * Per-queue metadata stored in POSIX shm for secondary processes to reconstruct
+ * local queue state without sending admin commands.
+ */
+struct xnvme_be_upcie_qinfo {
+	uint32_t qid;
+	uint16_t depth;
+	uint16_t sq_tail;   ///< Saved SQ tail, restored on next claim
+	uint64_t sq_offset; ///< Byte offset of SQ ring from hugepage base
+	uint64_t cq_offset; ///< Byte offset of CQ ring from hugepage base
+	uint16_t cq_head;   ///< Saved CQ head, restored on next claim
+	uint8_t cq_phase;   ///< Saved CQ phase bit, restored on next claim
+	uint8_t _pad[5];
+};
+
+/**
+ * Shared multi-process rendezvous for the upcie backend.
+ *
+ * Stored in a POSIX shared memory object named /xnvme-upcie-{sanitized-bdf}.
+ * The primary creates all I/O queue pairs upfront from its DMA heap (hugepage).
+ * Secondary processes import the hugepage, reconstruct local queue state, and
+ * claim queue pairs atomically via qidmap without submitting admin commands.
+ *
+ * The phys_lut array stores the physical address of each hugepage backing the
+ * heap. Secondary processes use these to create IOMMU mappings for their data
+ * buffers and to identify queue ring physical addresses.
+ */
+struct xnvme_be_upcie_mproc {
+	_Atomic uint64_t qidmap;  ///< Bit N set means queue ID N is available
+	_Atomic int32_t refcount; ///< Number of processes currently attached
+	int nqueues;              ///< Number of pre-allocated I/O queue pairs
+	char hugepage_path[256];  ///< Path to primary's hugepage file
+	size_t hugepage_size;     ///< Total hugepage allocation size in bytes
+	uint32_t nphys;           ///< Number of hugepages backing the heap
+	uint32_t _pad;
+	uint64_t phys_lut[XNVME_BE_UPCIE_MAX_HUGEPAGES]; ///< Physical address per hugepage
+	struct xnvme_be_upcie_qinfo queues[XNVME_BE_UPCIE_NQUEUES_MAX]; ///< Index 0 unused
+
+	///< Identify data cached by the primary so secondaries can derive geometry
+	///< without issuing admin commands. id_ready is set to 1 atomically after all
+	///< fields below have been written.
+	_Atomic uint8_t id_ready;
+	uint8_t csi; ///< Command Set Identifier determined by the primary
+	uint8_t _pad_id[2];
+	uint32_t nsid; ///< Namespace ID for id_ns / idcss_ns
+	struct xnvme_spec_idfy_ctrlr id_ctrlr;
+	struct xnvme_spec_idfy_ns id_ns;
+	struct xnvme_spec_idfy_ctrlr idcss_ctrlr;
+	struct xnvme_spec_idfy_ns idcss_ns;
+};
+
 struct xnvme_queue_upcie {
 	struct xnvme_queue_base base;
 	struct nvme_qpair qpair;
-	uint8_t _rvds[168];
+	uint8_t borrowed_ring; ///< Ring memory is borrowed from primary's hugepage
+	uint8_t _rvds[167];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue_upcie) == XNVME_BE_QUEUE_STATE_NBYTES,
 		    "Incorrect size")
@@ -27,12 +84,21 @@ enum nvme_backend {
 
 /**
  * Shared controller state, one per physical controller, managed by cref.
+ *
+ * When shm_fd >= 0 the process is primary and owns the POSIX shm.
+ * When shm_fd == -1 the process is a secondary that has attached to shm.
+ * When shm_fd == -2 the process is in single-process (auto) mode with no shm.
  */
 struct xnvme_be_upcie_ctrlr {
 	struct nvme_controller *ctrl;
-	struct nvme_qpair sync; ///< Shared submission/completion queue for synchronous IOs
+	struct nvme_qpair sync; ///< Synchronous I/O queue pair
 	struct vfio_ctx vfio;
 	enum nvme_backend backend;
+	struct xnvme_be_upcie_mproc *mproc;        ///< Shared rendezvous (in POSIX shm)
+	int shm_fd;                                ///< >=0 primary, -1 secondary, -2 auto
+	char shm_name[64];                         ///< POSIX shm name, set at init/attach time
+	struct hostmem_hugepage imported_hugepage; ///< Secondary: imported primary hugepage
+	struct nvme_qpair *preallocated;           ///< Primary: pre-allocated queue pairs
 };
 
 /**
@@ -62,6 +128,12 @@ extern struct xnvme_be_admin g_xnvme_be_upcie_admin;
 extern struct xnvme_be_sync g_xnvme_be_upcie_sync;
 extern struct xnvme_be_async g_xnvme_be_upcie_async;
 extern struct xnvme_be_dev g_xnvme_be_upcie_dev;
+
+int
+_upcie_claim_qpair(struct xnvme_be_upcie_ctrlr *ctrlr, void *ring_base, struct nvme_qpair *dest);
+
+void
+_upcie_release_qpair(struct xnvme_be_upcie_ctrlr *ctrlr, struct nvme_qpair *qp);
 
 int
 xnvme_be_upcie_get_driver_name(const char *bdf, char *driver_name, size_t driver_name_len);

--- a/lib/upcie/xnvme_be_upcie_admin.c
+++ b/lib/upcie/xnvme_be_upcie_admin.c
@@ -21,6 +21,11 @@ xnvme_be_upcie_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf
 	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
 	int err;
 
+	if (state->ctrlr->shm_fd == -1) {
+		XNVME_DEBUG("FAILED: secondary process cannot issue admin commands");
+		return -ENOTSUP;
+	}
+
 	if (dbuf) {
 		err = nvme_qpair_submit_sync_contig_prps(&ctrl->aq, &g_upcie_rte.heap, dbuf,
 							 dbuf_nbytes, cmd, ctrl->timeout_ms, cpl);

--- a/lib/upcie/xnvme_be_upcie_async.c
+++ b/lib/upcie/xnvme_be_upcie_async.c
@@ -18,12 +18,36 @@ xnvme_be_upcie_queue_init(struct xnvme_queue *queue, int XNVME_UNUSED(opts))
 {
 	struct xnvme_queue_upcie *upcie_queue = (void *)(queue);
 	struct xnvme_be_upcie_state *state = (void *)queue->base.dev->be.state;
+	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
 	int err;
+
+	if (ctrlr->mproc) {
+		uint8_t *bar0 = ctrlr->ctrl->func.bars[0].region;
+		int dstrd = nvme_reg_cap_get_dstrd(nvme_mmio_cap_read(bar0));
+		void *ring_base;
+		int qpid;
+
+		if (ctrlr->shm_fd == -1) {
+			ring_base = ctrlr->imported_hugepage.virt;
+		} else {
+			ring_base = g_upcie_rte.heap.memory.virt;
+		}
+
+		qpid = _upcie_claim_qpair(ctrlr, ring_base, &upcie_queue->qpair);
+		if (qpid < 0) {
+			XNVME_DEBUG("FAILED: _upcie_claim_qpair(); err(%d)", qpid);
+			return qpid;
+		}
+
+		upcie_queue->borrowed_ring = 1;
+
+		return 0;
+	}
 
 	// The spec says that for systems where memory ordering is not guaranteed, then one should
 	// leave room in the queue to avoid races. Thus, we do so here, by allocating one more than
 	// what is needed.
-	err = nvme_controller_create_io_qpair(state->ctrlr->ctrl, &upcie_queue->qpair,
+	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &upcie_queue->qpair,
 					      queue->base.capacity + 1);
 	if (err) {
 		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair()");
@@ -37,6 +61,13 @@ int
 xnvme_be_upcie_queue_term(struct xnvme_queue *queue)
 {
 	struct xnvme_queue_upcie *upcie_queue = (void *)queue;
+	struct xnvme_be_upcie_state *state = (void *)queue->base.dev->be.state;
+	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
+
+	if (ctrlr->mproc) {
+		_upcie_release_qpair(ctrlr, &upcie_queue->qpair);
+		return 0;
+	}
 
 	nvme_qpair_term(&upcie_queue->qpair);
 

--- a/lib/upcie/xnvme_be_upcie_async.c
+++ b/lib/upcie/xnvme_be_upcie_async.c
@@ -22,15 +22,37 @@ xnvme_be_upcie_queue_init(struct xnvme_queue *queue, int XNVME_UNUSED(opts))
 	int err;
 
 	if (ctrlr->mproc) {
-		uint8_t *bar0 = ctrlr->ctrl->func.bars[0].region;
-		int dstrd = nvme_reg_cap_get_dstrd(nvme_mmio_cap_read(bar0));
-		void *ring_base;
+		void *ring_base = ctrlr->imported_hugepage.virt;
 		int qpid;
 
-		if (ctrlr->shm_fd == -1) {
-			ring_base = ctrlr->imported_hugepage.virt;
-		} else {
-			ring_base = g_upcie_rte.heap.memory.virt;
+		if (ctrlr->shm_fd >= 0) {
+			struct hostmem_heap *heap = &g_upcie_rte.heap;
+			struct xnvme_be_upcie_mproc *mp = ctrlr->mproc;
+			uint32_t qid;
+
+			err = nvme_controller_create_io_qpair(ctrlr->ctrl, &upcie_queue->qpair,
+							      queue->base.capacity + 1);
+			if (err) {
+				XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair()");
+				return err;
+			}
+
+			qid = upcie_queue->qpair.qid;
+			mp->queues[qid].qid = qid;
+			mp->queues[qid].depth = upcie_queue->qpair.depth;
+			mp->queues[qid].sq_offset = (uint64_t)((uint8_t *)upcie_queue->qpair.sq -
+							       (uint8_t *)heap->memory.virt);
+			mp->queues[qid].cq_offset = (uint64_t)((uint8_t *)upcie_queue->qpair.cq -
+							       (uint8_t *)heap->memory.virt);
+			mp->queues[qid].sq_tail = 0;
+			mp->queues[qid].cq_head = 0;
+			mp->queues[qid].cq_phase = 1;
+
+			ctrlr->preallocated[qid] = upcie_queue->qpair;
+			ctrlr->preallocated[qid].rpool = NULL;
+			mp->nqueues++;
+
+			return 0;
 		}
 
 		qpid = _upcie_claim_qpair(ctrlr, ring_base, &upcie_queue->qpair);

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -273,79 +273,25 @@ _upcie_release_qpair(struct xnvme_be_upcie_ctrlr *ctrlr, struct nvme_qpair *qp)
 	atomic_fetch_or_explicit(&ctrlr->mproc->qidmap, 1ULL << qp->qid, memory_order_release);
 }
 
-static int
-_upcie_prealloc_queues(struct xnvme_be_upcie_ctrlr *ctrlr, int nqueues, int depth)
-{
-	struct xnvme_be_upcie_mproc *mp = ctrlr->mproc;
-	struct hostmem_heap *heap = &g_upcie_rte.heap;
-	int err;
-
-	ctrlr->preallocated = calloc(nqueues + 1, sizeof(*ctrlr->preallocated));
-	if (!ctrlr->preallocated) {
-		return -ENOMEM;
-	}
-
-	for (int qid = 1; qid <= nqueues; qid++) {
-		struct nvme_qpair *qp = &ctrlr->preallocated[qid];
-
-		err = nvme_controller_create_io_qpair(ctrlr->ctrl, qp, (uint16_t)depth);
-		if (err) {
-			XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(qid=%d); err(%d)",
-				    qid, err);
-			for (int j = 1; j < qid; j++) {
-				struct nvme_qpair *pqp = &ctrlr->preallocated[j];
-
-				_upcie_send_delete_iosq(ctrlr->ctrl, (uint16_t)j);
-				_upcie_send_delete_iocq(ctrlr->ctrl, (uint16_t)j);
-				hostmem_dma_free(heap, pqp->sq);
-				hostmem_dma_free(heap, pqp->cq);
-			}
-			free(ctrlr->preallocated);
-			ctrlr->preallocated = NULL;
-			return err;
-		}
-
-		/* Pre-allocated queues share ring memory via shm but don't need PRP pools —
-		 * each process allocates its own when claiming via _upcie_claim_qpair.
-		 * Without this, 63 queues × 4 MB/pool = 252 MB exhausts the 256 MB DMA heap. */
-		nvme_request_pool_term_prps(qp->rpool, heap);
-		free(qp->rpool);
-		qp->rpool = NULL;
-
-		mp->queues[qid].qid = (uint32_t)qid;
-		mp->queues[qid].depth = (uint16_t)depth;
-		mp->queues[qid].sq_offset =
-			(uint64_t)((uint8_t *)qp->sq - (uint8_t *)heap->memory.virt);
-		mp->queues[qid].cq_offset =
-			(uint64_t)((uint8_t *)qp->cq - (uint8_t *)heap->memory.virt);
-		mp->queues[qid].sq_tail = 0;
-		mp->queues[qid].cq_head = 0;
-		mp->queues[qid].cq_phase = 1;
-	}
-
-	return 0;
-}
-
 static void
 _upcie_free_preallocated_queues(struct xnvme_be_upcie_ctrlr *ctrlr)
 {
-	struct xnvme_be_upcie_mproc *mproc = ctrlr->mproc;
-	int nqueues = mproc->nqueues;
-
-	for (int qid = 1; qid <= nqueues; qid++) {
+	for (int qid = 1; qid < XNVME_BE_UPCIE_NQUEUES_MAX; qid++) {
 		struct nvme_qpair *qp = &ctrlr->preallocated[qid];
+
+		if (!qp->sq) {
+			continue;
+		}
 
 		_upcie_send_delete_iosq(ctrlr->ctrl, (uint16_t)qid);
 		_upcie_send_delete_iocq(ctrlr->ctrl, (uint16_t)qid);
 
-		if (qp->sq) {
-			if (qp->rpool) {
-				nvme_request_pool_term_prps(qp->rpool, qp->heap);
-				free(qp->rpool);
-			}
-			hostmem_dma_free(qp->heap, qp->sq);
-			hostmem_dma_free(qp->heap, qp->cq);
+		if (qp->rpool) {
+			nvme_request_pool_term_prps(qp->rpool, qp->heap);
+			free(qp->rpool);
 		}
+		hostmem_dma_free(qp->heap, qp->sq);
+		hostmem_dma_free(qp->heap, qp->cq);
 	}
 	free(ctrlr->preallocated);
 	ctrlr->preallocated = NULL;
@@ -358,10 +304,7 @@ _upcie_mproc_primary_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ct
 	struct hostmem_heap *heap = &g_upcie_rte.heap;
 	char shm_name[64];
 	size_t shm_size = sizeof(*mproc);
-	int shm_fd, nqueues, depth, qpid, err;
-
-	nqueues = XNVME_BE_UPCIE_NQUEUES_MAX - 1;
-	depth = XNVME_BE_UPCIE_QUEUE_DEPTH;
+	int shm_fd, err;
 
 	_upcie_shm_name(dev->ident.uri, shm_name, sizeof(shm_name));
 	snprintf(ctrlr->shm_name, sizeof(ctrlr->shm_name), "%s", shm_name);
@@ -389,7 +332,7 @@ _upcie_mproc_primary_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ct
 	}
 
 	memset(mproc, 0, shm_size);
-	mproc->nqueues = nqueues;
+	mproc->nqueues = 0;
 
 	snprintf(mproc->hugepage_path, sizeof(mproc->hugepage_path), "%s", heap->memory.path);
 	mproc->hugepage_size = heap->memory.size;
@@ -409,31 +352,26 @@ _upcie_mproc_primary_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ct
 	ctrlr->mproc = mproc;
 	ctrlr->shm_fd = shm_fd;
 
-	err = _upcie_prealloc_queues(ctrlr, nqueues, depth);
-	if (err) {
-		XNVME_DEBUG("FAILED: _upcie_prealloc_queues(); err(%d)", err);
+	ctrlr->preallocated = calloc(XNVME_BE_UPCIE_NQUEUES_MAX, sizeof(*ctrlr->preallocated));
+	if (!ctrlr->preallocated) {
+		XNVME_DEBUG("FAILED: calloc(preallocated)");
+		err = -ENOMEM;
 		goto failed_munmap;
 	}
 
-	{
-		uint64_t qidmap = 0;
-		for (int i = 1; i <= nqueues; i++) {
-			qidmap |= (1ULL << i);
-		}
-		atomic_store(&mproc->qidmap, qidmap);
-	}
 	atomic_store(&mproc->refcount, 1);
 
-	qpid = _upcie_claim_qpair(ctrlr, heap->memory.virt, &ctrlr->sync);
-	if (qpid < 0) {
-		err = qpid;
-		XNVME_DEBUG("FAILED: claim sync qpair: err(%d)", err);
-		_upcie_free_preallocated_queues(ctrlr);
-		goto failed_munmap;
+	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(%d)", err);
+		goto failed_free_preallocated;
 	}
 
 	return 0;
 
+failed_free_preallocated:
+	free(ctrlr->preallocated);
+	ctrlr->preallocated = NULL;
 failed_munmap:
 	munmap(mproc, shm_size);
 failed_close:
@@ -731,7 +669,7 @@ xnvme_be_upcie_ctrlr_term(void *handle)
 				    attached - 1);
 		}
 
-		_upcie_release_qpair(ctrlr, &ctrlr->sync);
+		nvme_qpair_term(&ctrlr->sync);
 		_upcie_free_preallocated_queues(ctrlr);
 
 		munmap(mproc, sizeof(*mproc));

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <fcntl.h>
 #include <libxnvme.h>
 #include <xnvme_be.h>
 #include <xnvme_be_nosys.h>
@@ -10,6 +11,8 @@
 #include <stdatomic.h>
 #include <xnvme_dev.h>
 #include <xnvme_be_upcie.h>
+
+#define XNVME_BE_UPCIE_QUEUE_DEPTH 256
 
 static _Atomic int g_ctrlr_count;
 
@@ -139,12 +142,320 @@ _pci_enable_bus_master(const char *bdf)
 	return 0;
 }
 
+static void
+_upcie_shm_name(const char *bdf, char *buf, size_t buflen)
+{
+	int i;
+
+	snprintf(buf, buflen, "/xnvme-upcie-%s", bdf);
+	for (i = 1; buf[i]; i++) {
+		if (buf[i] == ':' || buf[i] == '.') {
+			buf[i] = '-';
+		}
+	}
+}
+
+static int
+_upcie_send_delete_iosq(struct nvme_controller *ctrl, uint16_t qid)
+{
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+
+	cmd.opc = 0x00; ///< Delete I/O Submission Queue
+	cmd.cdw10 = qid;
+
+	return nvme_qpair_submit_sync(&ctrl->aq, &cmd, ctrl->timeout_ms, &cpl);
+}
+
+static int
+_upcie_send_delete_iocq(struct nvme_controller *ctrl, uint16_t qid)
+{
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+
+	cmd.opc = 0x04; ///< Delete I/O Completion Queue
+	cmd.cdw10 = qid;
+
+	return nvme_qpair_submit_sync(&ctrl->aq, &cmd, ctrl->timeout_ms, &cpl);
+}
+
+/**
+ * Claim a pre-allocated queue pair from the shared qidmap.
+ *
+ * On success, the caller owns the returned qpair's rpool and is responsible for
+ * freeing it. Ring memory (sq/cq) is NOT owned by the caller.
+ *
+ * @param ctrlr Controller whose qidmap to claim from.
+ * @param ring_base Base virtual address from which ring offsets are computed.
+ * @return The claimed queue ID (>= 1) on success, or -errno on error.
+ */
+int
+_upcie_claim_qpair(struct xnvme_be_upcie_ctrlr *ctrlr, void *ring_base, struct nvme_qpair *dest)
+{
+	struct xnvme_be_upcie_mproc *mp = ctrlr->mproc;
+	struct xnvme_be_upcie_qinfo *qi;
+	unsigned int qid_pos, qid;
+	uint64_t old, new_val, cap;
+	uint8_t *bar0;
+	int dstrd, err;
+
+	bar0 = ctrlr->ctrl->func.bars[0].region;
+	cap = nvme_mmio_cap_read(bar0);
+	dstrd = nvme_reg_cap_get_dstrd(cap);
+
+	do {
+		old = atomic_load_explicit(&mp->qidmap, memory_order_relaxed);
+		if (!old) {
+			XNVME_DEBUG("FAILED: no free queue identifiers");
+			return -EBUSY;
+		}
+		qid_pos = (unsigned int)__builtin_ffsll((long long)old);
+		if (qid_pos < 2) {
+			XNVME_DEBUG("FAILED: no free queue identifiers");
+			return -EBUSY;
+		}
+		new_val = old & ~(1ULL << (qid_pos - 1));
+	} while (!atomic_compare_exchange_weak_explicit(
+		&mp->qidmap, &old, new_val, memory_order_acq_rel, memory_order_relaxed));
+
+	qid = qid_pos - 1;
+	qi = &mp->queues[qid];
+
+	dest->sq = (uint8_t *)ring_base + qi->sq_offset;
+	dest->cq = (uint8_t *)ring_base + qi->cq_offset;
+	dest->sqdb = bar0 + 0x1000 + ((2 * qid) << (2 + dstrd));
+	dest->cqdb = bar0 + 0x1000 + ((2 * qid + 1) << (2 + dstrd));
+	dest->qid = qid;
+	dest->depth = qi->depth;
+	dest->tail = qi->sq_tail;
+	dest->tail_last_written = UINT16_MAX;
+	dest->head = qi->cq_head;
+	dest->phase = qi->cq_phase;
+	dest->heap = &g_upcie_rte.heap;
+
+	dest->rpool = calloc(1, sizeof(*dest->rpool));
+	if (!dest->rpool) {
+		atomic_fetch_or_explicit(&mp->qidmap, 1ULL << qid, memory_order_release);
+		return -ENOMEM;
+	}
+	nvme_request_pool_init(dest->rpool);
+
+	err = nvme_request_pool_init_prps(dest->rpool, &g_upcie_rte.heap);
+	if (err) {
+		free(dest->rpool);
+		dest->rpool = NULL;
+		atomic_fetch_or_explicit(&mp->qidmap, 1ULL << qid, memory_order_release);
+		return err;
+	}
+
+	return (int)qid;
+}
+
+/**
+ * Release a claimed queue pair's per-process resources back to the pool.
+ *
+ * Does NOT free ring memory — that is always owned by the primary's heap.
+ */
+void
+_upcie_release_qpair(struct xnvme_be_upcie_ctrlr *ctrlr, struct nvme_qpair *qp)
+{
+	struct xnvme_be_upcie_qinfo *qi = &ctrlr->mproc->queues[qp->qid];
+
+	if (qp->rpool) {
+		nvme_request_pool_term_prps(qp->rpool, qp->heap);
+		free(qp->rpool);
+		qp->rpool = NULL;
+	}
+
+	qi->sq_tail = qp->tail;
+	qi->cq_head = qp->head;
+	qi->cq_phase = qp->phase;
+	atomic_fetch_or_explicit(&ctrlr->mproc->qidmap, 1ULL << qp->qid, memory_order_release);
+}
+
+static int
+_upcie_prealloc_queues(struct xnvme_be_upcie_ctrlr *ctrlr, int nqueues, int depth)
+{
+	struct xnvme_be_upcie_mproc *mp = ctrlr->mproc;
+	struct hostmem_heap *heap = &g_upcie_rte.heap;
+	int err;
+
+	ctrlr->preallocated = calloc(nqueues + 1, sizeof(*ctrlr->preallocated));
+	if (!ctrlr->preallocated) {
+		return -ENOMEM;
+	}
+
+	for (int qid = 1; qid <= nqueues; qid++) {
+		struct nvme_qpair *qp = &ctrlr->preallocated[qid];
+
+		err = nvme_controller_create_io_qpair(ctrlr->ctrl, qp, (uint16_t)depth);
+		if (err) {
+			XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(qid=%d); err(%d)",
+				    qid, err);
+			for (int j = 1; j < qid; j++) {
+				struct nvme_qpair *pqp = &ctrlr->preallocated[j];
+
+				_upcie_send_delete_iosq(ctrlr->ctrl, (uint16_t)j);
+				_upcie_send_delete_iocq(ctrlr->ctrl, (uint16_t)j);
+				hostmem_dma_free(heap, pqp->sq);
+				hostmem_dma_free(heap, pqp->cq);
+			}
+			free(ctrlr->preallocated);
+			ctrlr->preallocated = NULL;
+			return err;
+		}
+
+		/* Pre-allocated queues share ring memory via shm but don't need PRP pools —
+		 * each process allocates its own when claiming via _upcie_claim_qpair.
+		 * Without this, 63 queues × 4 MB/pool = 252 MB exhausts the 256 MB DMA heap. */
+		nvme_request_pool_term_prps(qp->rpool, heap);
+		free(qp->rpool);
+		qp->rpool = NULL;
+
+		mp->queues[qid].qid = (uint32_t)qid;
+		mp->queues[qid].depth = (uint16_t)depth;
+		mp->queues[qid].sq_offset =
+			(uint64_t)((uint8_t *)qp->sq - (uint8_t *)heap->memory.virt);
+		mp->queues[qid].cq_offset =
+			(uint64_t)((uint8_t *)qp->cq - (uint8_t *)heap->memory.virt);
+		mp->queues[qid].sq_tail = 0;
+		mp->queues[qid].cq_head = 0;
+		mp->queues[qid].cq_phase = 1;
+	}
+
+	return 0;
+}
+
+static void
+_upcie_free_preallocated_queues(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_mproc *mproc = ctrlr->mproc;
+	int nqueues = mproc->nqueues;
+
+	for (int qid = 1; qid <= nqueues; qid++) {
+		struct nvme_qpair *qp = &ctrlr->preallocated[qid];
+
+		_upcie_send_delete_iosq(ctrlr->ctrl, (uint16_t)qid);
+		_upcie_send_delete_iocq(ctrlr->ctrl, (uint16_t)qid);
+
+		if (qp->sq) {
+			if (qp->rpool) {
+				nvme_request_pool_term_prps(qp->rpool, qp->heap);
+				free(qp->rpool);
+			}
+			hostmem_dma_free(qp->heap, qp->sq);
+			hostmem_dma_free(qp->heap, qp->cq);
+		}
+	}
+	free(ctrlr->preallocated);
+	ctrlr->preallocated = NULL;
+}
+
+int
+_upcie_mproc_primary_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_mproc *mproc;
+	struct hostmem_heap *heap = &g_upcie_rte.heap;
+	char shm_name[64];
+	size_t shm_size = sizeof(*mproc);
+	int shm_fd, nqueues, depth, qpid, err;
+
+	nqueues = XNVME_BE_UPCIE_NQUEUES_MAX - 1;
+	depth = XNVME_BE_UPCIE_QUEUE_DEPTH;
+
+	_upcie_shm_name(dev->ident.uri, shm_name, sizeof(shm_name));
+	snprintf(ctrlr->shm_name, sizeof(ctrlr->shm_name), "%s", shm_name);
+
+	shm_unlink(shm_name);
+	shm_fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	if (shm_fd < 0) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: shm_open(%s): %d", shm_name, err);
+		goto failed;
+	}
+
+	err = ftruncate(shm_fd, (off_t)shm_size);
+	if (err) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: ftruncate(); err(%d)", err);
+		goto failed_close;
+	}
+
+	mproc = mmap(NULL, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+	if (mproc == MAP_FAILED) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: mmap() shm; err(%d)", err);
+		goto failed_close;
+	}
+
+	memset(mproc, 0, shm_size);
+	mproc->nqueues = nqueues;
+
+	snprintf(mproc->hugepage_path, sizeof(mproc->hugepage_path), "%s", heap->memory.path);
+	mproc->hugepage_size = heap->memory.size;
+	mproc->nphys = (uint32_t)heap->nphys;
+
+	if (heap->nphys > XNVME_BE_UPCIE_MAX_HUGEPAGES) {
+		err = -ENOSPC;
+		XNVME_DEBUG("FAILED: too many hugepages (%zu > %d)", heap->nphys,
+			    XNVME_BE_UPCIE_MAX_HUGEPAGES);
+		goto failed_munmap;
+	}
+
+	for (size_t i = 0; i < heap->nphys; i++) {
+		mproc->phys_lut[i] = heap->phys_lut[i];
+	}
+
+	ctrlr->mproc = mproc;
+	ctrlr->shm_fd = shm_fd;
+
+	err = _upcie_prealloc_queues(ctrlr, nqueues, depth);
+	if (err) {
+		XNVME_DEBUG("FAILED: _upcie_prealloc_queues(); err(%d)", err);
+		goto failed_munmap;
+	}
+
+	{
+		uint64_t qidmap = 0;
+		for (int i = 1; i <= nqueues; i++) {
+			qidmap |= (1ULL << i);
+		}
+		atomic_store(&mproc->qidmap, qidmap);
+	}
+	atomic_store(&mproc->refcount, 1);
+
+	qpid = _upcie_claim_qpair(ctrlr, heap->memory.virt, &ctrlr->sync);
+	if (qpid < 0) {
+		err = qpid;
+		XNVME_DEBUG("FAILED: claim sync qpair: err(%d)", err);
+		_upcie_free_preallocated_queues(ctrlr);
+		goto failed_munmap;
+	}
+
+	return 0;
+
+failed_munmap:
+	munmap(mproc, shm_size);
+failed_close:
+	close(shm_fd);
+	shm_unlink(shm_name);
+	ctrlr->shm_fd = -2;
+failed:
+	ctrlr->mproc = NULL;
+	return err;
+}
+
 /**
  * Initialize the uPCIe controller.
  *
- * Initializes the runtime environment, allocates a shared xnvme_be_upcie_ctrlr,
- * opens the NVMe controller and creates a sync qpair. The returned handle is
- * stored in cref and written to dev->be.state[0] by the platform.
+ * For primary (proc_role == XNVME_PROC_PRIMARY): initializes the runtime
+ * environment, opens the NVMe controller, pre-allocates all I/O queue pairs,
+ * stores shared state in POSIX shm, and claims a sync queue pair. Secondary
+ * processes attach via ctrlr_attach and claim pre-allocated queue pairs
+ * atomically.
+ *
+ * For single (proc_role == XNVME_PROC_SINGLE): original single-process behavior
+ * with a single on-demand sync queue pair and no shared memory.
  */
 void *
 xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
@@ -173,6 +484,7 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 		errno = ENOMEM;
 		return NULL;
 	}
+	ctrlr->shm_fd = -2;
 
 	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
 	if (!ctrlr->ctrl) {
@@ -215,36 +527,249 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 		return NULL;
 	}
 
-	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
-	if (err) {
-		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(%d)", err);
-		errno = -err;
-		if (ctrlr->backend == NVME_BACKEND_VFIO) {
-			nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
-		} else {
-			nvme_controller_close(ctrlr->ctrl);
+	if (dev->opts.proc_role == XNVME_PROC_PRIMARY) {
+		err = _upcie_mproc_primary_init(dev, ctrlr);
+		if (err) {
+			XNVME_DEBUG("FAILED: _upcie_mproc_primary_init(); err(%d)", err);
+			errno = -err;
+			goto fail_close;
 		}
-		free(ctrlr->ctrl);
-		free(ctrlr);
-		return NULL;
+	} else {
+		err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
+		if (err) {
+			XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair; err(%d)", err);
+			errno = -err;
+			goto fail_close;
+		}
 	}
 
 	g_ctrlr_count++;
 
 	return ctrlr;
+
+fail_close:
+	if (ctrlr->backend == NVME_BACKEND_VFIO) {
+		nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+	} else {
+		nvme_controller_close(ctrlr->ctrl);
+	}
+	free(ctrlr->ctrl);
+	free(ctrlr);
+	return NULL;
+}
+
+/**
+ * Attach to an already-initialized uPCIe controller as a secondary process.
+ *
+ * Supports sysfs (uio_pci_generic) backend only. Opens the device without
+ * resetting the controller, imports the primary's hugepage for shared ring
+ * memory access, and claims a sync queue pair atomically from the shared
+ * qidmap without sending admin commands.
+ */
+static void *
+xnvme_be_upcie_ctrlr_attach(struct xnvme_dev *dev)
+{
+	struct xnvme_be_upcie_ctrlr *ctrlr;
+	struct xnvme_be_upcie_mproc *mproc;
+	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
+	char shm_name[64];
+	size_t shm_size = sizeof(*mproc);
+	int err;
+
+	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
+			    err);
+		return NULL;
+	}
+
+	if (strcmp(driver_name, "uio_pci_generic") != 0) {
+		XNVME_DEBUG("FAILED: ctrlr_attach only supported for uio_pci_generic, got '%s'",
+			    driver_name);
+		errno = ENOTSUP;
+		return NULL;
+	}
+
+	err = _rte_init();
+	if (err) {
+		XNVME_DEBUG("FAILED: _rte_init()");
+		errno = -err;
+		return NULL;
+	}
+
+	err = _pci_enable_bus_master(dev->ident.uri);
+	if (err) {
+		XNVME_DEBUG("FAILED: _pci_enable_bus_master(%s)", dev->ident.uri);
+		errno = -err;
+		goto fail_rte;
+	}
+
+	ctrlr = calloc(1, sizeof(*ctrlr));
+	if (!ctrlr) {
+		XNVME_DEBUG("FAILED: calloc(ctrlr)");
+		errno = ENOMEM;
+		goto fail_rte;
+	}
+
+	ctrlr->shm_fd = -1;
+	ctrlr->imported_hugepage.fd = -1;
+	ctrlr->backend = NVME_BACKEND_SYSFS;
+
+	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
+	if (!ctrlr->ctrl) {
+		XNVME_DEBUG("FAILED: calloc(ctrl)");
+		errno = ENOMEM;
+		free(ctrlr);
+		goto fail_rte;
+	}
+
+	_upcie_shm_name(dev->ident.uri, shm_name, sizeof(shm_name));
+	snprintf(ctrlr->shm_name, sizeof(ctrlr->shm_name), "%s", shm_name);
+
+	{
+		int fd;
+
+		fd = shm_open(shm_name, O_RDWR, 0);
+		if (fd < 0) {
+			XNVME_DEBUG("FAILED: shm_open(%s): %d", shm_name, errno);
+			goto fail_ctrl;
+		}
+
+		mproc = mmap(NULL, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		if (mproc == MAP_FAILED) {
+			XNVME_DEBUG("FAILED: mmap shm: %d", errno);
+			close(fd);
+			goto fail_ctrl;
+		}
+		close(fd);
+	}
+
+	ctrlr->mproc = mproc;
+
+	err = hostmem_hugepage_import(mproc->hugepage_path, &ctrlr->imported_hugepage,
+				      &g_upcie_rte.config);
+	if (err) {
+		XNVME_DEBUG("FAILED: hostmem_hugepage_import(%s): %d", mproc->hugepage_path, err);
+		goto fail_shm;
+	}
+
+	err = pci_func_open(dev->ident.uri, &ctrlr->ctrl->func);
+	if (err) {
+		XNVME_DEBUG("FAILED: pci_func_open(%s): %d", dev->ident.uri, err);
+		goto fail_hugepage;
+	}
+
+	err = pci_bar_map(dev->ident.uri, 0, &ctrlr->ctrl->func.bars[0]);
+	if (err) {
+		XNVME_DEBUG("FAILED: pci_bar_map(%s, BAR0): %d", dev->ident.uri, err);
+		pci_func_close(&ctrlr->ctrl->func);
+		goto fail_hugepage;
+	}
+
+	ctrlr->ctrl->heap = &g_upcie_rte.heap;
+
+	atomic_fetch_add_explicit(&mproc->refcount, 1, memory_order_release);
+
+	{
+		uint8_t *bar0 = ctrlr->ctrl->func.bars[0].region;
+		uint64_t cap = nvme_mmio_cap_read(bar0);
+		int qpid;
+
+		ctrlr->ctrl->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
+
+		qpid = _upcie_claim_qpair(ctrlr, ctrlr->imported_hugepage.virt, &ctrlr->sync);
+		if (qpid < 0) {
+			XNVME_DEBUG("FAILED: claim sync qpair: %d", qpid);
+			atomic_fetch_sub_explicit(&mproc->refcount, 1, memory_order_release);
+			pci_bar_unmap(&ctrlr->ctrl->func.bars[0]);
+			pci_func_close(&ctrlr->ctrl->func);
+			goto fail_hugepage;
+		}
+
+		snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s",
+			 driver_name);
+	}
+
+	g_ctrlr_count++;
+
+	return ctrlr;
+
+fail_hugepage:
+	if (ctrlr->imported_hugepage.virt) {
+		munmap(ctrlr->imported_hugepage.virt, ctrlr->imported_hugepage.size);
+	}
+	if (ctrlr->imported_hugepage.fd >= 0) {
+		close(ctrlr->imported_hugepage.fd);
+	}
+
+fail_shm:
+	munmap(mproc, shm_size);
+	ctrlr->mproc = NULL;
+
+fail_ctrl:
+	free(ctrlr->ctrl);
+	free(ctrlr);
+
+fail_rte:
+	_rte_term();
+	return NULL;
 }
 
 int
 xnvme_be_upcie_ctrlr_term(void *handle)
 {
 	struct xnvme_be_upcie_ctrlr *ctrlr = handle;
+	struct xnvme_be_upcie_mproc *mproc = ctrlr->mproc;
 
-	nvme_qpair_term(&ctrlr->sync);
-	if (ctrlr->backend == NVME_BACKEND_VFIO) {
-		nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+	if (ctrlr->shm_fd >= 0) {
+		int32_t attached;
+
+		attached = atomic_load_explicit(&mproc->refcount, memory_order_acquire);
+		if (attached > 1) {
+			XNVME_DEBUG("WARNING: closing primary with %d secondary process(es) still "
+				    "attached; their queue state will be corrupted",
+				    attached - 1);
+		}
+
+		_upcie_release_qpair(ctrlr, &ctrlr->sync);
+		_upcie_free_preallocated_queues(ctrlr);
+
+		munmap(mproc, sizeof(*mproc));
+		close(ctrlr->shm_fd);
+
+		shm_unlink(ctrlr->shm_name);
+
+		if (ctrlr->backend == NVME_BACKEND_VFIO) {
+			nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+		} else {
+			nvme_controller_close(ctrlr->ctrl);
+		}
+	} else if (ctrlr->shm_fd == -1) {
+		_upcie_release_qpair(ctrlr, &ctrlr->sync);
+
+		atomic_fetch_sub_explicit(&mproc->refcount, 1, memory_order_release);
+
+		munmap(mproc, sizeof(*mproc));
+
+		if (ctrlr->imported_hugepage.virt) {
+			munmap(ctrlr->imported_hugepage.virt, ctrlr->imported_hugepage.size);
+		}
+		if (ctrlr->imported_hugepage.fd >= 0) {
+			close(ctrlr->imported_hugepage.fd);
+		}
+
+		pci_bar_unmap(&ctrlr->ctrl->func.bars[0]);
+		pci_func_close(&ctrlr->ctrl->func);
 	} else {
-		nvme_controller_close(ctrlr->ctrl);
+		nvme_qpair_term(&ctrlr->sync);
+
+		if (ctrlr->backend == NVME_BACKEND_VFIO) {
+			nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+		} else {
+			nvme_controller_close(ctrlr->ctrl);
+		}
 	}
+
 	free(ctrlr->ctrl);
 	free(ctrlr);
 
@@ -260,13 +785,75 @@ xnvme_be_upcie_dev_close(struct xnvme_dev *XNVME_UNUSED(dev))
 {
 }
 
+static void
+_upcie_mproc_publish_idfy(struct xnvme_dev *dev)
+{
+	struct xnvme_be_upcie_state *state = (void *)dev->be.state;
+	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
+	struct xnvme_be_upcie_mproc *mp = ctrlr->mproc;
+
+	memcpy(&mp->id_ctrlr, &dev->id.ctrlr, sizeof(mp->id_ctrlr));
+
+	if (dev->ident.dtype != XNVME_DEV_TYPE_NVME_CONTROLLER) {
+		memcpy(&mp->id_ns, &dev->id.ns, sizeof(mp->id_ns));
+		memcpy(&mp->idcss_ctrlr, &dev->idcss.ctrlr, sizeof(mp->idcss_ctrlr));
+		memcpy(&mp->idcss_ns, &dev->idcss.ns, sizeof(mp->idcss_ns));
+		mp->nsid = dev->ident.nsid;
+		mp->csi = dev->ident.csi;
+	}
+
+	atomic_store_explicit(&mp->id_ready, 1, memory_order_release);
+}
+
 int
 xnvme_be_upcie_dev_open(struct xnvme_dev *dev)
 {
+	struct xnvme_be_upcie_state *state = (void *)dev->be.state;
+	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
+	int err;
+
+	if (dev->opts.proc_role == XNVME_PROC_SECONDARY && ctrlr->shm_fd != -1) {
+		XNVME_DEBUG("FAILED: secondary cannot reuse a primary/single ctrlr in the same "
+			    "process");
+		return -ENOTSUP;
+	}
+
 	dev->ident.dtype =
 		dev->opts.nsid ? XNVME_DEV_TYPE_NVME_NAMESPACE : XNVME_DEV_TYPE_NVME_CONTROLLER;
 	dev->ident.csi = XNVME_SPEC_CSI_NVM;
 	dev->ident.nsid = dev->opts.nsid;
+
+	if (dev->opts.proc_role == XNVME_PROC_SECONDARY) {
+		struct xnvme_be_upcie_mproc *mp = ctrlr->mproc;
+
+		if (!atomic_load_explicit(&mp->id_ready, memory_order_acquire)) {
+			XNVME_DEBUG("FAILED: primary identify data not yet published");
+			return -ENOENT;
+		}
+
+		memcpy(&dev->id.ctrlr, &mp->id_ctrlr, sizeof(dev->id.ctrlr));
+		memcpy(dev->ident.subnqn, dev->id.ctrlr.subnqn, sizeof(dev->ident.subnqn));
+
+		if (dev->ident.dtype != XNVME_DEV_TYPE_NVME_CONTROLLER) {
+			if (dev->ident.nsid != mp->nsid) {
+				XNVME_DEBUG("FAILED: nsid mismatch: want %u, have %u",
+					    dev->ident.nsid, mp->nsid);
+				return -ENOENT;
+			}
+			memcpy(&dev->id.ns, &mp->id_ns, sizeof(dev->id.ns));
+			memcpy(&dev->idcss.ctrlr, &mp->idcss_ctrlr, sizeof(dev->idcss.ctrlr));
+			memcpy(&dev->idcss.ns, &mp->idcss_ns, sizeof(dev->idcss.ns));
+			dev->ident.csi = mp->csi;
+		}
+	}
+
+	if (dev->opts.proc_role == XNVME_PROC_PRIMARY && ctrlr->mproc) {
+		err = xnvme_dev_derive_geo(dev);
+		if (err) {
+			return err;
+		}
+		_upcie_mproc_publish_idfy(dev);
+	}
 
 	return 0;
 }
@@ -280,11 +867,13 @@ struct xnvme_be_dev g_xnvme_be_upcie_dev = {
 	.id = "upcie",
 	.ctrlr_init = xnvme_be_upcie_ctrlr_init,
 	.ctrlr_term = xnvme_be_upcie_ctrlr_term,
+	.ctrlr_attach = xnvme_be_upcie_ctrlr_attach,
 #else
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",
 	.ctrlr_init = NULL,
 	.ctrlr_term = NULL,
+	.ctrlr_attach = NULL,
 #endif
 };

--- a/lib/xnvme_be_spdk.c
+++ b/lib/xnvme_be_spdk.c
@@ -17,7 +17,7 @@ const struct xnvme_be_config g_xnvme_be_spdk = {
 			.name = "spdk",
 			.descr = "SPDK userspace NVMe driver",
 			.caps = XNVME_BE_CAP_NVME_PCIE | XNVME_BE_CAP_NVME_TCP |
-				XNVME_BE_CAP_NVME_RDMA,
+				XNVME_BE_CAP_NVME_RDMA | XNVME_BE_CAP_MPROC,
 		},
 };
 

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -488,10 +488,15 @@ xnvme_be_spdk_ctrlr_init(struct xnvme_dev *dev)
 	int err;
 
 	spdk_env_opts_init(&env_opts);
-	if (dev->opts.core_mask) {
+
+	if (dev->opts.core_mask || dev->opts.proc_role != XNVME_PROC_SINGLE) {
 		XNVME_DEBUG("INFO: multi-process setup");
+
+		if (dev->opts.core_mask) {
+			env_opts.core_mask = dev->opts.core_mask;
+		}
+
 		env_opts.shm_id = dev->opts.shm_id;
-		env_opts.core_mask = dev->opts.core_mask;
 		env_opts.main_core = dev->opts.main_core;
 	}
 

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -889,6 +889,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "Number of queues per device",
 	},
 	{
+		.opt = XNVME_CLI_OPT_PROC_ROLE,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "proc_role",
+		.descr = "Multi-process role: 0=auto, 1=primary, 2=secondary",
+	},
+	{
 		.opt = XNVME_CLI_OPT_END,
 		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
 		.name = "",
@@ -1573,6 +1579,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 	case XNVME_CLI_OPT_NQUEUES:
 		args->nqueues = num;
 		break;
+	case XNVME_CLI_OPT_PROC_ROLE:
+		args->proc_role = num;
+		break;
 	case XNVME_CLI_OPT_POSA_TITLE:
 	case XNVME_CLI_OPT_NON_POSA_TITLE:
 	case XNVME_CLI_OPT_ORCH_TITLE:
@@ -2015,6 +2024,9 @@ xnvme_cli_to_opts(const struct xnvme_cli *cli, struct xnvme_opts *opts)
 	opts->adrfam = cli->given[XNVME_CLI_OPT_ADRFAM] ? cli->args.adrfam : opts->adrfam;
 	opts->subnqn = cli->given[XNVME_CLI_OPT_SUBNQN] ? cli->args.subnqn : opts->subnqn;
 	opts->hostnqn = cli->given[XNVME_CLI_OPT_HOSTNQN] ? cli->args.hostnqn : opts->hostnqn;
+
+	opts->proc_role =
+		cli->given[XNVME_CLI_OPT_PROC_ROLE] ? cli->args.proc_role : opts->proc_role;
 
 	return 0;
 }

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -375,6 +375,7 @@ _dev_idfy(struct xnvme_dev *dev)
 	int err;
 
 	dev->attempted_dev_idfy = true;
+
 	//
 	// Identify controller and namespace
 	//
@@ -470,10 +471,12 @@ xnvme_dev_derive_geo(struct xnvme_dev *dev)
 
 	dev->attempted_derive_geo = true;
 
-	err = _dev_idfy(dev);
-	if (err) {
-		XNVME_DEBUG("FAILED: identifying device; skipping derive-geo");
-		return err;
+	if (dev->opts.proc_role != XNVME_PROC_SECONDARY) {
+		err = _dev_idfy(dev);
+		if (err) {
+			XNVME_DEBUG("FAILED: identifying device; skipping derive-geo");
+			return err;
+		}
 	}
 
 	switch (dev->ident.dtype) {

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -86,6 +86,9 @@ xnvme_opts_yaml(FILE *stream, const struct xnvme_opts *opts, int indent, const c
 	wrtn += fprintf(stream, "%*sspdk_fabrics: 0x%" PRIx32 "%s", indent, "", opts->spdk_fabrics,
 			sep);
 
+	wrtn += fprintf(stream, "%*sproc_role: %" PRIu32 "%s", indent, "",
+			(uint32_t)opts->proc_role, sep);
+
 	return wrtn;
 }
 

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -61,12 +61,12 @@ _dev_open_resolve_mem(struct xnvme_be *be, const struct xnvme_be_config *cfg,
 
 /**
  * Initialize a controller reference for the device, reusing an existing one
- * or creating a new one via ctrlr_init.
+ * or creating a new one via ctrlr_init or ctrlr_attach.
  *
  * Looks up an existing cref for the URI and config name. When none exists,
- * checks for conflicts with other backend configs, initializes a new controller,
- * and inserts it into the cref table. On success, stores the controller
- * pointer in be->state[0].
+ * checks for conflicts with other backend configs, then dispatches to
+ * ctrlr_init (primary) or ctrlr_attach (secondary) based on proc_role.
+ * On success, stores the controller pointer in be->state[0].
  *
  * @param dev Device being opened
  * @param be Backend instance with dev operations
@@ -78,7 +78,7 @@ static int
 _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnvme_be_config *cfg)
 {
 	const struct xnvme_be_cref_entry *cref;
-	void *ctrlr;
+	void *ctrlr = NULL;
 	int err;
 
 	if (!be->dev.ctrlr_init) {
@@ -103,10 +103,21 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		return -ENOTSUP;
 	}
 
-	ctrlr = be->dev.ctrlr_init(dev);
+	if (dev->opts.proc_role == XNVME_PROC_SECONDARY && be->dev.ctrlr_attach) {
+		ctrlr = be->dev.ctrlr_attach(dev);
+		if (!ctrlr) {
+			XNVME_DEBUG("FAILED: ctrlr_attach for uri '%s'", dev->ident.uri);
+			return errno ? -errno : -EIO;
+		}
+	}
+
 	if (!ctrlr) {
-		XNVME_DEBUG("FAILED: ctrlr_init for uri '%s'", dev->ident.uri);
-		return errno ? -errno : -EIO;
+		errno = 0;
+		ctrlr = be->dev.ctrlr_init(dev);
+		if (!ctrlr) {
+			XNVME_DEBUG("FAILED: ctrlr_init for uri '%s'", dev->ident.uri);
+			return errno ? -errno : -EIO;
+		}
 	}
 
 	err = xnvme_be_cref_insert(dev->ident.uri, cfg->attr.name, ctrlr, be->dev.ctrlr_term);

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -98,6 +98,11 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		goto ctrlr_ready;
 	}
 
+	if (dev->opts.proc_role != XNVME_PROC_SINGLE && !(cfg->attr.caps & XNVME_BE_CAP_MPROC)) {
+		XNVME_DEBUG("FAILED: backend '%s' does not support multi-process", cfg->attr.name);
+		return -ENOTSUP;
+	}
+
 	ctrlr = be->dev.ctrlr_init(dev);
 	if (!ctrlr) {
 		XNVME_DEBUG("FAILED: ctrlr_init for uri '%s'", dev->ident.uri);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -70,6 +70,7 @@ tests = {
 
 if not is_windows
   tests += {'map.c': []}
+  tests += {'mproc.c': []}
 endif
 
 foreach test_source, tests_args : tests

--- a/tests/mproc.c
+++ b/tests/mproc.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <signal.h>
+#include <unistd.h>
+#include <libxnvme.h>
+
+static volatile sig_atomic_t g_stop;
+
+static void
+on_signal(int XNVME_UNUSED(sig))
+{
+	g_stop = 1;
+}
+
+static int
+sub_primary(struct xnvme_cli *cli)
+{
+	signal(SIGTERM, on_signal);
+	signal(SIGINT, on_signal);
+
+	xnvme_cli_pinf("primary: device open at %s, waiting for SIGTERM/SIGINT", cli->args.uri);
+
+	// Keep process alive, thereby keeping device open until process is killed.
+	while (!g_stop) {
+		sleep(1);
+	}
+
+	return 0;
+}
+
+static struct xnvme_cli_sub g_subs[] = {
+	{
+		"primary",
+		"Open device as primary and wait, allowing secondary processes to attach",
+		"Open device as primary and wait, allowing secondary processes to attach",
+		sub_primary,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+
+			XNVME_CLI_ADMIN_OPTS,
+		},
+	},
+};
+
+static struct xnvme_cli g_cli = {
+	.title = "Multi-Process Primary",
+	.descr_short = "Multi-Process Primary",
+	.subs = g_subs,
+	.nsubs = sizeof g_subs / sizeof(*g_subs),
+};
+
+int
+main(int argc, char **argv)
+{
+	return xnvme_cli_run(&g_cli, argc, argv, XNVME_CLI_INIT_DEV_OPEN);
+}

--- a/tests/mproc.c
+++ b/tests/mproc.c
@@ -6,6 +6,8 @@
 #include <unistd.h>
 #include <libxnvme.h>
 
+#define MPROC_QUEUE_DEPTH 256
+
 static volatile sig_atomic_t g_stop;
 
 static void
@@ -17,12 +19,33 @@ on_signal(int XNVME_UNUSED(sig))
 static int
 sub_primary(struct xnvme_cli *cli)
 {
+	struct xnvme_dev *dev = cli->args.dev;
+	uint32_t nqueues = cli->args.nqueues ? cli->args.nqueues : 1;
+	int err;
+
 	signal(SIGTERM, on_signal);
 	signal(SIGINT, on_signal);
 
-	xnvme_cli_pinf("primary: device open at %s, waiting for SIGTERM/SIGINT", cli->args.uri);
+	for (uint32_t i = 0; i < nqueues; i++) {
+		struct xnvme_queue *queue = NULL;
 
-	// Keep process alive, thereby keeping device open until process is killed.
+		err = xnvme_queue_init(dev, MPROC_QUEUE_DEPTH, 0, &queue);
+		if (err) {
+			xnvme_cli_perr("xnvme_queue_init()", err);
+			return err;
+		}
+
+		err = xnvme_queue_term(queue);
+		if (err) {
+			xnvme_cli_perr("xnvme_queue_term()", err);
+			return err;
+		}
+	}
+
+	xnvme_cli_pinf(
+		"primary: device open at %s, pool has %u queue(s), waiting for SIGTERM/SIGINT",
+		cli->args.uri, nqueues);
+
 	while (!g_stop) {
 		sleep(1);
 	}
@@ -41,6 +64,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
 
 			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_NQUEUES, XNVME_CLI_LOPT},
 
 			XNVME_CLI_ADMIN_OPTS,
 		},

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -1340,6 +1340,7 @@ static struct xnvme_cli_sub g_subs[] = {
 		{
 			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+			{XNVME_CLI_OPT_PROC_ROLE, XNVME_CLI_LOPT},
 
 			XNVME_CLI_ASYNC_OPTS,
 		},

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -1363,6 +1363,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_DIRECT, XNVME_CLI_LFLG},
 			{XNVME_CLI_OPT_POLL_IO, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_POLL_SQ, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_PROC_ROLE, XNVME_CLI_LOPT},
 		},
 	},
 	{


### PR DESCRIPTION
Here, I am adding multi-process support, which lets multiple processes share a single userspace NVMe device. The primary process initializes the hardware and preallocates a pool of queue pairs, and secondary processes attach and claim pairs from that pool via shared memory, without issuing any admin commands themselves.
  
The upcie backend gets full support for this through POSIX shm and hugepage import. SPDK gains the ability to enter multi-process mode through proc_role alone, without needing core_mask. Kernel backends supported this already, and the vfio backend does not support multi-process mode (by not allowing secondary processes to connect to xNVMe devices).