### PR TITLE
Multi-process mode in uPCIe backend + HOMI

### DIFF
--- a/cijoe/tests/apps/test_fio.py
+++ b/cijoe/tests/apps/test_fio.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import get_osname, get_shm_id, xnvme_parametrize
 from .fio_fancy import fio_fancy
 
 FIO_OUTPUT_FPATH = (
@@ -19,6 +19,8 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
         pytest.skip(
             reason="[mem=upcie-cuda] fio xNVMe ioengine does not support CUDA memory"
         )
+    if get_shm_id():
+        pytest.skip(reason="fio does not support multi-process mode")
 
     size = "64M"
     # size = "1G"
@@ -54,6 +56,8 @@ def test_fio_engine_iov(cijoe, device, be_opts, cli_args):
         pytest.skip(
             reason="[mem=upcie-cuda] fio xNVMe ioengine does not support CUDA memory"
         )
+    if get_shm_id():
+        pytest.skip(reason="fio does not support multi-process mode")
 
     size = "64M"
     # size = "1G"
@@ -86,6 +90,8 @@ def test_fio_engine_zns(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="[sync=psync,block] does not support mgmt. send/receive")
     if be_opts["async"] == "thrpool":
         pytest.skip(reason="[async=thrpool] gives Zone Invalid Write")
+    if get_shm_id():
+        pytest.skip(reason="fio does not support multi-process mode")
 
     size = "64M"
     # size = "1G"
@@ -112,6 +118,8 @@ def test_fio_engine_fdp(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="FIO requires a char device")
     if be_opts["sync"] == "psync":
         pytest.skip(reason="[sync=psync] cannot do write with directives")
+    if get_shm_id():
+        pytest.skip(reason="fio does not support multi-process mode")
 
     size = "64M"
     # size = "1G"

--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -15,10 +15,30 @@
 """
 
 from functools import wraps
+from time import sleep
 
 import pytest
 
 from .xnvme_be_combinations import get_backend_configurations
+
+_shm_id = 0
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--shm_id",
+        type=int,
+        default=0,
+        help="Open devices with the given shm_id (0 = single process mode)",
+    )
+
+
+def pytest_configure(config):
+    global _shm_id
+    try:
+        _shm_id = config.getoption("--shm_id", default=0)
+    except ValueError:
+        _shm_id = 0
 
 
 def get_osname():
@@ -27,6 +47,10 @@ def get_osname():
     if osname == "debian":
         osname = "linux"
     return osname
+
+
+def get_shm_id():
+    return _shm_id if _shm_id else None
 
 
 def xnvme_be_opts(options=None, only_labels=[]):
@@ -59,6 +83,7 @@ def xnvme_be_opts(options=None, only_labels=[]):
                                     "sync": be_sync,
                                     "async": be_async,
                                     "label": opts["label"],
+                                    "mproc": opts.get("mproc", False),
                                 }
                             )
 
@@ -123,6 +148,9 @@ def xnvme_cli_args(device, be_opts):
     if be_opts:
         args += [f"--{arg} {val}" for arg, val in be_opts.items() if arg != "label"]
 
+    if _shm_id > 0:
+        args += [f"--shm_id {_shm_id}"]
+
     return " ".join(args)
 
 
@@ -140,7 +168,7 @@ def xnvme_setup(labels=[], opts=[]):
         device = cijoe_config_get_device(search)
 
         dstr = device["uri"] if device else "None"
-        bstr = ",".join([f"{k}={v}" for k, v in be_opts.items()])
+        bstr = ",".join([f"{k}={v}" for k, v in be_opts.items() if k != "mproc"])
 
         paramid = f"uri={dstr},{bstr}"
 
@@ -207,6 +235,10 @@ class XnvmeDriver(object):
     def kernel_detach(cijoe):
         """Detach from kernel"""
 
+        # Rebinding devices and re-allocating hugepages invalidates a running primary,
+        # so tear it down first rather than leaving MprocPrimary with a stale handle.
+        MprocPrimary.stop(cijoe)
+
         # 64MB contigmem buffers avoid ENOMEM on FreeBSD's fragmented CI heap;
         # see toolbox/xnvme-driver.sh.
         cmd = "xnvme-driver"
@@ -222,6 +254,8 @@ class XnvmeDriver(object):
     @staticmethod
     def kernel_attach(cijoe):
         """Attach to kernel"""
+
+        MprocPrimary.stop(cijoe)
 
         err, _ = cijoe.run("xnvme-driver reset")
         if err:
@@ -268,6 +302,14 @@ def device(cijoe, request):
     from within the testcase body itself.
     """
     if request.param:
+        if _shm_id:
+            callspec = getattr(request.node, "callspec", None)
+            be_opts = callspec.params.get("be_opts") if callspec else None
+            if be_opts:
+                if be_opts.get("mproc"):
+                    MprocPrimary.start(cijoe, be_opts["be"])
+                else:
+                    pytest.skip(f"{be_opts.get('be')} does not support multi-process")
         XnvmeDriver.attach(cijoe, request.param)
 
     return request.param
@@ -305,6 +347,110 @@ def xnvme_parametrize(labels, opts):
         return inner
 
     return decorator
+
+
+class MprocPrimary:
+    """
+    Manages the lifecycle of a homi primary daemon.
+
+    A single primary holds every 'pcie' device in the configuration, so it can serve
+    whichever device a testcase asks for, as well as testcases enumerating and opening
+    all of them. Tracks which backend the running primary was started with (similar to
+    XnvmeDriver.IS_KERNEL_ATTACHED), so it is only restarted when the backend changes.
+    """
+
+    RUNNING = None
+    CIJOE = None
+    TIMEOUT = 60
+
+    # Emitted by homi once every device it was given is open
+    READY_MARKER = "HOMI started successfully"
+
+    @staticmethod
+    def is_running(cijoe):
+        """Returns True when a homi primary is running"""
+
+        # Match on the process name; 'pgrep -f' also matched the shell that cijoe.run()
+        # wraps the command in, so it never detected a failed start
+        err, _ = cijoe.run("pgrep -x homi")
+
+        return not err
+
+    @staticmethod
+    def is_ready(cijoe, be):
+        """Returns True when the homi primary has opened all of its devices"""
+
+        err, _ = cijoe.run(f"grep -q '{MprocPrimary.READY_MARKER}' /tmp/mproc_{be}.out")
+
+        return not err
+
+    @staticmethod
+    def start(cijoe, be):
+        if MprocPrimary.RUNNING == be:
+            return
+
+        uris = " ".join(d["uri"] for d in cijoe_config_get_all_devices(["pcie"]))
+        if not uris:
+            pytest.skip("Configuration has no device labelled: ['pcie']")
+
+        XnvmeDriver.kernel_detach(cijoe)
+
+        # SPDK backs its DMA memory with files in the hugetlbfs mount and never unlinks
+        # them, since secondaries must be able to map them. As xNVMe does not call
+        # spdk_env_fini(), they outlive the process and keep holding hugepages. Drop them
+        # so the primary starting here does so with a full pool.
+        mount_point = cijoe.getconf("hugetlbfs.mount_point", "/mnt/huge")
+        cijoe.run(f"rm -f {mount_point}/spdk*map_*")
+
+        # 'stdbuf -oL' keeps the readiness marker from sitting in libc's fully-buffered
+        # stdout while the primary parks waiting for a signal
+        cijoe.run(
+            f"stdbuf -oL nohup homi start {uris} --be {be} --shm_id {_shm_id} "
+            f"> /tmp/mproc_{be}.out 2>&1 &"
+        )
+
+        # Opening a device takes about a second, so waiting a fixed duration either
+        # wastes time or lets testcases attach while the primary is still opening the
+        # rest, where they fail with the primary unresponsive on the DPDK mp channel.
+        for _ in range(MprocPrimary.TIMEOUT):
+            if MprocPrimary.is_ready(cijoe, be):
+                break
+            if not MprocPrimary.is_running(cijoe):
+                cijoe.run(f"cat /tmp/mproc_{be}.out")
+                pytest.fail(f"homi primary for be({be}) is not running")
+            sleep(1)
+        else:
+            cijoe.run(f"cat /tmp/mproc_{be}.out")
+            pytest.fail(f"homi primary for be({be}) did not become ready")
+
+        MprocPrimary.RUNNING = be
+        MprocPrimary.CIJOE = cijoe
+
+    @staticmethod
+    def stop(cijoe):
+        if MprocPrimary.RUNNING is None:
+            return
+
+        MprocPrimary.RUNNING = None
+        MprocPrimary.CIJOE = None
+
+        cijoe.run("pkill -x homi || true")
+
+        # Closing a controller is not instant, and a primary still holding the device
+        # keeps its successor from claiming it, so wait for it to actually be gone
+        for _ in range(MprocPrimary.TIMEOUT):
+            if not MprocPrimary.is_running(cijoe):
+                break
+            sleep(1)
+        else:
+            pytest.fail("homi primary did not terminate")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mproc_teardown():
+    yield
+    if MprocPrimary.CIJOE is not None:
+        MprocPrimary.stop(MprocPrimary.CIJOE)
 
 
 # Sort order for pytest_collection_modifyitems. `be` first because backend

--- a/cijoe/tests/examples/test_xnvme_hello.py
+++ b/cijoe/tests/examples/test_xnvme_hello.py
@@ -1,7 +1,12 @@
-from ..conftest import xnvme_parametrize
+import pytest
+
+from ..conftest import get_shm_id, xnvme_parametrize
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_hw(cijoe, device, be_opts, cli_args):
+    if get_shm_id():
+        pytest.skip(reason="xnvme_hello does not take --shm_id as argument")
+
     err, _ = cijoe.run(f"xnvme_hello {device['uri']}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_enum.py
+++ b/cijoe/tests/logic/test_xnvme_tests_enum.py
@@ -1,47 +1,68 @@
 import pytest
 import yaml
 
-from ..conftest import XnvmeDriver, cijoe_config_get_all_devices, xnvme_parametrize
+from ..conftest import (
+    XnvmeDriver,
+    cijoe_config_get_all_devices,
+    get_shm_id,
+    xnvme_parametrize,
+)
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be"])
 def test_open(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     if be_opts["admin"] == "ramdisk":
         pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
-            f"xnvme_tests_enum open --uri {device['uri']} --count 4 --be {be_opts['be']}"
+            f"xnvme_tests_enum open --uri {device['uri']} --count 4"
+            f" --be {be_opts['be']} {shm_arg}"
         )
     else:
-        err, _ = cijoe.run(f"xnvme_tests_enum open --count 4 --be {be_opts['be']}")
+        err, _ = cijoe.run(
+            f"xnvme_tests_enum open --count 4 --be {be_opts['be']} {shm_arg}"
+        )
     assert not err
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be"])
 def test_keep_open(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     if be_opts["admin"] == "ramdisk":
         pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
 
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
-            f"xnvme_tests_enum keep_open --uri {device['uri']} --be {be_opts['be']}"
+            f"xnvme_tests_enum keep_open --uri {device['uri']}"
+            f" --be {be_opts['be']} {shm_arg}"
         )
     else:
-        err, _ = cijoe.run(f"xnvme_tests_enum keep_open --be {be_opts['be']}")
+        err, _ = cijoe.run(f"xnvme_tests_enum keep_open --be {be_opts['be']} {shm_arg}")
     assert not err
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be"])
 def test_multi(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     if be_opts["admin"] == "ramdisk":
         pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
 
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
-            f"xnvme_tests_enum multi --uri {device['uri']} --count 4 --be {be_opts['be']}"
+            f"xnvme_tests_enum multi --uri {device['uri']} --count 4"
+            f" --be {be_opts['be']} {shm_arg}"
         )
     else:
-        err, _ = cijoe.run(f"xnvme_tests_enum multi --count 4 --be {be_opts['be']}")
+        err, _ = cijoe.run(
+            f"xnvme_tests_enum multi --count 4 --be {be_opts['be']} {shm_arg}"
+        )
     assert not err
 
 

--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..conftest import XnvmeDriver, get_osname, xnvme_parametrize
+from ..conftest import XnvmeDriver, get_osname, get_shm_id, xnvme_parametrize
 
 
 def test_library_info(cijoe):
@@ -384,9 +384,7 @@ def test_show_regs(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "libvfn":
         pytest.skip(reason="[be=libvfn] does not support pseudo commands")
 
-    err, _ = cijoe.run(
-        f"xnvme show-regs {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
-    )
+    err, _ = cijoe.run(f"xnvme show-regs {cli_args}")
 
     expect_error = False
     if get_osname() == "linux" and be_opts["admin"] == "nvme":
@@ -407,6 +405,8 @@ def test_subsystem_reset(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="[be=libvfn] does not support pseudo commands")
     if be_opts["admin"] == "upcie":
         pytest.skip(reason="[be=upcie] does not support subsystem-reset")
+    if get_shm_id():
+        pytest.skip(reason="reset tears down the queues held by the mproc primary")
 
     err, state = cijoe.run(
         f"xnvme subsystem-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
@@ -436,6 +436,8 @@ def test_ctrlr_reset(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="[be=libvfn] does not support pseudo commands")
     if be_opts["admin"] == "upcie":
         pytest.skip(reason="[be=upcie] does not support controller-reset")
+    if get_shm_id():
+        pytest.skip(reason="reset tears down the queues held by the mproc primary")
 
     err, _ = cijoe.run(
         f"xnvme ctrlr-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
@@ -451,8 +453,6 @@ def test_namespace_rescan(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "spdk":
         pytest.skip(reason="[admin=spdk] does not support namespace rescan")
 
-    err, _ = cijoe.run(
-        f"xnvme ns-rescan {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
-    )
+    err, _ = cijoe.run(f"xnvme ns-rescan {cli_args}")
 
     assert not err

--- a/cijoe/tests/tools/test_xnvmeperf.py
+++ b/cijoe/tests/tools/test_xnvmeperf.py
@@ -1,45 +1,61 @@
-from ..conftest import xnvme_parametrize
+from ..conftest import get_shm_id, xnvme_parametrize
 
 
 @xnvme_parametrize(labels=["nvm"], opts=["be"])
 def test_run_read(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     err, _ = cijoe.run(
         f"xnvmeperf run --iopattern read --qdepth 32 --iosize 4096 --runtime 3"
-        f" --cpumask 0x1 --be {be_opts['be']} {device['uri']}"
+        f" --cpumask 0x1 --be {be_opts['be']} {shm_arg} {device['uri']}"
     )
     assert not err
 
 
 @xnvme_parametrize(labels=["nvm"], opts=["be"])
 def test_run_write(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     err, _ = cijoe.run(
         f"xnvmeperf run --iopattern write --qdepth 32 --iosize 4096 --runtime 3"
-        f" --cpumask 0x1 --be {be_opts['be']} {device['uri']}"
+        f" --cpumask 0x1 --be {be_opts['be']} {shm_arg} {device['uri']}"
     )
     assert not err
 
 
 @xnvme_parametrize(labels=["nvm"], opts=["be"])
 def test_run_randread(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     err, _ = cijoe.run(
         f"xnvmeperf run --iopattern randread --qdepth 32 --iosize 4096 --runtime 3"
-        f" --cpumask 0x1 --be {be_opts['be']} {device['uri']}"
+        f" --cpumask 0x1 --be {be_opts['be']} {shm_arg} {device['uri']}"
     )
     assert not err
 
 
 @xnvme_parametrize(labels=["nvm"], opts=["be"])
 def test_run_randwrite(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     err, _ = cijoe.run(
         f"xnvmeperf run --iopattern randwrite --qdepth 32 --iosize 4096 --runtime 3"
-        f" --cpumask 0x1 --be {be_opts['be']} {device['uri']}"
+        f" --cpumask 0x1 --be {be_opts['be']} {shm_arg} {device['uri']}"
     )
     assert not err
 
 
 @xnvme_parametrize(labels=["nvm"], opts=["be"])
 def test_verify(cijoe, device, be_opts, cli_args):
+    shm_id = get_shm_id()
+    shm_arg = f"--shm_id {shm_id}" if shm_id else ""
+
     err, _ = cijoe.run(
-        f"xnvmeperf verify --iosize 4096 --count 64 --be {be_opts['be']} {device['uri']}"
+        f"xnvmeperf verify --iosize 4096 --count 64"
+        f" --be {be_opts['be']} {shm_arg} {device['uri']}"
     )
     assert not err

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -128,6 +128,7 @@ def get_backend_configurations():
             "admin": ["spdk"],
             "mem": ["spdk"],
             "label": ["pcie"],
+            "mproc": True,
         },
         {
             "be": ["spdk"],
@@ -144,6 +145,7 @@ def get_backend_configurations():
             "sync": ["upcie"],
             "admin": ["upcie"],
             "label": ["pcie"],
+            "mproc": True,
         },
         {
             "be": ["upcie-cuda"],

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -208,6 +208,7 @@ def get_backend_configurations():
             "admin": ["spdk"],
             "mem": ["spdk"],
             "label": ["pcie"],
+            "mproc": True,
         },
         # Ramdisk
         {

--- a/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
@@ -28,3 +28,10 @@ steps:
   with:
     args: '-k "(upcie or spdk) and not fabrics" tests'
     random_order: false
+
+- name: test_mproc
+  uses: core.testrunner
+  with:
+    # Excluded from multi-process mode: kvs and dual_be (has no --shm_id)
+    args: '-k "(upcie or spdk) and not (fabrics or kvs or dual_be)" tests --shm_id 1'
+    random_order: false

--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
@@ -47,3 +47,10 @@ steps:
   with:
     args: '-k "pcie" tests'
     random_order: false
+
+- name: test_mproc
+  uses: core.testrunner
+  with:
+    # Excluded from multi-process mode: kvs and dual_be (has no --shm_id)
+    args: '-k "pcie and not (upcie or fabrics or kvs or dual_be)" tests --shm_id 1'
+    random_order: false

--- a/docs/background/backends/upcie/index.md
+++ b/docs/background/backends/upcie/index.md
@@ -16,6 +16,10 @@ allocated:
   enabling PCIe peer-to-peer (P2P) transfers directly between the NVMe device
   and the GPU.
 
+Additionally, the host-memory backend supports a **{ref}`sec-backends-upcie-mproc`**
+mode in which several processes share a single NVMe controller via a designated
+primary process.
+
 (sec-backends-upcie-identifiers)=
 
 ## Device Identifiers
@@ -85,4 +89,5 @@ struct xnvme_dev *cuda_dev = xnvme_dev_open("0000:03:00.0", &cuda_opts);
 
 host
 cuda
+mproc
 ```

--- a/docs/background/backends/upcie/mproc.md
+++ b/docs/background/backends/upcie/mproc.md
@@ -1,0 +1,204 @@
+(sec-backends-upcie-mproc)=
+# uPCIe (multi-process)
+
+The **upcie** backend supports a **multi-process** mode in which several
+independent processes share NVMe controllers. In a multi-process setup, there
+will always be one **primary** process, and any number of **secondary**
+processes. The **primary** owns the DMA hugepages and the controller hardware
+state. The **secondary** processes attach to that state and drive their own
+I/O without re-initializing the device.
+
+Multi-process mode is opt-in and enabled per device by supplying a non-zero
+**shared-memory id** via the `--shm_id` option (or the `shm_id` field of
+`struct xnvme_opts`). All processes that should share a controller must be
+launched with the **same** `shm_id`.
+
+```bash
+# Primary (first process to claim the shm_id) and secondaries use the same id
+xnvme info 0000:03:00.0 --be upcie --shm_id 1
+```
+
+(sec-backends-upcie-mproc-model)=
+## Process model
+
+### Role election
+
+Roles are decided with an advisory file lock (`flock`) on a lock file keyed by
+`shm_id` (`/tmp/xnvme-upcie-flock-<shm_id>`):
+
+- The first process to acquire the exclusive, non-blocking lock becomes the
+  **primary**. It holds the lock for its entire lifetime.
+- Any process that finds the lock already held becomes a **secondary**.
+
+### Shared memory segments
+
+Two kinds of POSIX shared-memory segments are used:
+
+- **Runtime segment** (`/xnvme-upcie-shm-<shm_id>`) — one per `shm_id`, created
+  by the primary. It carries the hugepage backing-file path and the primary's
+  hugepage virtual base address so that secondaries can import the same DMA
+  memory. A shared `refcount` keeps track of how many processes are attached.
+  Terminating a primary process while `refcount > 1` will not block, but instead
+  only warn that the state of secondary processes will be corrupted.
+- **Controller segment** (`/xnvme-upcie-<bdf>`) — one per physical controller,
+  created by the primary. It embeds the full `struct nvme_controller`, a robust
+  process-shared mutex guarding the admin queue, the bound driver name, an
+  attach `refcount`, and an `is_initialized` publication flag. Again, primary
+  processes will not be blocked from terminating even if secondary processes are
+  still attached.
+
+### Device ownership
+
+The controller segment is keyed by device BDF, independent of `shm_id`. To stop
+two primaries — for example two processes launched with different `shm_id`s —
+from both driving the same physical controller, the creating primary holds a
+second advisory lock keyed by the BDF (`/tmp/xnvme-upcie-<bdf>-lock`) for as long
+as it owns the controller. A process that cannot acquire this lock fails rather
+than creating a conflicting segment.
+
+Because the kernel releases the lock when its holder exits, the controller
+segment is self-healing across a primary crash: the next primary acquires the
+released lock, unlinks any segment the dead primary left behind, and creates a
+fresh one.
+
+### Hugepage sharing
+
+Every process allocates it own private DMA heap from its own hugepages. This
+means that I/O queue pairs and buffers are allocated from a private heap. The
+admin PRP pools are also allocated on the private heap, but the admin queue itself
+is allocated only once on the heap of the primary process. The primary
+publishes its hugepage backing-file path and virtual base into the runtime shared
+memory segment; a secondary imports that hugepage purely to reach the admin
+submission/completion rings and does not allocate from the imported mapping. The
+import lands at a kernel-chosen address, so the admin-queue pointers stored in
+the controller segment (which are primary-relative) are relocated into the
+secondary's mapping by the constant offset between the secondary's import base
+and the primary's published base. PRP entries for a secondary's own commands are
+translated against its private heap, whose physical pages it resolves itself.
+
+(sec-backends-upcie-mproc-startup)=
+## Startup handshake
+
+Secondaries may be launched concurrently with the primary, so attachment is
+guarded by two ordering barriers:
+
+1. **Runtime segment** — a secondary will wait up to ~1 second for the primary
+   to publish the hugepage information before importing hugepages.
+2. **Controller segment** — a secondary will wait up to ~1 second for the
+   per-controller segment to (a) exist, (b) be fully sized, and (c) have its
+   `is_initialized` flag published before reading any shared field.
+
+If the primary does not become ready within the timeout, attachment fails with
+`-ENOENT`.
+
+(sec-backends-upcie-mproc-admin)=
+## Admin queue serialization
+
+There is a single admin queue per controller, shared by all processes. Access
+is serialized with a **robust, process-shared** mutex (`PTHREAD_PROCESS_SHARED`
+and `PTHREAD_MUTEX_ROBUST`) held in the controller segment:
+
+- On **lock**, the holder reloads the admin queue head/tail/phase from shared
+  memory into its local controller view.
+- On **unlock**, the holder publishes its head/tail/phase back to shared memory.
+
+Synchronous admin commands and I/O queue-pair create/delete operations all run
+under this mutex. I/O queue identifiers are tracked in a shared bitmap in the
+controller segment and mutated only while the mutex is held, so each process
+creates and tears down its own I/O queue pairs without colliding.
+
+I/O **data** transfers are not serialized: each process owns its own I/O queue
+pairs and submits to them independently.
+
+(sec-backends-upcie-mproc-recovery)=
+### Crash Recovery
+
+Because the admin mutex is robust, if a process dies while holding it, the next
+locker receives `EOWNERDEAD`. In that case this process will:
+
+1. Drain any completions the dead owner may have left in the admin completion
+   queue, advancing the shared head/phase and ringing the completion-queue
+   doorbell. Since the shared head/phase are only published on unlock and
+   therefore never run ahead of the device, draining can only reap real or
+   phantom completions — never skip one.
+2. Mark the mutex consistent (`pthread_mutex_consistent`) and proceed.
+
+If the mutex has been marked unrecoverable, locking fails with `ENOTRECOVERABLE`.
+
+(sec-backends-upcie-mproc-teardown)=
+## Teardown
+
+Each process decrements the relevant `refcount` on exit. When the primary tears
+down a controller it deletes **all** I/O queue pairs still marked allocated in
+the shared bitmap before closing the controller, and then unmaps and unlinks the
+shared segments. Secondaries detach by deleting their own queue pairs, releasing
+their local request pool and BAR mapping, and unmapping the shared segments
+without unlinking or freeing DMA memory they do not own.
+
+(sec-backends-upcie-mproc-vulns)=
+## Vulnerabilities and limitations
+
+Multi-process mode is functional on the cooperative happy path but has known
+robustness and trust gaps. It is intended for trusted, same-user processes and
+should not be treated as a security boundary.
+
+### Partial crash robustness
+
+Owner-death recovery covers **only** the admin mutex and the admin completion
+queue. Other state left behind by a crashed process is **not** reclaimed:
+
+- **Leaked I/O queues and queue ids.** If a secondary crashes, the I/O queue
+  ids it allocated remain marked as in-use in the shared bitmap and the
+  corresponding device-side queues are never deleted. Over many crash/restart
+  cycles this can exhaust the queue-id space until the primary tears the
+  controller down.
+- **Stale attach refcounts.** A crashed process never decrements its
+  `refcount`. The primary's "secondaries still attached" accounting therefore
+  becomes permanently inflated after any crash. The refcount is advisory only,
+  and therefore it is not used for blocking or preventing a primary from
+  exiting.
+
+### Primary lifetime
+
+The primary owns the hugepages and the controller hardware. If the primary
+exits — cleanly or otherwise — while secondaries are still attached, those
+secondaries are left with admin-queue mapping and controller that may have been
+closed and freed. A clean primary teardown only logs a warning in this case; it
+does not prevent it. Operators must ensure the primary outlives all secondaries.
+
+### No isolation between processes
+
+All participating processes map the controller segment read/write, including the
+embedded `struct nvme_controller`. A misbehaving or compromised secondary can
+corrupt shared state and affect every other process sharing the controller.
+There is no privilege separation: any process running as the same user that can
+open the shared-memory segments can submit admin commands to the device.
+
+### Startup ordering and timeouts
+
+Attachment waits at most ~1 second at each handshake barrier. A primary that
+takes longer than that to initialize a controller will cause secondaries to time
+out with `-ENOENT`. The timeout is fixed and not currently configurable.
+
+### Compatibility with SPDK
+
+SPDK's own multi-process mode claims **all** free hugepages on the system at
+startup. Because uPCIe also needs hugepages for its DMA memory, the two cannot
+be expected to share a system, and running uPCIe and SPDK in multi-process
+mode side by side cannot be not guaranteed to work.
+
+### CUDA backend
+
+Multi-process mode is **not supported** with the `upcie-cuda` backend. The
+backend does not advertise the multi-process capability, so opening an
+`upcie-cuda` device with a non-zero `shm_id` fails with `-ENOTSUP`.
+
+The memory model is not the obstacle: `upcie-cuda` keeps all NVMe control
+structures — the admin queue, the I/O submission/completion rings, PRP lists
+and request pools — on the same host hugepage heap that multi-process mode
+shares, and places only data buffers in per-process GPU memory, which is never
+shared between processes. What is missing is serialization: the `upcie-cuda`
+admin path submits to the shared admin queue without taking the per-controller
+admin mutex, so concurrent processes would race on the admin submission ring.
+Enabling multi-process mode for `upcie-cuda` would require serializing its admin
+path under the same mutex used by the host backend.

--- a/docs/background/backends/upcie/mproc.md
+++ b/docs/background/backends/upcie/mproc.md
@@ -166,6 +166,10 @@ secondaries are left with admin-queue mapping and controller that may have been
 closed and freed. A clean primary teardown only logs a warning in this case; it
 does not prevent it. Operators must ensure the primary outlives all secondaries.
 
+The {ref}`sec-tools-homi` tool serves this purpose: it opens a set of devices and
+holds them open until signalled, giving the primary role to a process whose only
+job is to outlive the secondaries.
+
 ### No isolation between processes
 
 All participating processes map the controller segment read/write, including the

--- a/docs/tools/homi/index.rst
+++ b/docs/tools/homi/index.rst
@@ -1,0 +1,78 @@
+.. _sec-tools-homi:
+
+homi
+####
+
+**homi**, Host-Orchestrated Multi-process I/O,  opens a set of NVMe devices and
+holds them open until it is told to stop. It does no I/O of its own.
+
+Its purpose is to provide the long-lived **primary** process for
+:ref:`sec-backends-upcie-mproc`. The primary owns the DMA hugepages and the
+controller hardware state, and it must outlive every secondary attached to it.
+Running **homi** puts that responsibility in a process of its own, so the
+processes actually doing I/O can come and go freely as secondaries.
+
+:ref:`sec-backends-upcie-mproc` is only available for the
+:ref:`sec-backends-upcie` and :ref:`sec-backends-spdk` backends. **homi** is
+therefore useful where one of those is built: ``upcie`` on Linux, and ``spdk`` on
+Linux and FreeBSD. On Windows it exits with ``-ENOTSUP``, since no
+multi-process capable backend is available there. On other platforms it runs, but
+opening a device with a non-zero ``shm_id`` fails with ``-ENOTSUP``.
+
+``start`` — Hold devices open
+=============================
+
+Opens every device given as a positional argument, then blocks until signalled.
+
+``--shm_id`` is required and sets the shared-memory id the devices are opened
+with. Every process that should share these controllers must be started with the
+same id. ``--be`` optionally selects the backend.
+
+Roles are not assigned by the tool: whichever process claims a given ``shm_id``
+first becomes the primary (see :ref:`sec-backends-upcie-mproc-model`). Starting
+**homi** before any secondary is therefore what makes it the primary.
+
+``--host_heap_size`` sets the size of the ``upcie`` host DMA heap, in bytes. The
+heap is allocated once per process, on the first device open, so this value covers
+every device **homi** holds rather than being per device.
+
+Rather than the 1 GiB the backend would otherwise use, **homi** defaults to 16 MiB
+per device held. It needs only the admin queue and the sync queue pair that opening
+a device creates, and each of those carries a request pool costing 4 MiB — so 16
+MiB per device is roughly double what is required. Every process in multi-process
+mode allocates a heap of its own, so a primary claiming the backend default would
+leave nothing in the hugepage pool for the secondaries it exists to serve::
+
+   homi start 0000:03:00.0 --be upcie --shm_id 1 --host_heap_size 134217728
+
+If any device fails to open, **homi** closes the devices it has already opened
+and exits with an error, rather than holding a partial set open. Once all
+devices are open it reports that it has started, then waits for ``SIGINT``
+(Ctrl+C) or ``SIGTERM``. On either signal it closes all devices and exits.
+
+Example — hold a single device open as the primary for ``shm_id`` 1::
+
+   homi start 0000:03:00.0 --be upcie --shm_id 1
+
+Example — hold several devices under the same ``shm_id``::
+
+   homi start 0000:03:00.0 0000:04:00.0 --be upcie --shm_id 1
+
+While it runs, other processes attach as secondaries by passing the same
+``--shm_id``::
+
+   xnvme info 0000:03:00.0 --be upcie --shm_id 1
+
+Backends
+========
+
+**homi** works with any backend that advertises the multi-process capability,
+which is ``spdk`` and ``upcie``::
+
+   homi start 0000:03:00.0 --be spdk --shm_id 1
+
+.. seealso::
+
+   :ref:`sec-backends-upcie-mproc`
+      The process model, startup handshake, admin-queue serialization, and the
+      known limitations of multi-process mode.

--- a/docs/tools/index.rst
+++ b/docs/tools/index.rst
@@ -18,5 +18,6 @@ In addition to the cli tools, performance tools are provided in the form of
    zoned/index
    xdd/index
    file/index
+   homi/index
    fio/index
    xnvmeperf/index

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -120,6 +120,7 @@ struct xnvme_cli_args {
 	const char *admin;
 
 	uint64_t shm_id;
+	uint64_t host_heap_size;
 	uint32_t main_core;
 	const char *core_mask;
 	const char *iova_mode;
@@ -368,7 +369,9 @@ enum xnvme_cli_opt {
 
 	XNVME_CLI_OPT_CPULIST = 132, ///< XNVME_CLI_OPT_CPULIST
 
-	XNVME_CLI_OPT_END = 133, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_HOST_HEAP_SIZE = 133, ///< XNVME_CLI_OPT_HOST_HEAP_SIZE
+
+	XNVME_CLI_OPT_END = 134, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -6,11 +6,11 @@
  * @file libxnvme_cli.h
  */
 
-#define XNVME_CLI_CORE_OPTS                                                                 \
-	{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP}, {XNVME_CLI_OPT_SUBNQN, XNVME_CLI_LOPT}, \
-		{XNVME_CLI_OPT_HOSTNQN, XNVME_CLI_LOPT},                                    \
-	{                                                                                   \
-		XNVME_CLI_OPT_BE, XNVME_CLI_LOPT                                            \
+#define XNVME_CLI_CORE_OPTS                                                                  \
+	{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP}, {XNVME_CLI_OPT_SUBNQN, XNVME_CLI_LOPT},  \
+		{XNVME_CLI_OPT_HOSTNQN, XNVME_CLI_LOPT}, {XNVME_CLI_OPT_BE, XNVME_CLI_LOPT}, \
+	{                                                                                    \
+		XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT                                         \
 	}
 
 #define XNVME_CLI_ADMIN_OPTS                                                                \

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -39,7 +39,7 @@ struct xnvme_opts {
 	uint8_t register_buffers;  ///< io_uring: enable buffer-registration
 	struct xnvme_opts_css css; ///< SPDK controller-setup: do command-set-selection
 	uint32_t use_cmb_sqs;      ///< SPDK controller-setup: use controller-memory-buffer for sq
-	uint32_t shm_id;           ///< SPDK multi-processing: shared-memory-id
+	uint32_t shm_id;           ///< shared-memory-id
 	uint32_t main_core;        ///< SPDK: main-core
 	const char *core_mask;     ///< SPDK: core-mask
 	const char *iova_mode;     ///< SPDK env-init: DPDK IOVA mode ("va" or "pa")

--- a/include/xnvme_be.h
+++ b/include/xnvme_be.h
@@ -162,6 +162,7 @@ enum xnvme_be_cap {
 	XNVME_BE_CAP_NVME_PCIE = 0x1 << 5, ///< NVMe over PCIe (user-space driver)
 	XNVME_BE_CAP_NVME_TCP  = 0x1 << 6, ///< NVMe over TCP (user-space driver)
 	XNVME_BE_CAP_NVME_RDMA = 0x1 << 7, ///< NVMe over RDMA (user-space driver)
+	XNVME_BE_CAP_MPROC     = 0x1 << 8, ///< Multi-process mode
 };
 
 /**

--- a/lib/upcie/meson.build
+++ b/lib/upcie/meson.build
@@ -12,6 +12,7 @@ xnvmelib_upcie_source = files(
   'xnvme_be_upcie_dev.c',
   'xnvme_be_upcie_cuda_dev.c',
   'xnvme_be_upcie_mem.c',
+  'xnvme_be_upcie_mproc.c',
   'xnvme_be_upcie_cuda_mem.c',
   'xnvme_be_upcie_sync.c',
   'xnvme_be_upcie_cuda_sync.c',

--- a/lib/upcie/xnvme_be_upcie.c
+++ b/lib/upcie/xnvme_be_upcie.c
@@ -18,7 +18,7 @@ const struct xnvme_be_config g_xnvme_be_upcie = {
 		{
 			.name = "upcie",
 			.descr = "uPCIe userspace NVMe driver",
-			.caps = XNVME_BE_CAP_NVME_PCIE,
+			.caps = XNVME_BE_CAP_NVME_PCIE | XNVME_BE_CAP_MPROC,
 		},
 };
 

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -141,7 +141,7 @@ xnvme_be_upcie_mproc_rte_term();
 int
 xnvme_be_upcie_mproc_import_admin_hugepage();
 
-void
+int
 xnvme_be_upcie_ctrlr_mutex_lock(struct xnvme_be_upcie_ctrlr *ctrlr);
 void
 xnvme_be_upcie_ctrlr_mutex_unlock(struct xnvme_be_upcie_ctrlr *ctrlr);

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -5,6 +5,7 @@
 #ifndef __INTERNAL_XNVME_BE_UPCIE_H
 #define __INTERNAL_XNVME_BE_UPCIE_H
 #include <pthread.h>
+#include <stdatomic.h>
 
 #include <xnvme_be.h>
 #include <xnvme_queue.h>
@@ -53,6 +54,16 @@ struct xnvme_be_upcie_state {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_upcie_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
 
 /**
+ * Shared information about hugepages
+ */
+struct xnvme_be_upcie_mproc_shm {
+	char hugepage_path[256]; ///< Path to primary's hugepage file
+	uint64_t hugepage_base;  ///< Primary's hugepage virtual base for secondary pointer fixup
+	_Atomic int refcount;    ///< Number of processes currently attached
+	_Atomic bool is_initialized;
+};
+
+/**
  * Multi-process state
  */
 struct xnvme_be_upcie_mproc {
@@ -60,6 +71,12 @@ struct xnvme_be_upcie_mproc {
 
 	char lock_name[64];
 	int lock_fd;
+
+	char shm_name[64];
+	int shm_fd;
+	struct xnvme_be_upcie_mproc_shm *shm;
+
+	struct hostmem_hugepage *primary_hugepage; ///< Imported hugepage for admin queue
 };
 
 /**
@@ -106,5 +123,7 @@ int
 xnvme_be_upcie_mproc_rte_init(int shm_id);
 void
 xnvme_be_upcie_mproc_rte_term();
+int
+xnvme_be_upcie_mproc_import_admin_hugepage();
 
 #endif /* __INTERNAL_XNVME_BE_UPCIE */

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -153,6 +153,8 @@ int
 xnvme_be_upcie_mproc_ctrlr_shm_attach(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr);
 void
 xnvme_be_upcie_mproc_ctrlr_shm_term(struct xnvme_be_upcie_ctrlr *ctrlr);
+void
+xnvme_be_upcie_mproc_free_all_queues(struct xnvme_be_upcie_ctrlr *ctrlr);
 
 int
 xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrlr,

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -32,6 +32,14 @@ enum nvme_backend {
 	NVME_BACKEND_VFIO,
 };
 
+struct xnvme_be_upcie_ctrlr_shm {
+	_Atomic int32_t refcount;    ///< Number of processes currently attached
+	_Atomic bool is_initialized; ///< Set by primary once the controller is fully opened
+	pthread_mutex_t aq_mutex;    ///< Process-shared mutex for admin queue access
+	char driver_name[32];
+	struct nvme_controller ctrl; ///< Embedded controller; pointer fields use primary's VA
+};
+
 /**
  * Shared controller state, one per physical controller, managed by cref.
  */
@@ -40,6 +48,13 @@ struct xnvme_be_upcie_ctrlr {
 	struct nvme_qpair sync; ///< Shared submission/completion queue for synchronous IOs
 	struct vfio_ctx vfio;
 	enum nvme_backend backend;
+
+	char lock_name[64];
+	int lock_fd;
+
+	char shm_name[64];
+	int shm_fd;
+	struct xnvme_be_upcie_ctrlr_shm *shm;
 };
 
 /**
@@ -125,5 +140,16 @@ void
 xnvme_be_upcie_mproc_rte_term();
 int
 xnvme_be_upcie_mproc_import_admin_hugepage();
+
+void
+xnvme_be_upcie_ctrlr_mutex_lock(struct xnvme_be_upcie_ctrlr *ctrlr);
+void
+xnvme_be_upcie_ctrlr_mutex_unlock(struct xnvme_be_upcie_ctrlr *ctrlr);
+
+int
+xnvme_be_upcie_mproc_ctrlr_shm_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr,
+				    char *driver_name);
+void
+xnvme_be_upcie_mproc_ctrlr_shm_term(struct xnvme_be_upcie_ctrlr *ctrlr);
 
 #endif /* __INTERNAL_XNVME_BE_UPCIE */

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -53,11 +53,22 @@ struct xnvme_be_upcie_state {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_upcie_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
 
 /**
+ * Multi-process state
+ */
+struct xnvme_be_upcie_mproc {
+	bool is_primary; ///< If true, this process is owner of the shared memory
+
+	char lock_name[64];
+	int lock_fd;
+};
+
+/**
  * State used across multiple instances of controllers/namespaces
  */
 struct xnvme_be_upcie_rte {
 	struct hostmem_config config;
 	struct hostmem_heap heap;
+	struct xnvme_be_upcie_mproc *mproc; ///< will be NULL if not in multi-process mode
 	int is_initialized;
 };
 
@@ -89,4 +100,11 @@ int
 xnvme_be_upcie_queue_term(struct xnvme_queue *queue);
 int
 xnvme_be_upcie_queue_poke(struct xnvme_queue *queue, uint32_t max);
+
+// Used for multi-process mode
+int
+xnvme_be_upcie_mproc_rte_init(int shm_id);
+void
+xnvme_be_upcie_mproc_rte_term();
+
 #endif /* __INTERNAL_XNVME_BE_UPCIE */

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -149,7 +149,14 @@ xnvme_be_upcie_ctrlr_mutex_unlock(struct xnvme_be_upcie_ctrlr *ctrlr);
 int
 xnvme_be_upcie_mproc_ctrlr_shm_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr,
 				    char *driver_name);
+int
+xnvme_be_upcie_mproc_ctrlr_shm_attach(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr);
 void
 xnvme_be_upcie_mproc_ctrlr_shm_term(struct xnvme_be_upcie_ctrlr *ctrlr);
+
+int
+xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrlr,
+					       struct nvme_qpair *qpair, uint16_t depth,
+					       bool create);
 
 #endif /* __INTERNAL_XNVME_BE_UPCIE */

--- a/lib/upcie/xnvme_be_upcie_admin.c
+++ b/lib/upcie/xnvme_be_upcie_admin.c
@@ -16,10 +16,13 @@ xnvme_be_upcie_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf
 			      void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
 {
 	struct xnvme_be_upcie_state *state = (void *)ctx->dev->be.state;
+	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
 	struct nvme_controller *ctrl = state->ctrlr->ctrl;
 	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
 	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
 	int err;
+
+	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
 
 	if (dbuf) {
 		err = nvme_qpair_submit_sync_contig_prps(&ctrl->aq, &g_upcie_rte.heap, dbuf,
@@ -27,6 +30,8 @@ xnvme_be_upcie_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf
 	} else {
 		err = nvme_qpair_submit_sync(&ctrl->aq, cmd, ctrl->timeout_ms, cpl);
 	}
+
+	xnvme_be_upcie_ctrlr_mutex_unlock(ctrlr);
 
 	if (err || xnvme_cmd_ctx_cpl_status(ctx)) {
 		XNVME_DEBUG("FAILED: nvme_submit_sync(); err(%d)", err);

--- a/lib/upcie/xnvme_be_upcie_admin.c
+++ b/lib/upcie/xnvme_be_upcie_admin.c
@@ -22,7 +22,11 @@ xnvme_be_upcie_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf
 	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
 	int err;
 
-	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	err = xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		return err;
+	}
 
 	if (dbuf) {
 		err = nvme_qpair_submit_sync_contig_prps(&ctrl->aq, &g_upcie_rte.heap, dbuf,

--- a/lib/upcie/xnvme_be_upcie_async.c
+++ b/lib/upcie/xnvme_be_upcie_async.c
@@ -18,15 +18,25 @@ xnvme_be_upcie_queue_init(struct xnvme_queue *queue, int XNVME_UNUSED(opts))
 {
 	struct xnvme_queue_upcie *upcie_queue = (void *)(queue);
 	struct xnvme_be_upcie_state *state = (void *)queue->base.dev->be.state;
+	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
 	int err;
 
 	// The spec says that for systems where memory ordering is not guaranteed, then one should
 	// leave room in the queue to avoid races. Thus, we do so here, by allocating one more than
 	// what is needed.
-	err = nvme_controller_create_io_qpair(state->ctrlr->ctrl, &upcie_queue->qpair,
-					      queue->base.capacity + 1);
+	if (g_upcie_rte.mproc) {
+		err = xnvme_be_upcie_mproc_create_or_delete_io_qpair(
+			ctrlr, &upcie_queue->qpair, (uint16_t)(queue->base.capacity + 1), true);
+	} else {
+		err = nvme_controller_create_io_qpair(state->ctrlr->ctrl, &upcie_queue->qpair,
+						      queue->base.capacity + 1);
+	}
+
 	if (err) {
-		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair()");
+		XNVME_DEBUG("FAILED: %s(); err(%d)",
+			    g_upcie_rte.mproc ? "xnvme_be_upcie_mproc_create_or_delete_io_qpair"
+					      : "nvme_controller_create_io_qpair",
+			    err);
 		return err;
 	}
 
@@ -40,7 +50,12 @@ xnvme_be_upcie_queue_term(struct xnvme_queue *queue)
 	struct xnvme_be_upcie_state *state = (void *)queue->base.dev->be.state;
 	struct xnvme_be_upcie_ctrlr *ctrlr = state->ctrlr;
 
-	nvme_controller_delete_io_qpair(ctrlr->ctrl, &upcie_queue->qpair);
+	if (g_upcie_rte.mproc) {
+		xnvme_be_upcie_mproc_create_or_delete_io_qpair(ctrlr, &upcie_queue->qpair, 0,
+							       false);
+	} else {
+		nvme_controller_delete_io_qpair(ctrlr->ctrl, &upcie_queue->qpair);
+	}
 
 	return 0;
 }

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -360,7 +360,22 @@ xnvme_be_upcie_ctrlr_term(void *handle)
 		g_upcie_rte.mproc->is_primary; // Is this process the owner of the controller?
 
 	if (g_upcie_rte.mproc) {
+		if (g_upcie_rte.mproc->is_primary) {
+			int attached = atomic_load(&ctrlr->shm->refcount);
+			if (attached > 1) {
+				XNVME_DEBUG("WARNING: terminating controller with %d secondary "
+					    "process(es) still "
+					    "attached",
+					    attached - 1);
+			}
+		}
+
 		xnvme_be_upcie_mproc_create_or_delete_io_qpair(ctrlr, &ctrlr->sync, 0, false);
+
+		// Manually send qpair deletion commands to NVMe controller to not
+		// free DMA memory that the primary process does not own. Is skipped
+		// automatically if not in multi-process mode.
+		xnvme_be_upcie_mproc_free_all_queues(ctrlr);
 	} else {
 		nvme_controller_delete_io_qpair(ctrlr->ctrl, &ctrlr->sync);
 	}

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -248,7 +248,11 @@ _initialize_ctrlr(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr)
 		goto failed;
 	}
 
-	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	err = xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		goto failed_close_ctrlr;
+	}
 
 	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
 

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -294,6 +294,7 @@ void *
 xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 {
 	struct xnvme_be_upcie_ctrlr *ctrlr;
+	bool is_owner; // Is this process the owner of the controller?
 	int err;
 
 	err = _rte_init(&dev->opts);
@@ -302,6 +303,8 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 		errno = -err;
 		return NULL;
 	}
+
+	is_owner = !g_upcie_rte.mproc || g_upcie_rte.mproc->is_primary;
 
 	err = _pci_enable_bus_master(dev->ident.uri);
 	if (err) {
@@ -317,9 +320,17 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 		goto failed;
 	}
 
-	err = _initialize_ctrlr(dev, ctrlr);
+	if (is_owner) {
+		err = _initialize_ctrlr(dev, ctrlr);
+	} else {
+		err = xnvme_be_upcie_mproc_ctrlr_shm_attach(dev, ctrlr);
+	}
+
 	if (err) {
-		XNVME_DEBUG("FAILED: _initialize_ctrlr(); err(%d)", err);
+		XNVME_DEBUG("FAILED: %s(); err(%d)",
+			    is_owner ? "_initialize_ctrlr"
+				     : "xnvme_be_upcie_mproc_ctrlr_shm_attach",
+			    err);
 		errno = -err;
 		goto failed;
 	}
@@ -344,13 +355,26 @@ int
 xnvme_be_upcie_ctrlr_term(void *handle)
 {
 	struct xnvme_be_upcie_ctrlr *ctrlr = handle;
+	bool is_owner =
+		!g_upcie_rte.mproc ||
+		g_upcie_rte.mproc->is_primary; // Is this process the owner of the controller?
 
-	nvme_controller_delete_io_qpair(ctrlr->ctrl, &ctrlr->sync);
-
-	if (ctrlr->backend == NVME_BACKEND_VFIO) {
-		nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+	if (g_upcie_rte.mproc) {
+		xnvme_be_upcie_mproc_create_or_delete_io_qpair(ctrlr, &ctrlr->sync, 0, false);
 	} else {
-		nvme_controller_close(ctrlr->ctrl);
+		nvme_controller_delete_io_qpair(ctrlr->ctrl, &ctrlr->sync);
+	}
+
+	if (is_owner) {
+		if (ctrlr->backend == NVME_BACKEND_VFIO) {
+			nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+		} else {
+			nvme_controller_close(ctrlr->ctrl);
+		}
+	} else {
+		nvme_request_pool_term_prps(ctrlr->ctrl->aq.rpool, &g_upcie_rte.heap);
+		pci_func_close(&ctrlr->ctrl->func);
+		free(ctrlr->ctrl->aq.rpool);
 	}
 
 	if (g_upcie_rte.mproc) {

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -200,6 +200,65 @@ _pci_enable_bus_master(const char *bdf)
 	return 0;
 }
 
+static int
+_initialize_ctrlr(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
+	int err;
+
+	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
+			    err);
+		return err;
+	}
+	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
+
+	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
+	if (!ctrlr->ctrl) {
+		XNVME_DEBUG("FAILED: calloc(ctrl)");
+		return -ENOMEM;
+	}
+
+	if (!strcmp(driver_name, "vfio-pci")) {
+		ctrlr->backend = NVME_BACKEND_VFIO;
+		err = nvme_controller_open_vfio(ctrlr->ctrl, &ctrlr->vfio, dev->ident.uri,
+						&g_upcie_rte.heap);
+	} else if (!strcmp(driver_name, "uio_pci_generic")) {
+		ctrlr->backend = NVME_BACKEND_SYSFS;
+		err = nvme_controller_open(ctrlr->ctrl, dev->ident.uri, &g_upcie_rte.heap);
+	} else {
+		XNVME_DEBUG("FAILED: unsupported driver '%s'", driver_name);
+		err = -ENOTSUP;
+	}
+	if (err) {
+		XNVME_DEBUG("FAILED: %s(%s)",
+			    ctrlr->backend == NVME_BACKEND_VFIO ? "nvme_controller_open_vfio"
+								: "nvme_controller_open",
+			    dev->ident.uri);
+		goto failed;
+	}
+
+	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(%d)", err);
+		goto failed_close_ctrlr;
+	}
+
+	return 0;
+
+failed_close_ctrlr:
+	if (ctrlr->backend == NVME_BACKEND_VFIO) {
+		nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+	} else {
+		nvme_controller_close(ctrlr->ctrl);
+	}
+
+failed:
+	free(ctrlr->ctrl);
+	return err;
+}
+
 /**
  * Initialize the uPCIe controller.
  *
@@ -211,7 +270,6 @@ void *
 xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 {
 	struct xnvme_be_upcie_ctrlr *ctrlr;
-	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
 	int err;
 
 	err = _rte_init(&dev->opts);
@@ -235,51 +293,10 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 		goto failed;
 	}
 
-	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
-	if (!ctrlr->ctrl) {
-		XNVME_DEBUG("FAILED: calloc(ctrl)");
-		errno = ENOMEM;
-		goto failed;
-	}
-
-	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
+	err = _initialize_ctrlr(dev, ctrlr);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
-			    err);
+		XNVME_DEBUG("FAILED: _initialize_ctrlr(); err(%d)", err);
 		errno = -err;
-		goto failed;
-	}
-	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
-
-	if (!strcmp(driver_name, "vfio-pci")) {
-		ctrlr->backend = NVME_BACKEND_VFIO;
-		err = nvme_controller_open_vfio(ctrlr->ctrl, &ctrlr->vfio, dev->ident.uri,
-						&g_upcie_rte.heap);
-	} else if (!strcmp(driver_name, "uio_pci_generic")) {
-		ctrlr->backend = NVME_BACKEND_SYSFS;
-		err = nvme_controller_open(ctrlr->ctrl, dev->ident.uri, &g_upcie_rte.heap);
-	} else {
-		XNVME_DEBUG("FAILED: unsupported driver '%s'", driver_name);
-		err = -ENOTSUP;
-	}
-	if (err) {
-		XNVME_DEBUG("FAILED: %s(%s)",
-			    ctrlr->backend == NVME_BACKEND_VFIO ? "nvme_controller_open_vfio"
-								: "nvme_controller_open",
-			    dev->ident.uri);
-		errno = -err;
-		goto failed;
-	}
-
-	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
-	if (err) {
-		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(%d)", err);
-		errno = -err;
-		if (ctrlr->backend == NVME_BACKEND_VFIO) {
-			nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
-		} else {
-			nvme_controller_close(ctrlr->ctrl);
-		}
 		goto failed;
 	}
 
@@ -289,7 +306,6 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 
 failed:
 	if (ctrlr) {
-		free(ctrlr->ctrl);
 		free(ctrlr);
 	}
 

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -214,10 +214,19 @@ _initialize_ctrlr(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr)
 	}
 	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
 
-	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
-	if (!ctrlr->ctrl) {
-		XNVME_DEBUG("FAILED: calloc(ctrl)");
-		return -ENOMEM;
+	if (g_upcie_rte.mproc) {
+		// ctrlr->ctrl stored in shared memory, so no calloc()
+		err = xnvme_be_upcie_mproc_ctrlr_shm_init(dev, ctrlr, driver_name);
+		if (err) {
+			XNVME_DEBUG("FAILED: xnvme_be_upcie_mproc_ctrlr_shm_init(); err(%d)", err);
+			return err;
+		}
+	} else {
+		ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
+		if (!ctrlr->ctrl) {
+			XNVME_DEBUG("FAILED: calloc(ctrl)");
+			return -ENOMEM;
+		}
 	}
 
 	if (!strcmp(driver_name, "vfio-pci")) {
@@ -239,10 +248,20 @@ _initialize_ctrlr(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr)
 		goto failed;
 	}
 
+	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+
 	err = nvme_controller_create_io_qpair(ctrlr->ctrl, &ctrlr->sync, 16);
+
+	xnvme_be_upcie_ctrlr_mutex_unlock(ctrlr);
+
 	if (err) {
 		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(%d)", err);
 		goto failed_close_ctrlr;
+	}
+
+	if (ctrlr->shm) {
+		// Publish the fully-opened controller so secondaries may attach.
+		atomic_store_explicit(&ctrlr->shm->is_initialized, true, memory_order_release);
 	}
 
 	return 0;
@@ -255,7 +274,12 @@ failed_close_ctrlr:
 	}
 
 failed:
-	free(ctrlr->ctrl);
+	if (g_upcie_rte.mproc) {
+		xnvme_be_upcie_mproc_ctrlr_shm_term(ctrlr);
+	} else {
+		free(ctrlr->ctrl);
+	}
+
 	return err;
 }
 
@@ -328,6 +352,11 @@ xnvme_be_upcie_ctrlr_term(void *handle)
 	} else {
 		nvme_controller_close(ctrlr->ctrl);
 	}
+
+	if (g_upcie_rte.mproc) {
+		xnvme_be_upcie_mproc_ctrlr_shm_term(ctrlr);
+	}
+
 	free(ctrlr->ctrl);
 	free(ctrlr);
 

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -8,6 +8,7 @@
 #ifdef XNVME_BE_UPCIE_ENABLED
 #include <limits.h>
 #include <stdatomic.h>
+#include <sys/file.h>
 #include <xnvme_dev.h>
 #include <xnvme_be_upcie.h>
 
@@ -51,6 +52,10 @@ _rte_term(void)
 		return;
 	}
 
+	if (g_upcie_rte.mproc) {
+		xnvme_be_upcie_mproc_rte_term();
+	}
+
 	hostmem_heap_term(&g_upcie_rte.heap);
 
 	g_upcie_rte.is_initialized = 0;
@@ -63,8 +68,9 @@ _rte_term(void)
  * already initialized, then it exits early.
  */
 static int
-_rte_init(size_t heap_size)
+_rte_init(struct xnvme_opts *opts)
 {
+	size_t heap_size = opts->host_heap_size;
 	int err;
 
 	if (g_upcie_rte.is_initialized) {
@@ -79,6 +85,14 @@ _rte_init(size_t heap_size)
 	if (err) {
 		XNVME_DEBUG("FAILED: hostmem_config_init(); err(%d)", err);
 		return err;
+	}
+
+	if (opts->shm_id) {
+		err = xnvme_be_upcie_mproc_rte_init(opts->shm_id);
+		if (err) {
+			XNVME_DEBUG("FAILED: xnvme_be_upcie_mproc_rte_init(); err(%d)", err);
+			return err;
+		}
 	}
 
 	// hostmem_heap_init() requires a size that is a whole number of hugepages
@@ -161,7 +175,7 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
 	int err;
 
-	err = _rte_init(dev->opts.host_heap_size);
+	err = _rte_init(&dev->opts);
 	if (err) {
 		XNVME_DEBUG("FAILED: _rte_init()");
 		errno = -err;

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -7,8 +7,8 @@
 #include <xnvme_be_nosys.h>
 #ifdef XNVME_BE_UPCIE_ENABLED
 #include <limits.h>
-#include <stdatomic.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <xnvme_dev.h>
 #include <xnvme_be_upcie.h>
 
@@ -95,7 +95,6 @@ _rte_init(struct xnvme_opts *opts)
 		}
 	}
 
-	// hostmem_heap_init() requires a size that is a whole number of hugepages
 	heap_size = ((heap_size + g_upcie_rte.config.hugepgsz - 1) / g_upcie_rte.config.hugepgsz) *
 		    g_upcie_rte.config.hugepgsz;
 
@@ -103,6 +102,46 @@ _rte_init(struct xnvme_opts *opts)
 	if (err) {
 		XNVME_DEBUG("FAILED: hostmem_heap_init(); err(%d)", err);
 		return err;
+	}
+
+	if (g_upcie_rte.mproc) {
+		if (g_upcie_rte.mproc->is_primary) {
+			/* Store hugepage path in shm for secondaries to use for import */
+			struct xnvme_be_upcie_mproc_shm *shm = g_upcie_rte.mproc->shm;
+			char *path = g_upcie_rte.heap.memory.path;
+
+			snprintf(shm->hugepage_path, sizeof(shm->hugepage_path), "%s", path);
+
+			shm->hugepage_base = (uint64_t)g_upcie_rte.heap.memory.virt;
+			atomic_store_explicit(&shm->is_initialized, true, memory_order_release);
+		} else {
+			struct xnvme_be_upcie_mproc_shm *shm = g_upcie_rte.mproc->shm;
+
+			// Wait 1 second for primary to copy hugepage info to shared memory
+			for (int i = 0; i < 1000; i++) {
+				if (atomic_load_explicit(&shm->is_initialized,
+							 memory_order_acquire)) {
+					break;
+				}
+				usleep(1000);
+			}
+
+			if (!atomic_load_explicit(&shm->is_initialized, memory_order_acquire)) {
+				XNVME_DEBUG("FAILED: Timed out while waiting for primary process "
+					    "hugepage "
+					    "information");
+				return -ENOENT;
+			}
+
+			err = xnvme_be_upcie_mproc_import_admin_hugepage();
+			if (err) {
+				XNVME_DEBUG(
+					"FAILED: xnvme_be_upcie_mproc_import_admin_hugepage(); "
+					"err(%d)",
+					err);
+				return err;
+			}
+		}
 	}
 
 	g_upcie_rte.is_initialized = 1;

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -201,21 +201,82 @@ xnvme_be_upcie_mproc_import_admin_hugepage()
 	return 0;
 }
 
-void
+/**
+ * Recover the shared admin completion queue after a lock holder has crashed
+ *
+ * If a lock holder crashes, there might be unreaped completions in the CQ, which must be drained
+ * from head/phase in shared memory.
+ * Note: The shared head/phase are only published on unlock, so they are never ahead of the
+ * device; draining from the shared head can therefore only reap real or phantom completions, never
+ * skip one.
+ *
+ * Drained completions are discarded (no live waiter remains) and the shared head/phase are
+ * resynced with the device.
+ */
+static void
+_recover_aq(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
+	struct nvme_qpair *aq = &ctrlr->ctrl->aq;
+	struct nvme_completion *cq = aq->cq;
+	struct nvme_completion *cqe;
+	uint16_t head = shm->ctrl.aq.head;
+	uint8_t phase = shm->ctrl.aq.phase;
+	int drained = 0;
+
+	cqe = &cq[head];
+
+	while ((cqe->cid < 0xFFFF) && ((cqe->status & 0x1) == phase)) {
+		head++;
+		if (head == aq->depth) {
+			head = 0;
+			phase ^= 1;
+		}
+
+		mmio_write32(aq->cqdb, 0, head);
+		drained++;
+
+		cqe = &cq[head];
+	}
+
+	shm->ctrl.aq.head = head;
+	shm->ctrl.aq.phase = phase;
+
+	if (drained) {
+		XNVME_DEBUG("INFO: recovered admin CQ after owner death; drained(%d)", drained);
+	}
+}
+
+int
 xnvme_be_upcie_ctrlr_mutex_lock(struct xnvme_be_upcie_ctrlr *ctrlr)
 {
 	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
+	int err;
 
 	if (!shm) {
-		return;
+		return 0;
 	}
 
-	pthread_mutex_lock(&shm->aq_mutex);
+	err = pthread_mutex_lock(&shm->aq_mutex);
+	if (err == EOWNERDEAD) {
+		// Previous owner died inside the critical section; drain any
+		// completions it left behind and resync before marking consistent.
+		_recover_aq(ctrlr);
+		pthread_mutex_consistent(&shm->aq_mutex);
+	} else if (err == ENOTRECOVERABLE) {
+		XNVME_DEBUG("FAILED: aq_mutex unrecoverable (ENOTRECOVERABLE)");
+		return err;
+	} else if (err) {
+		XNVME_DEBUG("FAILED: pthread_mutex_lock(aq_mutex); err(%d)", err);
+		return err;
+	}
 
 	ctrlr->ctrl->aq.tail = shm->ctrl.aq.tail;
 	ctrlr->ctrl->aq.tail_last_written = UINT16_MAX;
 	ctrlr->ctrl->aq.head = shm->ctrl.aq.head;
 	ctrlr->ctrl->aq.phase = shm->ctrl.aq.phase;
+
+	return 0;
 }
 
 void
@@ -259,7 +320,11 @@ xnvme_be_upcie_mproc_free_all_queues(struct xnvme_be_upcie_ctrlr *ctrlr)
 		return;
 	}
 
-	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	err = xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		return;
+	}
 
 	for (uint16_t qid = 1; qid < NVME_QID_BITMAP_WORDS * BITS_PER_WORD; qid++) {
 		if (nvme_qid_is_allocated(shm->ctrl.qids, qid)) {
@@ -629,7 +694,12 @@ xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrl
 	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
 	int err;
 
-	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	err = xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		return err;
+	}
+
 	memcpy(ctrlr->ctrl->qids, shm->ctrl.qids, sizeof(ctrlr->ctrl->qids));
 
 	if (create) {

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <libxnvme.h>
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_UPCIE_ENABLED
+#include <limits.h>
+#include <stdatomic.h>
+#include <sys/file.h>
+#include <xnvme_dev.h>
+#include <xnvme_be_upcie.h>
+
+void
+xnvme_be_upcie_mproc_rte_term()
+{
+	struct xnvme_be_upcie_mproc *mproc = g_upcie_rte.mproc;
+
+	if (!mproc) {
+		return;
+	}
+
+	if (mproc->is_primary) {
+		if (mproc->lock_fd >= 0) {
+			flock(mproc->lock_fd, LOCK_UN);
+			close(mproc->lock_fd);
+		}
+		unlink(mproc->lock_name);
+	}
+
+	free(mproc);
+}
+
+int
+xnvme_be_upcie_mproc_rte_init(int shm_id)
+{
+	struct xnvme_be_upcie_mproc *mproc = NULL;
+	int err;
+
+	mproc = calloc(1, sizeof(*mproc));
+	if (!mproc) {
+		err = -ENOMEM;
+		XNVME_DEBUG("FAILED: calloc(xnvme_be_upcie_mproc); err(%d)", err);
+		return err;
+	}
+
+	mproc->is_primary = true;
+
+	snprintf(mproc->lock_name, sizeof(mproc->lock_name), "/tmp/xnvme-upcie-flock-%d", shm_id);
+	mproc->lock_fd = open(mproc->lock_name, O_CREAT | O_RDWR, 0600);
+	if (mproc->lock_fd < 0) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: open() with lock_name(%s); err(%d)", mproc->lock_name, err);
+		goto failed;
+	}
+
+	err = flock(mproc->lock_fd, LOCK_EX | LOCK_NB);
+	if (err) {
+		if (errno == EWOULDBLOCK) {
+			XNVME_DEBUG("INFO: Lock file already claimed, setting role to secondary");
+			close(mproc->lock_fd);
+			mproc->lock_fd = -1;
+			mproc->is_primary = false;
+			err = 0;
+			errno = 0;
+		} else {
+			err = -errno;
+			XNVME_DEBUG("FAILED: flock; err(%d)", err);
+			goto failed;
+		}
+	}
+
+	g_upcie_rte.mproc = mproc;
+
+	return 0;
+
+failed:
+	if (mproc && mproc->lock_fd >= 0) {
+		flock(mproc->lock_fd, LOCK_UN);
+		close(mproc->lock_fd);
+	}
+
+	free(mproc);
+	return err;
+}
+
+#endif

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -7,8 +7,8 @@
 #include <xnvme_be_nosys.h>
 #ifdef XNVME_BE_UPCIE_ENABLED
 #include <limits.h>
-#include <stdatomic.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <xnvme_dev.h>
 #include <xnvme_be_upcie.h>
 
@@ -22,6 +22,30 @@ xnvme_be_upcie_mproc_rte_term()
 	}
 
 	if (mproc->is_primary) {
+		int attached = atomic_load(&mproc->shm->refcount);
+		if (attached > 1) {
+			XNVME_DEBUG("WARNING: closing primary with %d secondary process(es) still "
+				    "attached",
+				    attached - 1);
+		}
+	}
+
+	atomic_fetch_sub(&mproc->shm->refcount, 1);
+
+	munmap(mproc->shm, sizeof(*mproc->shm));
+
+	if (mproc->primary_hugepage) {
+		munmap(mproc->primary_hugepage->virt, mproc->primary_hugepage->size);
+		close(mproc->primary_hugepage->fd);
+		free(mproc->primary_hugepage);
+	}
+
+	if (mproc->is_primary) {
+		if (mproc->shm_fd >= 0) {
+			close(mproc->shm_fd);
+			shm_unlink(mproc->shm_name);
+		}
+
 		if (mproc->lock_fd >= 0) {
 			flock(mproc->lock_fd, LOCK_UN);
 			close(mproc->lock_fd);
@@ -36,7 +60,8 @@ int
 xnvme_be_upcie_mproc_rte_init(int shm_id)
 {
 	struct xnvme_be_upcie_mproc *mproc = NULL;
-	int err;
+	mode_t shm_mode;
+	int shm_fd = -1, oflag, shm_size, err;
 
 	mproc = calloc(1, sizeof(*mproc));
 	if (!mproc) {
@@ -46,6 +71,8 @@ xnvme_be_upcie_mproc_rte_init(int shm_id)
 	}
 
 	mproc->is_primary = true;
+
+	/* Use flock to determine primary / secondary role */
 
 	snprintf(mproc->lock_name, sizeof(mproc->lock_name), "/tmp/xnvme-upcie-flock-%d", shm_id);
 	mproc->lock_fd = open(mproc->lock_name, O_CREAT | O_RDWR, 0600);
@@ -71,9 +98,68 @@ xnvme_be_upcie_mproc_rte_init(int shm_id)
 		}
 	}
 
+	/* Map shared memory for hugepage information */
+
+	snprintf(mproc->shm_name, sizeof(mproc->shm_name), "/xnvme-upcie-shm-%d", shm_id);
+	mproc->shm_fd = -1;
+
+	oflag = mproc->is_primary ? O_CREAT | O_EXCL | O_RDWR : O_RDWR;
+	shm_mode = mproc->is_primary ? 0600 : 0;
+	shm_size = sizeof(struct xnvme_be_upcie_mproc_shm);
+
+	if (mproc->is_primary) {
+		shm_unlink(mproc->shm_name);
+	}
+
+	// Wait at most ~1 second to open shared memory segment. We do not retry in primary
+	// processes.
+	for (int i = 0; i < 1000; i++) {
+		shm_fd = shm_open(mproc->shm_name, oflag, shm_mode);
+		if (shm_fd >= 0 || mproc->is_primary) {
+			break;
+		}
+		usleep(1000);
+	}
+
+	if (shm_fd < 0) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: shm_open(%s): %d", mproc->shm_name, err);
+		goto failed;
+	}
+
+	if (mproc->is_primary) {
+		err = ftruncate(shm_fd, shm_size);
+		if (err) {
+			err = -errno;
+			XNVME_DEBUG("FAILED: ftruncate(); err(%d)", err);
+			goto failed_unlink;
+		}
+	}
+
+	mproc->shm = mmap(NULL, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+	if (mproc->shm == MAP_FAILED) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: mmap() shm; err(%d)", err);
+		goto failed_unlink;
+	}
+
+	if (mproc->is_primary) {
+		memset(mproc->shm, 0, shm_size);
+		mproc->shm_fd = shm_fd;
+	} else {
+		close(shm_fd);
+	}
+
+	atomic_fetch_add(&mproc->shm->refcount, 1);
+
 	g_upcie_rte.mproc = mproc;
 
 	return 0;
+
+failed_unlink:
+	if (mproc->is_primary) {
+		shm_unlink(mproc->shm_name);
+	}
 
 failed:
 	if (mproc && mproc->lock_fd >= 0) {
@@ -81,8 +167,38 @@ failed:
 		close(mproc->lock_fd);
 	}
 
+	if (shm_fd >= 0) {
+		close(shm_fd);
+	}
+
 	free(mproc);
 	return err;
+}
+
+/**
+ * Import the primary's hugepages for accessing the admin queue in secondary processes.
+ */
+int
+xnvme_be_upcie_mproc_import_admin_hugepage()
+{
+	int err;
+
+	g_upcie_rte.mproc->primary_hugepage =
+		calloc(1, sizeof(*g_upcie_rte.mproc->primary_hugepage));
+	if (!g_upcie_rte.mproc->primary_hugepage) {
+		XNVME_DEBUG("FAILED: calloc(primary_hugepage)");
+		return -ENOMEM;
+	}
+
+	err = hostmem_hugepage_import(g_upcie_rte.mproc->shm->hugepage_path,
+				      g_upcie_rte.mproc->primary_hugepage, &g_upcie_rte.config);
+	if (err) {
+		XNVME_DEBUG("FAILED: hostmem_hugepage_import(); err(%d)", err);
+		free(g_upcie_rte.mproc->primary_hugepage);
+		return err;
+	}
+
+	return 0;
 }
 
 #endif

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -248,6 +248,47 @@ xnvme_be_upcie_shm_bdf_name(const char *bdf, char *buf, size_t buflen)
 }
 
 void
+xnvme_be_upcie_mproc_free_all_queues(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
+	int err;
+
+	if (!g_upcie_rte.mproc || !g_upcie_rte.mproc->is_primary) {
+		XNVME_DEBUG("INFO: xnvme_be_upcie_mproc_free_all_queues() called in non-primary "
+			    "process; skipping");
+		return;
+	}
+
+	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+
+	for (uint16_t qid = 1; qid < NVME_QID_BITMAP_WORDS * BITS_PER_WORD; qid++) {
+		if (nvme_qid_is_allocated(shm->ctrl.qids, qid)) {
+			struct nvme_command cmd = {0};
+			struct nvme_completion cpl = {0};
+			int err;
+
+			cmd.cdw10 = qid;
+
+			cmd.opc = 0x00; ///< Delete I/O Submission Queue
+			err = nvme_qpair_submit_sync(&ctrlr->ctrl->aq, &cmd,
+						     ctrlr->ctrl->timeout_ms, &cpl);
+			if (err) {
+				XNVME_DEBUG("FAILED: nvme_qpair_submit_sync(); err(%d)", err);
+			}
+
+			cmd.opc = 0x04; ///< Delete I/O Completion Queue
+			err = nvme_qpair_submit_sync(&ctrlr->ctrl->aq, &cmd,
+						     ctrlr->ctrl->timeout_ms, &cpl);
+			if (err) {
+				XNVME_DEBUG("FAILED: nvme_qpair_submit_sync(); err(%d)", err);
+			}
+		}
+	}
+
+	xnvme_be_upcie_ctrlr_mutex_unlock(ctrlr);
+}
+
+void
 xnvme_be_upcie_mproc_ctrlr_shm_term(struct xnvme_be_upcie_ctrlr *ctrlr)
 {
 	if (g_upcie_rte.mproc->is_primary) {

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -374,4 +374,233 @@ failed:
 	return err;
 }
 
+/**
+ * Attach to an existing controller in shared memory
+ *
+ * Waits (up to ~1s) for the primary to create, size and finish initializing the
+ * shared segment, so starting the primary and secondary concurrently is safe;
+ * if the primary does not become ready within the timeout, attach fails.
+ */
+int
+xnvme_be_upcie_mproc_ctrlr_shm_attach(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm = NULL;
+	char shm_name[64];
+	size_t shm_size = sizeof(*shm);
+	int shm_fd, err;
+
+	ctrlr->shm_fd = -1; // File descripter should not be saved in secondaries
+
+	xnvme_be_upcie_shm_bdf_name(dev->ident.uri, shm_name, sizeof(shm_name));
+
+	// Wait for the primary to create and size the segment. shm_open() can
+	// succeed before the primary has ftruncate()'d it, so mapping and touching
+	// it then would SIGBUS; only proceed once it is at least shm_size bytes.
+	for (int i = 0; i < 1000; i++) {
+		struct stat st;
+
+		shm_fd = shm_open(shm_name, O_RDWR, 0);
+		if (shm_fd >= 0) {
+			err = fstat(shm_fd, &st);
+			if (err) {
+				err = -errno;
+				XNVME_DEBUG("FAILED: fstat(shm); err(%d)", err);
+				goto failed;
+			}
+			if ((size_t)st.st_size >= shm_size) {
+				break;
+			}
+			close(shm_fd);
+			shm_fd = -1;
+		} else if (errno != ENOENT) {
+			err = -errno;
+			XNVME_DEBUG("FAILED: shm_open(%s): err(%d)", shm_name, err);
+			goto failed;
+		}
+
+		usleep(1000);
+	}
+
+	if (shm_fd < 0) {
+		XNVME_DEBUG("FAILED: timed out waiting for primary to create shm(%s)", shm_name);
+		err = -ENOENT;
+		goto failed;
+	}
+
+	shm = mmap(NULL, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+	if (shm == MAP_FAILED) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: mmap() shm; err(%d)", err);
+		goto failed;
+	}
+
+	close(shm_fd);
+	shm_fd = -1;
+
+	ctrlr->shm = shm;
+	snprintf(ctrlr->shm_name, sizeof(ctrlr->shm_name), "%s", shm_name);
+
+	// Wait for the primary to finish opening the controller before reading any
+	// shared fields; they are undefined until is_initialized is published.
+	for (int i = 0; i < 1000; i++) {
+		if (atomic_load_explicit(&shm->is_initialized, memory_order_acquire)) {
+			break;
+		}
+		usleep(1000);
+	}
+
+	if (!atomic_load_explicit(&shm->is_initialized, memory_order_acquire)) {
+		XNVME_DEBUG("FAILED: timed out waiting for primary controller init");
+		err = -ENOENT;
+		goto failed;
+	}
+
+	if (!strcmp(shm->driver_name, "vfio-pci")) {
+		ctrlr->backend = NVME_BACKEND_VFIO;
+	} else if (!strcmp(shm->driver_name, "uio_pci_generic")) {
+		ctrlr->backend = NVME_BACKEND_SYSFS;
+	} else {
+		XNVME_DEBUG("FAILED: unsupported driver '%s'", shm->driver_name);
+		err = -ENOTSUP;
+		goto failed;
+	}
+
+	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
+	if (!ctrlr->ctrl) {
+		XNVME_DEBUG("FAILED: calloc(ctrl)");
+		err = -ENOMEM;
+		goto failed;
+	}
+
+	ctrlr->ctrl->heap = &g_upcie_rte.heap;
+	ctrlr->ctrl->aq.heap = &g_upcie_rte.heap;
+	ctrlr->ctrl->timeout_ms = shm->ctrl.timeout_ms;
+
+	/* Retrieve BAR0 register mapping (not in shared memory) */
+	{
+		uint8_t *bar0;
+		uint64_t cap;
+		int dstrd;
+
+		err = pci_func_open(dev->ident.uri, &ctrlr->ctrl->func);
+		if (err) {
+			XNVME_DEBUG("FAILED: pci_func_open(%s): %d", dev->ident.uri, err);
+			goto failed;
+		}
+
+		err = pci_bar_map(dev->ident.uri, 0, &ctrlr->ctrl->func.bars[0]);
+		if (err) {
+			XNVME_DEBUG("FAILED: pci_bar_map(%s, BAR0): %d", dev->ident.uri, err);
+			goto failed_close_function;
+		}
+
+		bar0 = ctrlr->ctrl->func.bars[0].region;
+		cap = nvme_mmio_cap_read(bar0);
+		dstrd = nvme_reg_cap_get_dstrd(cap);
+
+		ctrlr->ctrl->aq.sqdb = bar0 + 0x1000;
+		ctrlr->ctrl->aq.cqdb = bar0 + 0x1000 + (1 << (2 + dstrd));
+	}
+
+	/* Import admin queue from shared memory */
+	{
+		uint64_t offset = (uint64_t)g_upcie_rte.mproc->primary_hugepage->virt -
+				  g_upcie_rte.mproc->shm->hugepage_base;
+
+		ctrlr->ctrl->aq.sq = (char *)shm->ctrl.aq.sq + offset;
+		ctrlr->ctrl->aq.cq = (char *)shm->ctrl.aq.cq + offset;
+		ctrlr->ctrl->aq.depth = shm->ctrl.aq.depth;
+		ctrlr->ctrl->aq.phase = shm->ctrl.aq.phase;
+		ctrlr->ctrl->aq.qid = shm->ctrl.aq.qid;
+	}
+
+	/* Allocate local request pool */
+	{
+		ctrlr->ctrl->aq.rpool = calloc(1, sizeof(*ctrlr->ctrl->aq.rpool));
+		if (!ctrlr->ctrl->aq.rpool) {
+			err = -ENOMEM;
+			XNVME_DEBUG("FAILED: calloc(aq.rpool)");
+			goto failed_close_function;
+		}
+		nvme_request_pool_init(ctrlr->ctrl->aq.rpool);
+
+		err = nvme_request_pool_init_prps(ctrlr->ctrl->aq.rpool, &g_upcie_rte.heap);
+		if (err) {
+			err = -errno;
+			XNVME_DEBUG("FAILED: nvme_request_pool_init_prps(aq.rpool); err(%d)", err);
+			goto failed_close_function;
+		}
+	}
+
+	err = xnvme_be_upcie_mproc_create_or_delete_io_qpair(ctrlr, &ctrlr->sync, 16, true);
+	if (err) {
+		XNVME_DEBUG("FAILED: create with "
+			    "xnvme_be_upcie_mproc_create_or_delete_io_qpair(); err(%d)",
+			    err);
+		nvme_request_pool_term_prps(ctrlr->ctrl->aq.rpool, &g_upcie_rte.heap);
+		errno = -err;
+		goto failed_close_function;
+	}
+
+	atomic_fetch_add(&shm->refcount, 1);
+
+	return 0;
+
+failed_close_function:
+	pci_func_close(&ctrlr->ctrl->func);
+
+failed:
+	if (ctrlr->ctrl) {
+		free(ctrlr->ctrl->aq.rpool);
+	}
+
+	free(ctrlr->ctrl);
+	ctrlr->ctrl = NULL;
+
+	if (shm_fd >= 0) {
+		close(shm_fd);
+	}
+
+	if (shm && shm != MAP_FAILED) {
+		munmap(shm, sizeof(*shm));
+	}
+	ctrlr->shm = NULL;
+
+	return err;
+}
+
+/**
+ * Create or delete a queue pair in multi process mode
+ *
+ * Helper function for locking the shared controller mutex, updating the
+ * allocation status of IO queues and creating/deleting a queue pair
+ *
+ * @param ctrlr The backend controller
+ * @param qpair NVMe queue pair to create / delete
+ * @param depth queue depth of the queues, not used if (!create)
+ * @param create if true, creates the qpair, else, deletes the qpair
+ */
+int
+xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrlr,
+					       struct nvme_qpair *qpair, uint16_t depth,
+					       bool create)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
+	int err;
+
+	xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	memcpy(ctrlr->ctrl->qids, shm->ctrl.qids, sizeof(ctrlr->ctrl->qids));
+
+	if (create) {
+		err = nvme_controller_create_io_qpair(ctrlr->ctrl, qpair, depth);
+	} else {
+		err = nvme_controller_delete_io_qpair(ctrlr->ctrl, qpair);
+	}
+
+	memcpy(shm->ctrl.qids, ctrlr->ctrl->qids, sizeof(shm->ctrl.qids));
+	xnvme_be_upcie_ctrlr_mutex_unlock(ctrlr);
+
+	return err;
+}
+
 #endif

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -201,4 +201,177 @@ xnvme_be_upcie_mproc_import_admin_hugepage()
 	return 0;
 }
 
+void
+xnvme_be_upcie_ctrlr_mutex_lock(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
+
+	if (!shm) {
+		return;
+	}
+
+	pthread_mutex_lock(&shm->aq_mutex);
+
+	ctrlr->ctrl->aq.tail = shm->ctrl.aq.tail;
+	ctrlr->ctrl->aq.tail_last_written = UINT16_MAX;
+	ctrlr->ctrl->aq.head = shm->ctrl.aq.head;
+	ctrlr->ctrl->aq.phase = shm->ctrl.aq.phase;
+}
+
+void
+xnvme_be_upcie_ctrlr_mutex_unlock(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
+
+	if (!shm) {
+		return;
+	}
+
+	shm->ctrl.aq.tail = ctrlr->ctrl->aq.tail;
+	shm->ctrl.aq.head = ctrlr->ctrl->aq.head;
+	shm->ctrl.aq.phase = ctrlr->ctrl->aq.phase;
+
+	pthread_mutex_unlock(&shm->aq_mutex);
+}
+
+static void
+xnvme_be_upcie_shm_bdf_name(const char *bdf, char *buf, size_t buflen)
+{
+	int i;
+
+	snprintf(buf, buflen, "/xnvme-upcie-%s", bdf);
+	for (i = 1; buf[i]; i++) {
+		if (buf[i] == ':' || buf[i] == '.' || buf[i] == '/') {
+			buf[i] = '-';
+		}
+	}
+}
+
+void
+xnvme_be_upcie_mproc_ctrlr_shm_term(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	if (g_upcie_rte.mproc->is_primary) {
+		int attached = atomic_load(&ctrlr->shm->refcount);
+		if (attached > 1) {
+			XNVME_DEBUG("WARNING: terminating controller with %d secondary "
+				    "process(es) still "
+				    "attached",
+				    attached - 1);
+		}
+	}
+
+	atomic_fetch_sub(&ctrlr->shm->refcount, 1);
+
+	if (g_upcie_rte.mproc->is_primary) {
+		pthread_mutex_destroy(&ctrlr->shm->aq_mutex);
+	}
+
+	munmap(ctrlr->shm, sizeof(*ctrlr->shm));
+
+	if (g_upcie_rte.mproc->is_primary) {
+		close(ctrlr->shm_fd);
+		shm_unlink(ctrlr->shm_name);
+		ctrlr->ctrl = NULL; // was a pointer to shared memory, so remove this
+
+		flock(ctrlr->lock_fd, LOCK_UN);
+		close(ctrlr->lock_fd);
+		unlink(ctrlr->lock_name);
+	}
+}
+
+int
+xnvme_be_upcie_mproc_ctrlr_shm_init(struct xnvme_dev *dev, struct xnvme_be_upcie_ctrlr *ctrlr,
+				    char *driver_name)
+{
+	struct xnvme_be_upcie_ctrlr_shm *shm;
+	char shm_name[64];
+	size_t shm_size = sizeof(*shm);
+	int shm_fd, lock_fd, err;
+
+	xnvme_be_upcie_shm_bdf_name(dev->ident.uri, shm_name, sizeof(shm_name));
+
+	/* Use flock to determine whether another primary process has claimed device */
+	snprintf(ctrlr->lock_name, sizeof(ctrlr->lock_name), "/tmp%s-lock", dev->ident.uri);
+	ctrlr->lock_fd = -1;
+
+	lock_fd = open(ctrlr->lock_name, O_CREAT | O_RDWR, 0600);
+	if (lock_fd < 0) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: open() with lock_name(%s); err(%d)", ctrlr->lock_name, err);
+		goto failed;
+	}
+
+	err = flock(lock_fd, LOCK_EX | LOCK_NB);
+	if (err) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: flock; err(%d)", err);
+		goto failed;
+	}
+
+	ctrlr->lock_fd = lock_fd;
+	shm_unlink(shm_name);
+
+	shm_fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	if (shm_fd < 0) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: shm_open(%s): err(%d)", shm_name, err);
+		goto failed;
+	}
+
+	err = ftruncate(shm_fd, (off_t)shm_size);
+	if (err) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: ftruncate(); err(%d)", err);
+		goto failed;
+	}
+
+	shm = mmap(NULL, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+	if (shm == MAP_FAILED) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: mmap() shm; err(%d)", err);
+		goto failed;
+	}
+
+	memset(shm, 0, shm_size);
+	atomic_store(&shm->refcount, 1);
+	strncpy(shm->driver_name, driver_name, sizeof(shm->driver_name));
+
+	{
+		pthread_mutexattr_t attr;
+
+		pthread_mutexattr_init(&attr);
+		pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+		pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST);
+		pthread_mutex_init(&shm->aq_mutex, &attr);
+		pthread_mutexattr_destroy(&attr);
+	}
+
+	ctrlr->ctrl = &shm->ctrl;
+	ctrlr->shm = shm;
+	ctrlr->shm_fd = shm_fd;
+	snprintf(ctrlr->shm_name, sizeof(ctrlr->shm_name), "%s", shm_name);
+
+	return 0;
+
+failed:
+	if (ctrlr->lock_fd >= 0) {
+		flock(ctrlr->lock_fd, LOCK_UN);
+	}
+
+	if (lock_fd >= 0) {
+		close(lock_fd);
+		ctrlr->lock_fd = -1;
+	}
+
+	if (shm_fd >= 0) {
+		close(shm_fd);
+		shm_unlink(shm_name);
+	}
+
+	ctrlr->shm_fd = -1;
+	ctrlr->shm = NULL;
+
+	return err;
+}
+
 #endif

--- a/lib/xnvme_be_spdk.c
+++ b/lib/xnvme_be_spdk.c
@@ -17,7 +17,7 @@ const struct xnvme_be_config g_xnvme_be_spdk = {
 			.name = "spdk",
 			.descr = "SPDK userspace NVMe driver",
 			.caps = XNVME_BE_CAP_NVME_PCIE | XNVME_BE_CAP_NVME_TCP |
-				XNVME_BE_CAP_NVME_RDMA,
+				XNVME_BE_CAP_NVME_RDMA | XNVME_BE_CAP_MPROC,
 		},
 };
 

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -617,6 +617,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "For be={spdk,upcie}, multi-process shared-memory-id",
 	},
 	{
+		.opt = XNVME_CLI_OPT_HOST_HEAP_SIZE,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "host_heap_size",
+		.descr = "For be=upcie, host DMA heap size in bytes",
+	},
+	{
 		.opt = XNVME_CLI_OPT_MAIN_CORE,
 		.vtype = XNVME_CLI_OPT_VTYPE_HEX,
 		.name = "main_core",
@@ -1612,6 +1618,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 	case XNVME_CLI_OPT_SHM_ID:
 		args->shm_id = num;
 		break;
+	case XNVME_CLI_OPT_HOST_HEAP_SIZE:
+		args->host_heap_size = num;
+		break;
 	case XNVME_CLI_OPT_MAIN_CORE:
 		args->main_core = arg ? num : 0;
 		break;
@@ -2237,6 +2246,8 @@ xnvme_cli_to_opts(const struct xnvme_cli *cli, struct xnvme_opts *opts)
 	opts->use_cmb_sqs =
 		cli->given[XNVME_CLI_OPT_USE_CMB_SQS] ? cli->args.use_cmb_sqs : opts->use_cmb_sqs;
 	opts->shm_id = cli->given[XNVME_CLI_OPT_SHM_ID] ? cli->args.shm_id : opts->shm_id;
+	opts->host_heap_size = cli->given[XNVME_CLI_OPT_HOST_HEAP_SIZE] ? cli->args.host_heap_size
+									: opts->host_heap_size;
 	opts->main_core =
 		cli->given[XNVME_CLI_OPT_MAIN_CORE] ? cli->args.main_core : opts->main_core;
 	opts->core_mask =

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -612,9 +612,9 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 	},
 	{
 		.opt = XNVME_CLI_OPT_SHM_ID,
-		.vtype = XNVME_CLI_OPT_VTYPE_HEX,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
 		.name = "shm_id",
-		.descr = "For be=spdk, multi-process shared-memory-id",
+		.descr = "For be={spdk,upcie}, multi-process shared-memory-id",
 	},
 	{
 		.opt = XNVME_CLI_OPT_MAIN_CORE,

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -102,6 +102,11 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		goto ctrlr_ready;
 	}
 
+	if (dev->opts.shm_id && !(cfg->attr.caps & XNVME_BE_CAP_MPROC)) {
+		XNVME_DEBUG("FAILED: backend '%s' does not support multi-process", cfg->attr.name);
+		return -ENOTSUP;
+	}
+
 	ctrlr = be->dev.ctrlr_init(dev);
 	if (!ctrlr) {
 		XNVME_DEBUG("FAILED: ctrlr_init for uri '%s'", dev->ident.uri);

--- a/tools/homi.c
+++ b/tools/homi.c
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#include <libxnvme.h>
+
+// The backend default (1GiB) is sized for a process doing I/O. HOMI only needs the
+// admin queue and the sync qpair that opening a device creates, so claiming the
+// default is overkill. Each of those two queue pairs carries a request pool of
+// NVME_REQUEST_POOL_LEN PRP pages, which is 4MiB apiece, so budget double the 8MiB
+// per device that costs.
+#define HOMI_HEAP_SIZE_PER_DEV (16ULL * 1024 * 1024)
+
+#ifndef XNVME_PLATFORM_WINDOWS_ENABLED
+
+static volatile sig_atomic_t stop = 0;
+
+static void
+handle_signal(int sig __attribute__((unused)))
+{
+	stop = 1;
+}
+
+static void
+_xnvme_dev_close_all(struct xnvme_dev **devs, int count)
+{
+	for (int i = 0; i < count; i++) {
+		xnvme_dev_close(devs[i]);
+	}
+	free(devs);
+}
+
+static int
+_xnvme_dev_open_all(const char **uris, int count, struct xnvme_opts *opts, struct xnvme_dev ***out)
+{
+	struct xnvme_dev **devs;
+	int opened = 0, err;
+
+	devs = calloc(count, sizeof(*devs));
+	if (!devs) {
+		err = -errno;
+		xnvme_cli_perr("Failed: calloc()", err);
+		return err;
+	}
+
+	for (int i = 0; i < count; i++) {
+		devs[i] = xnvme_dev_open(uris[i], opts);
+		if (!devs[i]) {
+			err = -errno;
+			xnvme_cli_perr("Failed: xnvme_dev_open()", err);
+			XNVME_DEBUG("Could not open uri(%s) at index(%d): err(%d)", uris[i], i,
+				    err);
+			goto failed;
+		}
+		opened++;
+	}
+
+	*out = devs;
+
+	return 0;
+
+failed:
+	_xnvme_dev_close_all(devs, opened);
+	return err;
+}
+
+static void
+_wait_for_stop_signal(void)
+{
+	struct sigaction sa = {0};
+	sigset_t mask, orig;
+
+	sa.sa_handler = handle_signal;
+	sa.sa_flags = 0;
+
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGTERM, &sa, NULL);
+	sigaction(SIGINT, &sa, NULL);
+
+	// Block the stop-signals before testing 'stop', and let sigsuspend() unblock them only
+	// while parked, such that a signal arriving between the test and the wait cannot be lost
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGTERM);
+	sigaddset(&mask, SIGINT);
+	sigprocmask(SIG_BLOCK, &mask, &orig);
+
+	while (!stop) {
+		sigsuspend(&orig);
+	}
+
+	sigprocmask(SIG_SETMASK, &orig, NULL);
+}
+
+static int
+sub_start(struct xnvme_cli *cli)
+{
+	struct xnvme_dev **devs;
+	struct xnvme_opts opts = xnvme_opts_default();
+	const char **dev_uris;
+	int ndevs, err;
+
+	ndevs = cli->args.posn_count;
+	if (ndevs <= 0) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: at least one device URI is required", err);
+		return err;
+	}
+	dev_uris = cli->args.posn;
+
+	opts.shm_id = cli->args.shm_id;
+	opts.be = cli->args.be;
+
+	// The heap is per-process rather than per-device, so it has to cover every device
+	// held. Claiming the backend default would leave nothing in the hugepage pool for
+	// the secondaries HOMI exists to serve.
+	opts.host_heap_size = cli->args.host_heap_size ? cli->args.host_heap_size
+						       : HOMI_HEAP_SIZE_PER_DEV * ndevs;
+
+	err = _xnvme_dev_open_all(dev_uris, ndevs, &opts, &devs);
+	if (err) {
+		xnvme_cli_perr("Failed opening all devices", err);
+		return err;
+	}
+
+	xnvme_cli_pinf("HOMI started successfully, use Ctrl+C to stop");
+	_wait_for_stop_signal();
+
+	_xnvme_dev_close_all(devs, ndevs);
+
+	return 0;
+}
+
+#else
+
+static int
+sub_start(struct xnvme_cli *XNVME_UNUSED(cli))
+{
+	int err = -ENOTSUP;
+
+	xnvme_cli_perr("No multi-process capable backend is available on Windows", err);
+
+	return err;
+}
+
+#endif
+
+static struct xnvme_cli_sub g_subs[] = {
+	{
+		"start",
+		"Open the given devices and hold them open",
+		"Open the given devices and hold them open",
+		sub_start,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSN},
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_HOST_HEAP_SIZE, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+		},
+	},
+};
+
+static struct xnvme_cli g_cli = {
+	.title = "homi - Host-Orchestrated Multi-process I/O",
+	.descr_short = "Hold NVMe devices open for multi-process sharing",
+	.descr_long = "Hold NVMe devices open for multi-process sharing. Secondary "
+		      "processes attach to the same controllers by passing the same --shm_id.",
+	.subs = g_subs,
+	.nsubs = sizeof g_subs / sizeof(*g_subs),
+};
+
+int
+main(int argc, char **argv)
+{
+	return xnvme_cli_run(&g_cli, argc, argv, XNVME_CLI_INIT_NONE);
+}

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -4,6 +4,7 @@
 
 tools_source = [
   'lblk.c',
+  'homi.c',
   'xdd.c',
   'xnvme.c',
   'xnvme_file.c',
@@ -11,6 +12,7 @@ tools_source = [
   'kvs.c',
 ]
 tools = {
+  'homi.c': [],
   'kvs.c': [],
   'lblk.c': [
     ['enum', ['enum']],

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -1332,6 +1332,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_POLL_IO, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_POLL_SQ, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT},
 		},
 	},
 	{
@@ -1353,6 +1354,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_POLL_IO, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_POLL_SQ, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT},
 		},
 	},
 	{
@@ -1374,6 +1376,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT},
 		},
 	},
 	{
@@ -1393,6 +1396,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT},
 		},
 	},
 };


### PR DESCRIPTION
This is a replacement for PR #686. I have reworked my initial implementation such that the admin queue is now shared and guarded with a mutex. Also, "multi-process mode" is no longer a generic thing for xNVMe but a specific functionality within the uPCIe (and SPDK) backend.

Let me explain how it works, and sorry for this being so long:

Overall we use both flocks and shared memory regions on two different levels: for the runtime environment, which lives as long as the process (or as long as *some* devices are open), and for each device, which lives as long as the specific device is open.

To enable multi-process mode, a user must provice a `shm_id > 0` via `xnvme_opts.shm_id` or the `--shm_id` cli arguments. Then, a process will attempt to claim an flock derived from the given id: if successful, it becomes the **primary** and owner of the NVMe controllers and shared memory, and if not successful (`EWOULDBLOCK`), it becomes a **secondary**, which just attaches to shared memory. An flock is used, as the kernel manages these and releases it if the primary crashes. There is not any recovery for a crashed primary, but this ensures that a new primary can be started and clear the shared memory from any previously crashed primaries.

The primary process is responsible for initializing the uPCIe heap and hugepages, and this process then opens a shared memory region to publish the hugepage path and base pointer, which will later be used to map the admin queues in secondary processes. A secondary (that failed to claim the flock), simply maps this shared memory region and imports the hugepage from the primary. I've added a ~1 sek timeout here, since if primary and secondary are started at the same time, there might be a race on this shared memory region, so this just lets the primary finish before the secondary decides to fail :)

When the runtime environment is initialised, devices can be opened (rte_init is called at the first device startup, so the following will happen at least once, maybe more times). When an NVMe controller needs to be initialised, another flock is used to claim ownership of this if the process is the primary. This is to prevent two different primary processes (shm_id=1 and shm_id=2) from opening the same device. A shared memory region is then opened for this device, where a mutex for the admin queue is stored, along with the nvme_controller and some other necessary informations. 
Secondary processes map this shared memory region but stores a local version of the nvme_controller. Here, it updates the pointer to the admin queue using the hugepage base read from the rte shared memory. A device cannot be opened by a secondary before the primary, as it depends on the shared memory region from the primary - again a ~1 sek timeout has been added to prevent a speedy secondary from failing early because a primary was not 100% ready.
The admin queue is, as mentioned, guarded by a mutex, and a helper function for this ensures that the local and shared version of the admin queue's head/tail/phase are synchronized.

When terminating a controller, a secondary merely decreases a shared refcount and removes its local setup, but does not teardown any shared memory or the admin queue. The primary will warn when terminating a controller if the refcount is more than 1 (the last one being itself), but will not block - this is to ensure that a crashed secondary does not prevent a primary to exit, but this of course means that the state of any running secondaries will be corrupted. This is documented in the docs.
The exact same heuristic is used for the runtime environment: a secondary munmaps shared memory without unlinking shared memory and decreases the refcount; a primary will teardown the hugepages and unlink shared memory with a warning if refcount > 1.