### PR TITLE
feat(be): add be_dmamem for CPU-init hostmem across vfio-cdev + uio

### DIFF
--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -396,6 +396,8 @@ def test_subsystem_reset(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="[be=libvfn] does not support pseudo commands")
     if be_opts["admin"] == "upcie":
         pytest.skip(reason="[be=upcie] does not support subsystem-reset")
+    if be_opts["admin"] == "dmamem":
+        pytest.skip(reason="[be=dmamem] does not support subsystem-reset")
 
     err, state = cijoe.run(
         f"xnvme subsystem-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
@@ -425,6 +427,8 @@ def test_ctrlr_reset(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="[be=libvfn] does not support pseudo commands")
     if be_opts["admin"] == "upcie":
         pytest.skip(reason="[be=upcie] does not support controller-reset")
+    if be_opts["admin"] == "dmamem":
+        pytest.skip(reason="[be=dmamem] does not support controller-reset")
 
     err, _ = cijoe.run(
         f"xnvme ctrlr-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"

--- a/cijoe/tests/tools/test_xnvme_library_info.py
+++ b/cijoe/tests/tools/test_xnvme_library_info.py
@@ -104,6 +104,7 @@ def test_library_info_has_all_combos(cijoe):
         "libaio_file": "XNVME_BE_LINUX_LIBAIO_ENABLED",
         "upcie": "XNVME_BE_UPCIE_ENABLED",
         "upcie-cuda": "XNVME_BE_UPCIE_CUDA_ENABLED",
+        "dmamem": "XNVME_BE_DMAMEM_ENABLED",
     }
 
     combos = get_backend_configurations()

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -146,6 +146,14 @@ def get_backend_configurations():
             "label": ["pcie"],
         },
         {
+            "be": ["dmamem"],
+            "mem": ["dmamem"],
+            "async": ["dmamem"],
+            "sync": ["dmamem"],
+            "admin": ["dmamem"],
+            "label": ["pcie"],
+        },
+        {
             "be": ["upcie-cuda"],
             "mem": ["upcie-cuda"],
             "async": ["upcie-cuda"],

--- a/include/xnvme_be_registry.h
+++ b/include/xnvme_be_registry.h
@@ -28,6 +28,11 @@ extern const struct xnvme_be_config g_xnvme_be_upcie_cuda;
 extern const struct xnvme_be_config g_xnvme_be_upcie_hip;
 #endif
 
+/* uPCIe iommufd + dmamem */
+#ifdef XNVME_BE_DMAMEM_ENABLED
+extern const struct xnvme_be_config g_xnvme_be_dmamem;
+#endif
+
 /* Linux */
 #ifdef XNVME_PLATFORM_LINUX_ENABLED
 extern const struct xnvme_be_config g_xnvme_be_linux_emu_nvme;

--- a/lib/dmamem/meson.build
+++ b/lib/dmamem/meson.build
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Simon A. F. Lund
+# SPDX-License-Identifier: BSD-3-Clause
+
+xnvmelib_dmamem_source = files(
+  'xnvme_be_dmamem.c',
+  'xnvme_be_dmamem_admin.c',
+  'xnvme_be_dmamem_async.c',
+  'xnvme_be_dmamem_dev.c',
+  'xnvme_be_dmamem_mem.c',
+  'xnvme_be_dmamem_sync.c',
+)
+xnvmelib_source += xnvmelib_dmamem_source
+
+if get_option('be_dmamem') and is_linux
+conf_inc += [ include_directories('.') ]
+endif

--- a/lib/dmamem/xnvme_be_dmamem.c
+++ b/lib/dmamem/xnvme_be_dmamem.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <xnvme_be.h>
+#ifdef XNVME_BE_DMAMEM_ENABLED
+#include <xnvme_be_dmamem.h>
+
+struct xnvme_be_dmamem_rte g_dmamem_rte = {0};
+#endif
+
+const struct xnvme_be_config g_xnvme_be_dmamem = {
+#ifdef XNVME_BE_DMAMEM_ENABLED
+	.async = &g_xnvme_be_dmamem_async,
+	.sync = &g_xnvme_be_dmamem_sync,
+	.admin = &g_xnvme_be_dmamem_admin,
+	.dev = &g_xnvme_be_dmamem_dev,
+	.mem = &g_xnvme_be_dmamem_mem,
+#endif
+	.attr =
+		{
+			.name = "dmamem",
+			.descr = "uPCIe iommufd + dmamem userspace NVMe driver",
+			.caps = XNVME_BE_CAP_NVME_PCIE,
+		},
+};

--- a/lib/dmamem/xnvme_be_dmamem.h
+++ b/lib/dmamem/xnvme_be_dmamem.h
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef __INTERNAL_XNVME_BE_DMAMEM_H
+#define __INTERNAL_XNVME_BE_DMAMEM_H
+
+#include <xnvme_be.h>
+#include <xnvme_queue.h>
+
+#define _UPCIE_WITH_NVME
+#include <upcie/upcie.h>
+
+/**
+ * Default heap size used for the DMA heap when xnvme_opts leaves the
+ * size unset (0). Sits on a hugepage-backed memfd and gets a single
+ * contiguous IOVA window through iommufd, so allocations from this
+ * heap translate arithmetically at submission.
+ */
+#define XNVME_BE_DMAMEM_DEFAULT_HEAP_SIZE (1024ULL * 1024 * 1024)
+
+/**
+ * Controller-open mode, decided by the kernel driver bound to the NVMe
+ * device and (for vfio-pci) which vfio API is available.
+ *
+ * vfio-pci             -> either VFIO_CDEV (iommufd + memfd hugepage +
+ *                         arithmetic translator) if /dev/iommu and a
+ *                         vfio-cdev entry both exist, otherwise TYPE1
+ *                         (legacy vfio container + hostmem hugepage +
+ *                         arithmetic translator). The XNVME_DMAMEM_VFIO_MODE
+ *                         env var (iommufd | type1 | auto) overrides the
+ *                         default preference which is iommufd.
+ * uio_pci_generic      -> UIO_LUT (pci_bar_map + hostmem hugepage +
+ *                         LUT translator; requires iommu=pt or iommu=off).
+ *
+ * The RTE is process-wide so the first controller's mode pins the shape;
+ * a later controller with a different mode is rejected.
+ */
+enum xnvme_be_dmamem_mode {
+	XNVME_BE_DMAMEM_MODE_UNSET = 0,
+	XNVME_BE_DMAMEM_MODE_VFIO_CDEV,
+	XNVME_BE_DMAMEM_MODE_UIO_LUT,
+	XNVME_BE_DMAMEM_MODE_VFIO_TYPE1,
+};
+
+struct xnvme_queue_dmamem {
+	struct xnvme_queue_base base;
+	struct nvme_qpair qpair;
+	size_t sq_offset;  ///< Heap offset of the qpair's SQ, for delete
+	size_t cq_offset;  ///< Heap offset of the qpair's CQ, for delete
+	size_t prp_offset; ///< Heap offset of the qpair's per-request PRP scratch, for delete
+	uint8_t _rvds[144];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue_dmamem) == XNVME_BE_QUEUE_STATE_NBYTES,
+		    "Incorrect size")
+
+/**
+ * Shared controller state, one per physical controller, managed by cref.
+ *
+ * ctx / uio_ctx are discriminated by the RTE's mode; only one is live at
+ * a time.
+ */
+struct xnvme_be_dmamem_ctrlr {
+	struct nvme_controller *ctrl;
+	struct nvme_dmamem_vfio_ctx ctx;        ///< vfio-cdev + iommufd state (VFIO_CDEV mode)
+	struct nvme_dmamem_uio_ctx uio_ctx;     ///< pci_bar_map state         (UIO_LUT mode)
+	struct nvme_dmamem_type1_ctx type1_ctx; ///< type1 device fd state     (VFIO_TYPE1 mode)
+	struct vfio_group type1_group;          ///< Owned per-controller in VFIO_TYPE1 mode
+	int type1_group_attached;               ///< Whether type1_group is set_container'd
+	struct nvme_qpair sync; ///< Shared submission/completion queue for synchronous IOs
+	size_t sync_sq_offset;  ///< Heap offset of the sync qpair's SQ
+	size_t sync_cq_offset;  ///< Heap offset of the sync qpair's CQ
+	size_t sync_prp_offset; ///< Heap offset of the sync qpair's per-request PRP scratch
+};
+
+/**
+ * Per-device state embedded in xnvme_dev.be.state.
+ * The first field (ctrlr) is the cref handle written by the platform.
+ */
+struct xnvme_be_dmamem_state {
+	struct xnvme_be_dmamem_ctrlr *ctrlr; ///< Shared controller (first field for platform)
+
+	uint8_t _rvds[120];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_dmamem_state) == XNVME_BE_STATE_NBYTES,
+		    "Incorrect size")
+
+/**
+ * State shared across every controller instance in the process.
+ *
+ * One dmamem_heap regardless of mode. In VFIO_CDEV mode it sits on a
+ * hugepage-backed memfd wired into an iommufd IOAS; every controller
+ * attaches into that same IOAS so PRPs translate arithmetically off a
+ * shared base_iova. In UIO_LUT mode it sits on a hostmem_hugepage whose
+ * borrowed phys_lut resolves PRPs to physical addresses at submit.
+ */
+struct xnvme_be_dmamem_rte {
+	enum xnvme_be_dmamem_mode mode;
+	struct iommufd iommufd;       ///< VFIO_CDEV mode
+	uint32_t ioas_id;             ///< VFIO_CDEV mode
+	struct hostmem_config hp_cfg; ///< UIO_LUT + VFIO_TYPE1 modes
+	struct hostmem_hugepage hp;   ///< UIO_LUT + VFIO_TYPE1 modes
+	struct vfio_container
+		type1_container; ///< VFIO_TYPE1 mode; first ctrlr's iommu is set on it
+	int type1_iommu_set;     ///< Whether the container has VFIO_SET_IOMMU applied
+	struct dmamem dmem;
+	struct dmamem_heap heap;
+	int is_initialized;
+	int iommufd_alive;
+	int ioas_alive;
+	int hp_alive;
+	int type1_container_alive;
+	int dmem_alive;
+	int heap_alive;
+};
+
+extern struct xnvme_be_dmamem_rte g_dmamem_rte;
+
+extern struct xnvme_be_mem g_xnvme_be_dmamem_mem;
+extern struct xnvme_be_admin g_xnvme_be_dmamem_admin;
+extern struct xnvme_be_sync g_xnvme_be_dmamem_sync;
+extern struct xnvme_be_async g_xnvme_be_dmamem_async;
+extern struct xnvme_be_dev g_xnvme_be_dmamem_dev;
+
+int
+xnvme_be_dmamem_resolve_vfio_cdev(const char *bdf, char *cdev_path, size_t cdev_path_len);
+
+void
+xnvme_be_dmamem_dev_close(struct xnvme_dev *dev);
+int
+xnvme_be_dmamem_dev_open(struct xnvme_dev *dev);
+void *
+xnvme_be_dmamem_ctrlr_init(struct xnvme_dev *dev);
+int
+xnvme_be_dmamem_ctrlr_term(void *handle);
+
+int
+xnvme_be_dmamem_queue_init(struct xnvme_queue *queue, int opts);
+int
+xnvme_be_dmamem_queue_term(struct xnvme_queue *queue);
+int
+xnvme_be_dmamem_queue_poke(struct xnvme_queue *queue, uint32_t max);
+
+#endif /* __INTERNAL_XNVME_BE_DMAMEM_H */

--- a/lib/dmamem/xnvme_be_dmamem_admin.c
+++ b/lib/dmamem/xnvme_be_dmamem_admin.c
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <libxnvme.h>
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_DMAMEM_ENABLED
+#include <xnvme_dev.h>
+#include <xnvme_queue.h>
+#include <xnvme_spec.h>
+#include <xnvme_be_dmamem.h>
+
+int
+xnvme_be_dmamem_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf,
+			       size_t XNVME_UNUSED(dbuf_nbytes), void *XNVME_UNUSED(mbuf),
+			       size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_dmamem_state *state = (void *)ctx->dev->be.state;
+	struct nvme_controller *ctrl = state->ctrlr->ctrl;
+	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
+	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
+	int err;
+
+	if (dbuf) {
+		cmd->prp1 = dmamem_va_to_iova(&g_dmamem_rte.dmem, dbuf);
+	}
+
+	err = nvme_admin_sync_dmamem(ctrl, cmd, 0, cpl);
+	if (err || xnvme_cmd_ctx_cpl_status(ctx)) {
+		XNVME_DEBUG("FAILED: nvme_admin_sync_dmamem(); err(%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int
+xnvme_be_dmamem_sync_cmd_pseudo(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
+				void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_dmamem_state *state = (void *)ctx->dev->be.state;
+	struct nvme_controller *ctrl = state->ctrlr->ctrl;
+	void *bar0 = ctrl->func.bars[0].region;
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_PSEUDO_OPC_SHOW_REGS:
+		if (dbuf_nbytes != sizeof(struct xnvme_spec_ctrlr_bar)) {
+			XNVME_DEBUG(
+				"FAILED: dbuf_nbytes(%zu) != sizeof(struct xnvme_spec_ctrlr_bar)",
+				dbuf_nbytes);
+			return -EINVAL;
+		}
+		memcpy(dbuf, bar0, dbuf_nbytes);
+		return 0;
+
+	case XNVME_SPEC_PSEUDO_OPC_CONTROLLER_RESET:
+		XNVME_DEBUG(
+			"FAILED: controller-reset not supported (requires admin queue re-init)");
+		return -ENOSYS;
+
+	case XNVME_SPEC_PSEUDO_OPC_NAMESPACE_RESCAN:
+		return 0;
+
+	case XNVME_SPEC_PSEUDO_OPC_SUBSYSTEM_RESET:
+		XNVME_DEBUG(
+			"FAILED: subsystem-reset not supported (requires admin queue re-init)");
+		return -ENOSYS;
+
+	default:
+		XNVME_DEBUG("FAILED: unsupported opcode: %d", ctx->cmd.common.opcode);
+		return -ENOSYS;
+	}
+}
+#endif
+
+struct xnvme_be_admin g_xnvme_be_dmamem_admin = {
+	.id = "dmamem",
+#ifdef XNVME_BE_DMAMEM_ENABLED
+	.cmd_admin = xnvme_be_dmamem_sync_cmd_admin,
+	.cmd_pseudo = xnvme_be_dmamem_sync_cmd_pseudo,
+#else
+	.cmd_admin = xnvme_be_nosys_sync_cmd_admin,
+	.cmd_pseudo = xnvme_be_nosys_sync_cmd_pseudo,
+#endif
+};

--- a/lib/dmamem/xnvme_be_dmamem_async.c
+++ b/lib/dmamem/xnvme_be_dmamem_async.c
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <libxnvme.h>
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_DMAMEM_ENABLED
+#include <xnvme_dev.h>
+#include <xnvme_queue.h>
+#include <xnvme_be_dmamem.h>
+
+int
+xnvme_be_dmamem_queue_init(struct xnvme_queue *queue, int XNVME_UNUSED(opts))
+{
+	struct xnvme_queue_dmamem *dq = (void *)queue;
+	struct xnvme_be_dmamem_state *state = (void *)queue->base.dev->be.state;
+	int err;
+
+	err = nvme_controller_create_io_qpair_dmamem(
+		state->ctrlr->ctrl, &dq->qpair, queue->base.capacity + 1, &g_dmamem_rte.heap,
+		&dq->sq_offset, &dq->cq_offset, &dq->prp_offset);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair_dmamem(); err(%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int
+xnvme_be_dmamem_queue_term(struct xnvme_queue *queue)
+{
+	struct xnvme_queue_dmamem *dq = (void *)queue;
+	struct xnvme_be_dmamem_state *state = (void *)queue->base.dev->be.state;
+
+	nvme_controller_delete_io_qpair_dmamem(state->ctrlr->ctrl, &dq->qpair, &g_dmamem_rte.heap,
+					       dq->sq_offset, dq->cq_offset, dq->prp_offset);
+
+	return 0;
+}
+
+int
+xnvme_be_dmamem_queue_poke(struct xnvme_queue *queue, uint32_t max)
+{
+	struct xnvme_queue_dmamem *dq = (struct xnvme_queue_dmamem *)queue;
+	struct nvme_qpair *qp = &dq->qpair;
+	struct nvme_completion *cq = qp->cq;
+	unsigned int reaped = 0;
+
+	if (!max) {
+		max = queue->base.outstanding;
+	}
+
+	wmb();
+	nvme_qpair_sqdb_update(qp);
+
+	do {
+		struct nvme_completion *cqe;
+
+		cqe = &cq[qp->head];
+		if (((*(const volatile uint16_t *)&(cqe->status)) & 0x1) != qp->phase) {
+			break;
+		}
+
+		dma_rmb();
+
+		if (++qp->head == qp->depth) {
+			qp->head = 0;
+			qp->phase ^= 1;
+		}
+
+		reaped++;
+
+		{
+			struct xnvme_cmd_ctx *ctx;
+			struct nvme_request *req;
+
+			req = nvme_request_get(qp->rpool, cqe->cid);
+			if (!req) {
+				XNVME_DEBUG("FAILED: nvme_request_get()");
+				return -EIO;
+			}
+
+			ctx = req->user;
+			memcpy(&ctx->cpl, cqe, sizeof(ctx->cpl));
+			nvme_request_free(qp->rpool, req->cid);
+
+			queue->base.outstanding -= 1;
+
+			ctx->async.cb(ctx, ctx->async.cb_arg);
+		}
+	} while (reaped < max);
+
+	if (reaped) {
+		mmio_write32(qp->cqdb, 0, qp->head);
+	}
+
+	return reaped;
+}
+
+int
+xnvme_be_dmamem_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			     size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_queue_dmamem *dq = (struct xnvme_queue_dmamem *)ctx->async.queue;
+	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
+	struct nvme_request *req;
+	int err;
+
+	if (dq->base.outstanding == ctx->async.queue->base.capacity) {
+		XNVME_DEBUG("FAILED: queue is full");
+		return -EBUSY;
+	}
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_FS_OPC_READ:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	}
+
+	req = nvme_request_alloc(dq->qpair.rpool);
+	if (!req) {
+		XNVME_DEBUG("FAILED: nvme_request_alloc(); errno(%d)", errno);
+		return -errno;
+	}
+
+	req->user = ctx;
+	cmd->cid = req->cid;
+
+	if (dbuf) {
+		nvme_request_prep_command_prps_contig_dmamem(req, &g_dmamem_rte.heap, dbuf,
+							     dbuf_nbytes, cmd);
+	}
+	if (mbuf) {
+		cmd->mptr = dmamem_va_to_iova(&g_dmamem_rte.dmem, mbuf);
+	}
+
+	err = nvme_qpair_enqueue(&dq->qpair, cmd);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_qpair_enqueue(); err(%d)", err);
+		nvme_request_free(dq->qpair.rpool, req->cid);
+		return err;
+	}
+
+	dq->base.outstanding += 1;
+	return 0;
+}
+
+int
+xnvme_be_dmamem_async_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			      size_t XNVME_UNUSED(dvec_nbytes), void *mbuf,
+			      size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_queue_dmamem *dq = (struct xnvme_queue_dmamem *)ctx->async.queue;
+	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
+	struct nvme_request *req;
+	int err;
+
+	if (dq->base.outstanding == ctx->async.queue->base.capacity) {
+		XNVME_DEBUG("FAILED: queue is full");
+		return -EBUSY;
+	}
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_FS_OPC_READ:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	}
+
+	req = nvme_request_alloc(dq->qpair.rpool);
+	if (!req) {
+		XNVME_DEBUG("FAILED: nvme_request_alloc(); errno(%d)", errno);
+		return -errno;
+	}
+
+	req->user = ctx;
+	cmd->cid = req->cid;
+
+	if (dvec) {
+		nvme_request_prep_command_prps_iov_dmamem(req, &g_dmamem_rte.heap, dvec, dvec_cnt,
+							  cmd);
+	}
+	if (mbuf) {
+		cmd->mptr = dmamem_va_to_iova(&g_dmamem_rte.dmem, mbuf);
+	}
+
+	err = nvme_qpair_enqueue(&dq->qpair, cmd);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_qpair_enqueue(); err(%d)", err);
+		nvme_request_free(dq->qpair.rpool, req->cid);
+		return err;
+	}
+
+	dq->base.outstanding += 1;
+	return 0;
+}
+
+#endif
+
+struct xnvme_be_async g_xnvme_be_dmamem_async = {
+	.id = "dmamem",
+#ifdef XNVME_BE_DMAMEM_ENABLED
+	.cmd_io = xnvme_be_dmamem_async_cmd_io,
+	.cmd_iov = xnvme_be_dmamem_async_cmd_iov,
+	.poke = xnvme_be_dmamem_queue_poke,
+	.wait = xnvme_be_nosys_queue_wait,
+	.init = xnvme_be_dmamem_queue_init,
+	.term = xnvme_be_dmamem_queue_term,
+	.get_completion_fd = xnvme_be_nosys_queue_get_completion_fd,
+#else
+	.cmd_io = xnvme_be_nosys_queue_cmd_io,
+	.cmd_iov = xnvme_be_nosys_queue_cmd_iov,
+	.poke = xnvme_be_nosys_queue_poke,
+	.wait = xnvme_be_nosys_queue_wait,
+	.init = xnvme_be_nosys_queue_init,
+	.term = xnvme_be_nosys_queue_term,
+	.get_completion_fd = xnvme_be_nosys_queue_get_completion_fd,
+#endif
+};

--- a/lib/dmamem/xnvme_be_dmamem_dev.c
+++ b/lib/dmamem/xnvme_be_dmamem_dev.c
@@ -1,0 +1,669 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <libxnvme.h>
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_DMAMEM_ENABLED
+#include <dirent.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <xnvme_dev.h>
+#include <xnvme_be_dmamem.h>
+
+static _Atomic int g_ctrlr_count;
+
+int
+xnvme_be_dmamem_resolve_vfio_cdev(const char *bdf, char *cdev_path, size_t cdev_path_len)
+{
+	char sysfs_path[PATH_MAX] = {0};
+	DIR *dir;
+	struct dirent *ent;
+	int found = 0;
+
+	snprintf(sysfs_path, sizeof(sysfs_path), "/sys/bus/pci/devices/%s/vfio-dev", bdf);
+	dir = opendir(sysfs_path);
+	if (!dir) {
+		return -errno;
+	}
+	while ((ent = readdir(dir))) {
+		if (strncmp(ent->d_name, "vfio", 4) != 0) {
+			continue;
+		}
+		snprintf(cdev_path, cdev_path_len, "/dev/vfio/devices/%s", ent->d_name);
+		found = 1;
+		break;
+	}
+	closedir(dir);
+	return found ? 0 : -ENOENT;
+}
+
+/**
+ * Return non-zero if the target BDF has a vfio-cdev entry, i.e.
+ * /sys/bus/pci/devices/<bdf>/vfio-dev/vfio* exists.
+ */
+static int
+_bdf_has_vfio_cdev(const char *bdf)
+{
+	char sysfs_path[PATH_MAX] = {0};
+	DIR *dir;
+	struct dirent *ent;
+	int found = 0;
+
+	snprintf(sysfs_path, sizeof(sysfs_path), "/sys/bus/pci/devices/%s/vfio-dev", bdf);
+	dir = opendir(sysfs_path);
+	if (!dir) {
+		return 0;
+	}
+	while ((ent = readdir(dir))) {
+		if (strncmp(ent->d_name, "vfio", 4) == 0) {
+			found = 1;
+			break;
+		}
+	}
+	closedir(dir);
+	return found;
+}
+
+/**
+ * Read the kernel driver bound to `bdf` and derive the dmamem mode.
+ *
+ * vfio-pci        -> VFIO_CDEV if /dev/iommu and a vfio-cdev entry both
+ *                    exist, otherwise VFIO_TYPE1 (legacy vfio container).
+ *                    Env override: XNVME_DMAMEM_VFIO_MODE = iommufd |
+ *                    type1 | auto.
+ * uio_pci_generic -> UIO_LUT (pci_bar_map + hostmem hugepage + LUT).
+ * anything else   -> -ENOTSUP.
+ */
+static int
+_detect_mode(const char *bdf, enum xnvme_be_dmamem_mode *mode_out)
+{
+	char link_path[PATH_MAX] = {0};
+	char resolved[PATH_MAX] = {0};
+	const char *driver;
+	const char *override;
+	ssize_t ret;
+
+	snprintf(link_path, sizeof(link_path), "/sys/bus/pci/devices/%s/driver", bdf);
+	ret = readlink(link_path, resolved, sizeof(resolved) - 1);
+	if (ret < 0) {
+		return -errno;
+	}
+	resolved[ret] = '\0';
+
+	driver = strrchr(resolved, '/');
+	driver = driver ? driver + 1 : resolved;
+
+	if (!strcmp(driver, "uio_pci_generic")) {
+		*mode_out = XNVME_BE_DMAMEM_MODE_UIO_LUT;
+		return 0;
+	}
+
+	if (strcmp(driver, "vfio-pci")) {
+		XNVME_DEBUG("FAILED: unsupported driver '%s' bound to '%s'", driver, bdf);
+		return -ENOTSUP;
+	}
+
+	override = getenv("XNVME_DMAMEM_VFIO_MODE");
+	if (override && !strcmp(override, "iommufd")) {
+		*mode_out = XNVME_BE_DMAMEM_MODE_VFIO_CDEV;
+		return 0;
+	}
+	if (override && !strcmp(override, "type1")) {
+		*mode_out = XNVME_BE_DMAMEM_MODE_VFIO_TYPE1;
+		return 0;
+	}
+
+	/* auto: prefer iommufd if usable, else type1 */
+	if (access("/dev/iommu", R_OK | W_OK) == 0 && _bdf_has_vfio_cdev(bdf)) {
+		*mode_out = XNVME_BE_DMAMEM_MODE_VFIO_CDEV;
+	} else {
+		*mode_out = XNVME_BE_DMAMEM_MODE_VFIO_TYPE1;
+	}
+	return 0;
+}
+
+/**
+ * Release the process-wide RTE.
+ *
+ * Order matters: heap first (releases the freelist bookkeeping), then
+ * dmamem (unmaps the DMA mapping in VFIO_CDEV mode; no-op in UIO_LUT),
+ * then the mode-specific backing (memfd + IOAS + iommufd, or
+ * hostmem_hugepage), then reset the mode.
+ */
+static void
+_rte_term(void)
+{
+	if (!g_dmamem_rte.is_initialized) {
+		return;
+	}
+
+	if (g_dmamem_rte.heap_alive) {
+		dmamem_heap_term(&g_dmamem_rte.heap);
+		g_dmamem_rte.heap_alive = 0;
+	}
+	if (g_dmamem_rte.dmem_alive) {
+		dmamem_destroy(&g_dmamem_rte.dmem);
+		g_dmamem_rte.dmem_alive = 0;
+	}
+	if (g_dmamem_rte.hp_alive) {
+		hostmem_hugepage_free(&g_dmamem_rte.hp);
+		g_dmamem_rte.hp_alive = 0;
+	}
+	if (g_dmamem_rte.type1_container_alive) {
+		vfio_container_close(&g_dmamem_rte.type1_container);
+		g_dmamem_rte.type1_container_alive = 0;
+		g_dmamem_rte.type1_iommu_set = 0;
+	}
+	if (g_dmamem_rte.ioas_alive) {
+		iommufd_destroy(&g_dmamem_rte.iommufd, g_dmamem_rte.ioas_id);
+		g_dmamem_rte.ioas_alive = 0;
+	}
+	if (g_dmamem_rte.iommufd_alive) {
+		iommufd_close(&g_dmamem_rte.iommufd);
+		g_dmamem_rte.iommufd_alive = 0;
+	}
+
+	g_dmamem_rte.mode = XNVME_BE_DMAMEM_MODE_UNSET;
+	g_dmamem_rte.is_initialized = 0;
+}
+
+/**
+ * Bring up the RTE in VFIO_CDEV mode.
+ *
+ * /dev/iommu + one IOAS + a hugepage-backed memfd imported via
+ * IOMMU_IOAS_MAP_FILE. All controllers opened afterwards attach into
+ * this same IOAS so their PRPs translate arithmetically off the shared
+ * base_iova.
+ */
+static int
+_rte_init_vfio_cdev(size_t heap_size)
+{
+	size_t hugepgsz = 2ULL * 1024 * 1024;
+	int err;
+
+	/* dmamem_from_memfd requires size to be a multiple of hugepgsz;
+	 * round up so callers (like xnvmeperf) that hand us a page-off
+	 * size don't fail at -EINVAL. */
+	heap_size = ((heap_size + hugepgsz - 1) / hugepgsz) * hugepgsz;
+
+	err = iommufd_open(&g_dmamem_rte.iommufd);
+	if (err) {
+		XNVME_DEBUG("FAILED: iommufd_open(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.iommufd_alive = 1;
+
+	err = iommufd_ioas_alloc(&g_dmamem_rte.iommufd, &g_dmamem_rte.ioas_id);
+	if (err) {
+		XNVME_DEBUG("FAILED: iommufd_ioas_alloc(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.ioas_alive = 1;
+
+	err = dmamem_from_memfd(&g_dmamem_rte.dmem, &g_dmamem_rte.iommufd, g_dmamem_rte.ioas_id,
+				heap_size, hugepgsz);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmamem_from_memfd(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.dmem_alive = 1;
+
+	err = dmamem_heap_init(&g_dmamem_rte.heap, &g_dmamem_rte.dmem, 4096);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmamem_heap_init(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.heap_alive = 1;
+
+	return 0;
+}
+
+/**
+ * Bring up the RTE in UIO_LUT mode.
+ *
+ * Allocate a hostmem_hugepage (with phys_lut populated via pagemap) and
+ * wrap it via dmamem_from_hostmem_lut so translation returns physical
+ * addresses. Requires CAP_SYS_ADMIN so the pagemap read at
+ * hostmem_hugepage_alloc time succeeds; without it dmamem_from_hostmem_lut
+ * fails with EINVAL and the RTE bring-up aborts.
+ */
+static int
+_rte_init_uio_lut(size_t heap_size)
+{
+	int err;
+
+	err = hostmem_config_init(&g_dmamem_rte.hp_cfg);
+	if (err) {
+		XNVME_DEBUG("FAILED: hostmem_config_init(); err(%d)", err);
+		return err;
+	}
+	heap_size =
+		((heap_size + g_dmamem_rte.hp_cfg.hugepgsz - 1) / g_dmamem_rte.hp_cfg.hugepgsz) *
+		g_dmamem_rte.hp_cfg.hugepgsz;
+
+	err = hostmem_hugepage_alloc(heap_size, &g_dmamem_rte.hp, &g_dmamem_rte.hp_cfg);
+	if (err) {
+		XNVME_DEBUG("FAILED: hostmem_hugepage_alloc(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.hp_alive = 1;
+
+	err = dmamem_from_hostmem_lut(&g_dmamem_rte.dmem, &g_dmamem_rte.hp);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmamem_from_hostmem_lut(); err(%d) "
+			    "(missing CAP_SYS_ADMIN?)",
+			    err);
+		return err;
+	}
+	g_dmamem_rte.dmem_alive = 1;
+
+	err = dmamem_heap_init(&g_dmamem_rte.heap, &g_dmamem_rte.dmem, 4096);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmamem_heap_init(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.heap_alive = 1;
+
+	return 0;
+}
+
+/**
+ * Bring up the RTE in VFIO_TYPE1 mode.
+ *
+ * Opens a vfio type1 container and allocates the hostmem_hugepage that
+ * backs the shared dmamem_heap. The container is not yet iommu-set nor
+ * mapped; that happens on the first ctrlr_init when a group first gets
+ * attached (VFIO_SET_IOMMU requires a group attached to the container
+ * before it can be set, so the mapping has to wait). Subsequent
+ * ctrlr_init calls skip the iommu-set + MAP_DMA and just attach their
+ * group + acquire BAR0.
+ */
+static int
+_rte_init_vfio_type1(size_t heap_size)
+{
+	int err;
+
+	err = hostmem_config_init(&g_dmamem_rte.hp_cfg);
+	if (err) {
+		XNVME_DEBUG("FAILED: hostmem_config_init(); err(%d)", err);
+		return err;
+	}
+	heap_size =
+		((heap_size + g_dmamem_rte.hp_cfg.hugepgsz - 1) / g_dmamem_rte.hp_cfg.hugepgsz) *
+		g_dmamem_rte.hp_cfg.hugepgsz;
+
+	err = hostmem_hugepage_alloc(heap_size, &g_dmamem_rte.hp, &g_dmamem_rte.hp_cfg);
+	if (err) {
+		XNVME_DEBUG("FAILED: hostmem_hugepage_alloc(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.hp_alive = 1;
+
+	err = vfio_container_open(&g_dmamem_rte.type1_container);
+	if (err) {
+		XNVME_DEBUG("FAILED: vfio_container_open(); err(%d)", err);
+		return err;
+	}
+	g_dmamem_rte.type1_container_alive = 1;
+
+	return 0;
+}
+
+/**
+ * Bring up the process-wide RTE in the given mode, or verify an already
+ * initialized RTE matches.
+ */
+static int
+_rte_init(enum xnvme_be_dmamem_mode mode, size_t heap_size)
+{
+	int err;
+
+	if (g_dmamem_rte.is_initialized) {
+		if (g_dmamem_rte.mode != mode) {
+			XNVME_DEBUG("FAILED: existing dmamem RTE mode(%d) != requested(%d)",
+				    g_dmamem_rte.mode, mode);
+			return -EINVAL;
+		}
+		return 0;
+	}
+
+	if (!heap_size) {
+		heap_size = XNVME_BE_DMAMEM_DEFAULT_HEAP_SIZE;
+	}
+
+	g_dmamem_rte.mode = mode;
+
+	switch (mode) {
+	case XNVME_BE_DMAMEM_MODE_VFIO_CDEV:
+		err = _rte_init_vfio_cdev(heap_size);
+		break;
+	case XNVME_BE_DMAMEM_MODE_UIO_LUT:
+		err = _rte_init_uio_lut(heap_size);
+		break;
+	case XNVME_BE_DMAMEM_MODE_VFIO_TYPE1:
+		err = _rte_init_vfio_type1(heap_size);
+		break;
+	default:
+		err = -EINVAL;
+		break;
+	}
+
+	if (err) {
+		_rte_term();
+		return err;
+	}
+
+	g_dmamem_rte.is_initialized = 1;
+	return 0;
+}
+
+/**
+ * Attach a controller's group to the RTE's type1 container, and on the
+ * first controller also set_iommu(TYPE1) + MAP_DMA the hostmem hugepage
+ * + init the shared dmamem_heap.
+ *
+ * Rolls back the group open (and any RTE-side state it turned on) on
+ * failure. The container itself and the hostmem hugepage remain owned
+ * by the RTE.
+ */
+static int
+_type1_attach_and_maybe_map(struct xnvme_be_dmamem_ctrlr *ctrlr, const char *bdf)
+{
+	int api_version = 0;
+	int group_id = -1;
+	int err;
+
+	err = vfio_device_get_iommu_group_id(bdf, &group_id);
+	if (err) {
+		XNVME_DEBUG("FAILED: vfio_device_get_iommu_group_id(%s); err(%d)", bdf, err);
+		return err;
+	}
+
+	err = vfio_group_open(group_id, &ctrlr->type1_group);
+	if (err) {
+		XNVME_DEBUG("FAILED: vfio_group_open(%d); err(%d)", group_id, err);
+		return err;
+	}
+
+	err = vfio_group_get_status(&ctrlr->type1_group);
+	if (err < 0) {
+		XNVME_DEBUG("FAILED: vfio_group_get_status(); errno(%d)", errno);
+		err = -errno;
+		goto fail_group;
+	}
+	if (!(ctrlr->type1_group.status.flags & VFIO_GROUP_FLAGS_VIABLE)) {
+		XNVME_DEBUG("FAILED: iommu group %d not viable", group_id);
+		err = -EBUSY;
+		goto fail_group;
+	}
+
+	err = vfio_group_set_container(&ctrlr->type1_group, &g_dmamem_rte.type1_container);
+	if (err < 0) {
+		XNVME_DEBUG("FAILED: vfio_group_set_container(); errno(%d)", errno);
+		err = -errno;
+		goto fail_group;
+	}
+	ctrlr->type1_group_attached = 1;
+
+	if (g_dmamem_rte.type1_iommu_set) {
+		/* Container already set_iommu'd + mapped by an earlier controller. */
+		return 0;
+	}
+
+	err = vfio_get_api_version(&g_dmamem_rte.type1_container, &api_version);
+	if (err) {
+		XNVME_DEBUG("FAILED: vfio_get_api_version(); err(%d)", err);
+		goto fail_group;
+	}
+	if (api_version != VFIO_API_VERSION) {
+		XNVME_DEBUG("FAILED: unexpected VFIO_API_VERSION(%d != %d)", api_version,
+			    VFIO_API_VERSION);
+		err = -EINVAL;
+		goto fail_group;
+	}
+
+	if (!vfio_check_extension(&g_dmamem_rte.type1_container, VFIO_TYPE1_IOMMU)) {
+		XNVME_DEBUG("FAILED: VFIO_TYPE1_IOMMU extension not supported");
+		err = -ENOTSUP;
+		goto fail_group;
+	}
+
+	err = vfio_set_iommu(&g_dmamem_rte.type1_container, VFIO_TYPE1_IOMMU);
+	if (err < 0) {
+		XNVME_DEBUG("FAILED: vfio_set_iommu(TYPE1); errno(%d)", errno);
+		err = -errno;
+		goto fail_group;
+	}
+	g_dmamem_rte.type1_iommu_set = 1;
+
+	/* MAP_DMA the whole hugepage at a caller-chosen base_iova; the
+	 * dmamem sits on that mapping as ARITHMETIC (base_iova + offset). */
+	err = dmamem_from_hostmem_type1(&g_dmamem_rte.dmem, &g_dmamem_rte.type1_container,
+					(uint64_t)0, &g_dmamem_rte.hp);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmamem_from_hostmem_type1(); err(%d)", err);
+		goto fail_group;
+	}
+	g_dmamem_rte.dmem_alive = 1;
+
+	err = dmamem_heap_init(&g_dmamem_rte.heap, &g_dmamem_rte.dmem, 4096);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmamem_heap_init(); err(%d)", err);
+		dmamem_destroy(&g_dmamem_rte.dmem);
+		g_dmamem_rte.dmem_alive = 0;
+		goto fail_group;
+	}
+	g_dmamem_rte.heap_alive = 1;
+
+	return 0;
+
+fail_group:
+	if (ctrlr->type1_group.fd >= 0) {
+		vfio_group_close(&ctrlr->type1_group);
+		ctrlr->type1_group_attached = 0;
+	}
+	return err;
+}
+
+/**
+ * Bring up the shared controller state for one physical NVMe.
+ *
+ * Detects the kernel driver bound to the device, brings up (or verifies)
+ * the RTE in the matching mode, opens the controller through one of the
+ * three nvme_controller_open_dmamem_{vfio,uio,type1} entry points, and
+ * creates one shared sync IO qpair for xnvme's synchronous submit path.
+ * The async path allocates additional qpairs on demand via queue_init.
+ * The IO qpair helpers are shared between modes.
+ */
+void *
+xnvme_be_dmamem_ctrlr_init(struct xnvme_dev *dev)
+{
+	struct xnvme_be_dmamem_ctrlr *ctrlr;
+	enum xnvme_be_dmamem_mode mode = XNVME_BE_DMAMEM_MODE_UNSET;
+	char cdev_path[PATH_MAX] = {0};
+	int err;
+
+	err = _detect_mode(dev->ident.uri, &mode);
+	if (err) {
+		XNVME_DEBUG("FAILED: _detect_mode(%s); err(%d)", dev->ident.uri, err);
+		errno = -err;
+		return NULL;
+	}
+
+	err = _rte_init(mode, dev->opts.host_heap_size);
+	if (err) {
+		XNVME_DEBUG("FAILED: _rte_init(); err(%d)", err);
+		errno = -err;
+		return NULL;
+	}
+
+	if (XNVME_BE_DMAMEM_MODE_VFIO_CDEV == mode) {
+		err = xnvme_be_dmamem_resolve_vfio_cdev(dev->ident.uri, cdev_path,
+							sizeof(cdev_path));
+		if (err) {
+			XNVME_DEBUG("FAILED: resolve_vfio_cdev(%s); err(%d)", dev->ident.uri, err);
+			errno = -err;
+			return NULL;
+		}
+	}
+
+	ctrlr = calloc(1, sizeof(*ctrlr));
+	if (!ctrlr) {
+		XNVME_DEBUG("FAILED: calloc(ctrlr)");
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	ctrlr->ctrl = calloc(1, sizeof(*ctrlr->ctrl));
+	if (!ctrlr->ctrl) {
+		XNVME_DEBUG("FAILED: calloc(ctrl)");
+		free(ctrlr);
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	ctrlr->type1_group.fd = -1;
+
+	switch (mode) {
+	case XNVME_BE_DMAMEM_MODE_VFIO_CDEV:
+		err = nvme_controller_open_dmamem_vfio(ctrlr->ctrl, &ctrlr->ctx,
+						       &g_dmamem_rte.iommufd, g_dmamem_rte.ioas_id,
+						       &g_dmamem_rte.heap, cdev_path);
+		break;
+	case XNVME_BE_DMAMEM_MODE_UIO_LUT:
+		err = nvme_controller_open_dmamem_uio(ctrlr->ctrl, &ctrlr->uio_ctx,
+						      &g_dmamem_rte.heap, dev->ident.uri);
+		break;
+	case XNVME_BE_DMAMEM_MODE_VFIO_TYPE1:
+		err = _type1_attach_and_maybe_map(ctrlr, dev->ident.uri);
+		if (err) {
+			break;
+		}
+		err = nvme_controller_open_dmamem_type1(
+			ctrlr->ctrl, &ctrlr->type1_ctx, &g_dmamem_rte.type1_container,
+			&ctrlr->type1_group, &g_dmamem_rte.heap, dev->ident.uri);
+		if (err && ctrlr->type1_group_attached) {
+			vfio_group_close(&ctrlr->type1_group);
+			ctrlr->type1_group_attached = 0;
+		}
+		break;
+	default:
+		err = -EINVAL;
+		break;
+	}
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_controller_open_dmamem*(); err(%d)", err);
+		free(ctrlr->ctrl);
+		free(ctrlr);
+		errno = -err;
+		return NULL;
+	}
+
+	err = nvme_controller_create_io_qpair_dmamem(
+		ctrlr->ctrl, &ctrlr->sync, 16, &g_dmamem_rte.heap, &ctrlr->sync_sq_offset,
+		&ctrlr->sync_cq_offset, &ctrlr->sync_prp_offset);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair_dmamem(); err(%d)", err);
+		switch (mode) {
+		case XNVME_BE_DMAMEM_MODE_VFIO_CDEV:
+			nvme_controller_close_dmamem_vfio(ctrlr->ctrl, &ctrlr->ctx,
+							  &g_dmamem_rte.heap);
+			break;
+		case XNVME_BE_DMAMEM_MODE_UIO_LUT:
+			nvme_controller_close_dmamem_uio(ctrlr->ctrl, &ctrlr->uio_ctx,
+							 &g_dmamem_rte.heap);
+			break;
+		case XNVME_BE_DMAMEM_MODE_VFIO_TYPE1:
+			nvme_controller_close_dmamem_type1(ctrlr->ctrl, &ctrlr->type1_ctx,
+							   &g_dmamem_rte.heap);
+			if (ctrlr->type1_group_attached) {
+				vfio_group_close(&ctrlr->type1_group);
+				ctrlr->type1_group_attached = 0;
+			}
+			break;
+		default:
+			break;
+		}
+		free(ctrlr->ctrl);
+		free(ctrlr);
+		errno = -err;
+		return NULL;
+	}
+
+	g_ctrlr_count++;
+	return ctrlr;
+}
+
+int
+xnvme_be_dmamem_ctrlr_term(void *handle)
+{
+	struct xnvme_be_dmamem_ctrlr *ctrlr = handle;
+
+	nvme_controller_delete_io_qpair_dmamem(ctrlr->ctrl, &ctrlr->sync, &g_dmamem_rte.heap,
+					       ctrlr->sync_sq_offset, ctrlr->sync_cq_offset,
+					       ctrlr->sync_prp_offset);
+
+	switch (g_dmamem_rte.mode) {
+	case XNVME_BE_DMAMEM_MODE_VFIO_CDEV:
+		nvme_controller_close_dmamem_vfio(ctrlr->ctrl, &ctrlr->ctx, &g_dmamem_rte.heap);
+		break;
+	case XNVME_BE_DMAMEM_MODE_UIO_LUT:
+		nvme_controller_close_dmamem_uio(ctrlr->ctrl, &ctrlr->uio_ctx, &g_dmamem_rte.heap);
+		break;
+	case XNVME_BE_DMAMEM_MODE_VFIO_TYPE1:
+		nvme_controller_close_dmamem_type1(ctrlr->ctrl, &ctrlr->type1_ctx,
+						   &g_dmamem_rte.heap);
+		if (ctrlr->type1_group_attached) {
+			vfio_group_close(&ctrlr->type1_group);
+			ctrlr->type1_group_attached = 0;
+		}
+		break;
+	default:
+		break;
+	}
+
+	free(ctrlr->ctrl);
+	free(ctrlr);
+
+	if (--g_ctrlr_count == 0) {
+		_rte_term();
+	}
+
+	return 0;
+}
+
+void
+xnvme_be_dmamem_dev_close(struct xnvme_dev *XNVME_UNUSED(dev))
+{
+}
+
+int
+xnvme_be_dmamem_dev_open(struct xnvme_dev *dev)
+{
+	dev->ident.dtype =
+		dev->opts.nsid ? XNVME_DEV_TYPE_NVME_NAMESPACE : XNVME_DEV_TYPE_NVME_CONTROLLER;
+	dev->ident.csi = XNVME_SPEC_CSI_NVM;
+	dev->ident.nsid = dev->opts.nsid;
+
+	return 0;
+}
+
+#endif
+
+struct xnvme_be_dev g_xnvme_be_dmamem_dev = {
+#ifdef XNVME_BE_DMAMEM_ENABLED
+	.dev_open = xnvme_be_dmamem_dev_open,
+	.dev_close = xnvme_be_dmamem_dev_close,
+	.id = "dmamem",
+	.ctrlr_init = xnvme_be_dmamem_ctrlr_init,
+	.ctrlr_term = xnvme_be_dmamem_ctrlr_term,
+#else
+	.dev_open = xnvme_be_nosys_dev_open,
+	.dev_close = xnvme_be_nosys_dev_close,
+	.id = "nosys",
+	.ctrlr_init = NULL,
+	.ctrlr_term = NULL,
+#endif
+};

--- a/lib/dmamem/xnvme_be_dmamem_mem.c
+++ b/lib/dmamem/xnvme_be_dmamem_mem.c
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_DMAMEM_ENABLED
+#include <errno.h>
+#include <xnvme_be_dmamem.h>
+#include <xnvme_dev.h>
+
+/**
+ * Allocate a buffer from the RTE's dmamem_heap.
+ *
+ * The heap sits on one contiguous IOVA window, so offsets translate to
+ * IOVAs with a single addition. Callers hand the returned VA to the
+ * device via cmd.prp1 = dmamem_va_to_iova(...) later on.
+ */
+void *
+xnvme_be_dmamem_buf_alloc(const struct xnvme_dev *XNVME_UNUSED(dev), size_t nbytes, uint64_t *phys)
+{
+	size_t offset = 0;
+	void *buf;
+	int err;
+
+	err = dmamem_heap_alloc(&g_dmamem_rte.heap, nbytes, &offset);
+	if (err) {
+		errno = -err;
+		return NULL;
+	}
+
+	buf = dmamem_heap_at_va(&g_dmamem_rte.heap, offset);
+	if (!buf) {
+		dmamem_heap_free(&g_dmamem_rte.heap, offset);
+		errno = EFAULT;
+		return NULL;
+	}
+
+	if (phys) {
+		*phys = dmamem_heap_at_iova(&g_dmamem_rte.heap, offset);
+	}
+
+	return buf;
+}
+
+void
+xnvme_be_dmamem_buf_free(const struct xnvme_dev *XNVME_UNUSED(dev), void *buf)
+{
+	size_t offset;
+
+	if (!buf) {
+		return;
+	}
+	offset = (size_t)((char *)buf - (char *)g_dmamem_rte.dmem.cpu_va);
+
+	dmamem_heap_free(&g_dmamem_rte.heap, offset);
+}
+
+int
+xnvme_be_dmamem_buf_vtophys(const struct xnvme_dev *XNVME_UNUSED(dev), void *buf, uint64_t *phys)
+{
+	*phys = dmamem_va_to_iova(&g_dmamem_rte.dmem, buf);
+
+	return 0;
+}
+
+#endif
+
+struct xnvme_be_mem g_xnvme_be_dmamem_mem = {
+	.id = "dmamem",
+#ifdef XNVME_BE_DMAMEM_ENABLED
+	.buf_alloc = xnvme_be_dmamem_buf_alloc,
+	.buf_realloc = xnvme_be_nosys_buf_realloc,
+	.buf_free = xnvme_be_dmamem_buf_free,
+	.buf_vtophys = xnvme_be_dmamem_buf_vtophys,
+	.mem_map = xnvme_be_nosys_mem_map,
+	.mem_unmap = xnvme_be_nosys_mem_unmap,
+#else
+	.buf_alloc = xnvme_be_nosys_buf_alloc,
+	.buf_realloc = xnvme_be_nosys_buf_realloc,
+	.buf_free = xnvme_be_nosys_buf_free,
+	.buf_vtophys = xnvme_be_nosys_buf_vtophys,
+	.mem_map = xnvme_be_nosys_mem_map,
+	.mem_unmap = xnvme_be_nosys_mem_unmap,
+#endif
+};

--- a/lib/dmamem/xnvme_be_dmamem_sync.c
+++ b/lib/dmamem/xnvme_be_dmamem_sync.c
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Simon A. F. Lund
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <libxnvme.h>
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_DMAMEM_ENABLED
+#include <xnvme_dev.h>
+#include <xnvme_be_dmamem.h>
+
+static int
+_submit_sync(struct nvme_qpair *qp, struct nvme_command *cmd, uint32_t timeout_ms,
+	     struct nvme_completion *cpl)
+{
+	int err;
+
+	err = nvme_qpair_enqueue(qp, cmd);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_qpair_enqueue(); err(%d)", err);
+		return err;
+	}
+	nvme_qpair_sqdb_update(qp);
+
+	err = nvme_qpair_reap_cpl(qp, timeout_ms, cpl);
+	if (err) {
+		XNVME_DEBUG("FAILED: nvme_qpair_reap_cpl(); err(%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int
+xnvme_be_dmamem_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			    size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_dmamem_state *state = (void *)ctx->dev->be.state;
+	struct nvme_controller *ctrl = state->ctrlr->ctrl;
+	struct nvme_qpair *qp = &state->ctrlr->sync;
+	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
+	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
+	struct nvme_request *req;
+	int err;
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_FS_OPC_READ:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	}
+
+	req = nvme_request_alloc(qp->rpool);
+	if (!req) {
+		XNVME_DEBUG("FAILED: nvme_request_alloc(); errno(%d)", errno);
+		return -errno;
+	}
+	req->user = ctx;
+	cmd->cid = req->cid;
+
+	if (dbuf) {
+		nvme_request_prep_command_prps_contig_dmamem(req, &g_dmamem_rte.heap, dbuf,
+							     dbuf_nbytes, cmd);
+	}
+	if (mbuf) {
+		cmd->mptr = dmamem_va_to_iova(&g_dmamem_rte.dmem, mbuf);
+	}
+
+	err = _submit_sync(qp, cmd, ctrl->timeout_ms, cpl);
+	nvme_request_free(qp->rpool, req->cid);
+
+	if (err || xnvme_cmd_ctx_cpl_status(ctx)) {
+		XNVME_DEBUG("FAILED: sync_cmd_io(); err(%d); sc(%d); sct(%d)", err,
+			    ctx->cpl.status.sc, ctx->cpl.status.sct);
+		return err;
+	}
+
+	return 0;
+}
+
+int
+xnvme_be_dmamem_sync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			     size_t XNVME_UNUSED(dvec_nbytes), void *mbuf,
+			     size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_dmamem_state *state = (void *)ctx->dev->be.state;
+	struct nvme_controller *ctrl = state->ctrlr->ctrl;
+	struct nvme_qpair *qp = &state->ctrlr->sync;
+	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
+	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
+	struct nvme_request *req;
+	int err;
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_FS_OPC_READ:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	}
+
+	req = nvme_request_alloc(qp->rpool);
+	if (!req) {
+		XNVME_DEBUG("FAILED: nvme_request_alloc(); errno(%d)", errno);
+		return -errno;
+	}
+	req->user = ctx;
+	cmd->cid = req->cid;
+
+	if (dvec) {
+		nvme_request_prep_command_prps_iov_dmamem(req, &g_dmamem_rte.heap, dvec, dvec_cnt,
+							  cmd);
+	}
+	if (mbuf) {
+		cmd->mptr = dmamem_va_to_iova(&g_dmamem_rte.dmem, mbuf);
+	}
+
+	err = _submit_sync(qp, cmd, ctrl->timeout_ms, cpl);
+	nvme_request_free(qp->rpool, req->cid);
+
+	if (err || xnvme_cmd_ctx_cpl_status(ctx)) {
+		XNVME_DEBUG("FAILED: sync_cmd_iov(); err(%d); sc(%d); sct(%d)", err,
+			    ctx->cpl.status.sc, ctx->cpl.status.sct);
+		return err;
+	}
+
+	return 0;
+}
+
+#endif
+
+struct xnvme_be_sync g_xnvme_be_dmamem_sync = {
+	.id = "dmamem",
+#ifdef XNVME_BE_DMAMEM_ENABLED
+	.cmd_io = xnvme_be_dmamem_sync_cmd_io,
+	.cmd_iov = xnvme_be_dmamem_sync_cmd_iov,
+#else
+	.cmd_io = xnvme_be_nosys_sync_cmd_io,
+	.cmd_iov = xnvme_be_nosys_sync_cmd_iov,
+#endif
+};

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -108,6 +108,7 @@ xnvmelib_deps = [
 ]
 
 subdir('upcie')
+subdir('dmamem')
 
 mapfile = 'libxnvme.map'
 # Version script is not supported by the linker on OSX

--- a/lib/xnvme_platform_linux.c
+++ b/lib/xnvme_platform_linux.c
@@ -359,6 +359,9 @@ struct xnvme_platform g_xnvme_platform_linux = {
 #ifdef XNVME_BE_UPCIE_HIP_ENABLED
 			&g_xnvme_be_upcie_hip,
 #endif
+#ifdef XNVME_BE_DMAMEM_ENABLED
+			&g_xnvme_be_dmamem,
+#endif
 			&g_xnvme_be_linux_emu_nvme,
 #ifdef XNVME_BE_LINUX_BLOCK_ENABLED
 			&g_xnvme_be_linux_emu_block,

--- a/meson.build
+++ b/meson.build
@@ -103,7 +103,8 @@ conf_data.set('XNVME_BE_CBI_SYNC_PSYNC_ENABLED', get_option('cbi_sync_psync') an
 
 conf_data.set('XNVME_BE_RAMDISK_ENABLED', get_option('be_ramdisk'))
 conf_data.set('XNVME_BE_UPCIE_ENABLED', get_option('be_upcie') and is_linux)
-if get_option('be_upcie') and is_linux
+conf_data.set('XNVME_BE_DMAMEM_ENABLED', get_option('be_dmamem') and is_linux)
+if (get_option('be_upcie') or get_option('be_dmamem')) and is_linux
   # uPCIe vendored headers (dmabuf.h: memfd_create + file sealing) need _GNU_SOURCE
   add_project_arguments('-D_GNU_SOURCE', language: 'c')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,7 @@ option('with-hip', type: 'feature', value: 'auto')
 
 option('be_ramdisk', type: 'boolean', value: true)
 option('be_upcie', type: 'boolean', value: true)
+option('be_dmamem', type: 'boolean', value: true)
 
 option('cbi_admin_shim', type: 'boolean', value: true)
 option('cbi_async_emu', type: 'boolean', value: true)

--- a/toolbox/third-party/linux/upcie/dmamem.h
+++ b/toolbox/third-party/linux/upcie/dmamem.h
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * DMA memory abstraction
+ * ======================
+ *
+ * A dmamem describes memory usable as a DMA source or destination,
+ * regardless of which exporter produced it (memfd hugepage, CUDA VRAM,
+ * HIP VRAM, libdrm BO, VFIO BAR) and regardless of which kernel API
+ * installed the DMA mapping. Cousin of the kernel's dma-buf, at the
+ * layer above.
+ *
+ * A dmamem holds an fd, an optional CPU virtual address (NULL for peer
+ * memory that is not CPU-mappable), a size, and enough state to turn a
+ * caller-chosen offset into the DMA address the device expects. Two
+ * translation shapes live behind the same public call:
+ *
+ *   ARITHMETIC: iova = base_iova + offset. Used whenever a real IOMMU
+ *   mapping (iommufd IOAS or vfio type1 container) installed a single
+ *   contiguous IOVA range for the whole dmamem. The dmamem stashes
+ *   base_iova at construction and the submit path adds. No lookup.
+ *
+ *   LUT: iova = phys_lut[offset >> hugepgsz_shift] + (offset & mask).
+ *   Used when no IOMMU mapping was installed (uio_pci_generic with
+ *   iommu=pt/off) and the device consumes physical addresses directly.
+ *   The dmamem stashes a borrowed per-hugepage PA table and reads it on
+ *   submit. One extra load and a shift compared to the arithmetic
+ *   fastpath; identical shape to the retired hostmem_dma_v2p.
+ *
+ * dmamem_va_to_iova branches once on the translator. When a caller
+ * uses one translator throughout (which is the typical shape, e.g.
+ * an xNVMe be_dmamem process runs exactly one), that branch has a
+ * stable direction; branch-prediction cost is not measured here.
+ *
+ * Mapping context. Each dmamem stashes at most one owner pointer:
+ * either an iommufd handle + IOAS id, or a legacy vfio type1 container,
+ * or neither. dmamem_destroy dispatches on whichever is set (or does
+ * nothing for LUT dmamems with no mapping installed).
+ *
+ * Constructors split into two families.
+ *
+ *   Owned constructors allocate the backing themselves and hold the
+ *   fd / CPU view for the lifetime of the dmamem: dmamem_from_memfd()
+ *   creates a hugepage-backed memfd internally; dmamem_from_dmabuf()
+ *   takes an existing dma-buf fd from an exporter (VFIO BAR export,
+ *   CUDA / HIP / libdrm export). Both set owned=1 so dmamem_destroy()
+ *   munmaps and closes on the way out.
+ *
+ *   Wrapping constructors install a mapping (or install a translator
+ *   without a mapping, for the LUT case) over memory the caller already
+ *   owns; they set owned=0 so dmamem_destroy() only removes the mapping.
+ *   dmamem_from_hostmem_iommufd(), _type1(), and _lut() live in
+ *   dmamem_hostmem.h and wrap an existing hostmem_hugepage.
+ *
+ * @file dmamem.h
+ * @version 0.5.2
+ */
+
+enum dmamem_backing {
+	DMAMEM_BACKING_UNKNOWN = 0x0,
+	DMAMEM_BACKING_MEMFD = 0x1,
+	DMAMEM_BACKING_DMABUF = 0x2,
+	DMAMEM_BACKING_HOSTMEM = 0x3, ///< wrapping an existing hostmem_hugepage
+	DMAMEM_BACKING_CUDAMEM = 0x4, ///< wrapping an existing cudamem_heap
+	DMAMEM_BACKING_HIPMEM = 0x5,  ///< wrapping an existing hipmem_heap
+};
+
+/**
+ * How offsets resolve to DMA addresses at submission.
+ *
+ * ARITHMETIC = 0 by intent: a memset-to-zero dmamem is arithmetic by
+ * default, which is what every current owned constructor produces
+ * without extra code.
+ */
+enum dmamem_translator {
+	DMAMEM_XLATE_ARITHMETIC = 0x0, ///< iova = base_iova + offset
+	DMAMEM_XLATE_LUT = 0x1,        ///< iova = phys_lut[off >> shift] + (off & mask)
+};
+
+/* Forward-declare so dmamem.h stays independent of vfioctl.h include
+ * order in the umbrella header. */
+struct vfio_container;
+
+/**
+ * A DMA-capable memory region.
+ *
+ * At most one of iommufd or vfio_container is set, identifying the
+ * kernel API that installed the mapping and, on destroy, the unmap
+ * ioctl to invoke. LUT-translator dmamems have neither set; no mapping
+ * was installed and destroy has nothing to undo.
+ */
+struct dmamem {
+	int fd;                     ///< memfd or dma-buf when owned=1; -1 when wrapping
+	void *cpu_va;               ///< CPU virtual address, NULL when not mappable
+	size_t size;                ///< Size in bytes
+	uint64_t base_iova;         ///< Base IOVA (ARITHMETIC translator only)
+	uint32_t ioas_id;           ///< IOAS the mapping lives in (iommufd only)
+	struct iommufd *iommufd;    ///< Not owned; caller lifetime. NULL for type1 and LUT.
+	struct vfio_container *vfio_container; ///< Not owned; caller lifetime. NULL for iommufd and LUT.
+	enum dmamem_backing backing;
+	enum dmamem_translator translator; ///< How offsets resolve to DMA addresses
+	const uint64_t *phys_lut;   ///< Borrowed per-hugepage PA table (LUT only)
+	size_t hugepgsz;            ///< Hugepage size in bytes (LUT only)
+	int hugepgsz_shift;         ///< log2(hugepgsz) (LUT only)
+	int owned;                  ///< 1: dmamem owns fd + cpu_va; 0: wrapping caller memory
+};
+
+/**
+ * Print information about the given dmamem
+ */
+static inline int
+dmamem_pp(struct dmamem *dmem)
+{
+	int wrtn = 0;
+
+	wrtn += printf("dmamem:");
+
+	if (!dmem) {
+		wrtn += printf(" ~\n");
+		return 0;
+	}
+
+	wrtn += printf("\n");
+	wrtn += printf("  fd: %d\n", dmem->fd);
+	wrtn += printf("  cpu_va: %p\n", dmem->cpu_va);
+	wrtn += printf("  size: %zu\n", dmem->size);
+	wrtn += printf("  base_iova: 0x%" PRIx64 "\n", dmem->base_iova);
+	wrtn += printf("  ioas_id: %u\n", dmem->ioas_id);
+	wrtn += printf("  iommufd.fd: %d\n", dmem->iommufd ? dmem->iommufd->fd : -1);
+	wrtn += printf("  vfio_container: %s\n", dmem->vfio_container ? "set" : "none");
+	wrtn += printf("  backing: %d\n", dmem->backing);
+	wrtn += printf("  translator: %s\n",
+		       dmem->translator == DMAMEM_XLATE_LUT          ? "LUT"
+		       : dmem->translator == DMAMEM_XLATE_ARITHMETIC ? "ARITHMETIC"
+								     : "?");
+	if (DMAMEM_XLATE_LUT == dmem->translator) {
+		wrtn += printf("  phys_lut: %p\n", (void *)dmem->phys_lut);
+		wrtn += printf("  hugepgsz: %zu\n", dmem->hugepgsz);
+		wrtn += printf("  hugepgsz_shift: %d\n", dmem->hugepgsz_shift);
+	}
+	wrtn += printf("  owned: %d\n", dmem->owned);
+
+	return wrtn;
+}
+
+/**
+ * Compute log2 of a supported LUT page size.
+ *
+ * Accepts 4 KiB, 2 MiB, and 1 GiB; returns -1 for anything else. Used
+ * by the LUT-translator importers so the fastpath does a shift + AND
+ * instead of a divide + modulo.
+ */
+static inline int
+dmamem_lut_pagesize_shift(size_t pagesize)
+{
+	if (pagesize == 4096) {
+		return 12;
+	}
+	if (pagesize == 2ULL * 1024 * 1024) {
+		return 21;
+	}
+	if (pagesize == 1024ULL * 1024 * 1024) {
+		return 30;
+	}
+	return -1;
+}
+
+/**
+ * Convert an offset inside the dmamem to an IOVA.
+ *
+ * The submission-path function. One compare on dmem->translator,
+ * then either a single addition (ARITHMETIC) or a shift + table
+ * lookup + addition (LUT).
+ */
+static inline uint64_t
+dmamem_offset_to_iova(struct dmamem *dmem, size_t offset)
+{
+	if (DMAMEM_XLATE_LUT == dmem->translator) {
+		return dmem->phys_lut[offset >> dmem->hugepgsz_shift] +
+		       (offset & (dmem->hugepgsz - 1));
+	}
+
+	return dmem->base_iova + offset;
+}
+
+/**
+ * Convert a CPU VA inside the dmamem to an IOVA.
+ *
+ * Only usable when the backing exposes a CPU VA. Callers must assert
+ * dmem->cpu_va != NULL before invoking; the fast path does not check.
+ */
+static inline uint64_t
+dmamem_va_to_iova(struct dmamem *dmem, void *vaddr)
+{
+	assert(dmem->cpu_va);
+	return dmamem_offset_to_iova(dmem, (size_t)((char *)vaddr - (char *)dmem->cpu_va));
+}
+
+/**
+ * Unmap the dmamem via whichever kernel API installed the mapping and,
+ * if the dmamem owns its memfd + CPU view, munmap and close it.
+ * Wrapping dmamems (owned=0) leave fd + cpu_va alone since another
+ * owner manages their lifetime. LUT-translator dmamems have no mapping
+ * to undo and (typically) do not own memory either, so destroy reduces
+ * to the trailing memset.
+ */
+static inline void
+dmamem_destroy(struct dmamem *dmem)
+{
+	if (!dmem) {
+		return;
+	}
+
+	if (dmem->iommufd && dmem->size) {
+		int err = iommufd_ioas_unmap(dmem->iommufd, dmem->ioas_id, dmem->base_iova,
+					     dmem->size);
+		if (err) {
+			UPCIE_DEBUG("FAILED: iommufd_ioas_unmap(); err(%d)", err);
+		}
+	}
+
+	if (dmem->vfio_container && dmem->size) {
+		struct vfio_iommu_type1_dma_unmap unmap = {0};
+		unmap.argsz = sizeof(unmap);
+		unmap.iova = dmem->base_iova;
+		unmap.size = dmem->size;
+		if (vfio_iommu_unmap_dma(dmem->vfio_container, &unmap) < 0) {
+			UPCIE_DEBUG("FAILED: vfio_iommu_unmap_dma(); errno(%d)", errno);
+		}
+	}
+
+	if (dmem->owned && dmem->cpu_va && dmem->size) {
+		munmap(dmem->cpu_va, dmem->size);
+	}
+
+	if (dmem->owned && dmem->fd >= 0) {
+		close(dmem->fd);
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+}

--- a/toolbox/third-party/linux/upcie/dmamem_cuda.h
+++ b/toolbox/third-party/linux/upcie/dmamem_cuda.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem constructor: wrap an existing cudamem_heap (LUT translator)
+ * ==================================================================
+ *
+ * Closes the "CPU-init + CUDA VRAM + iommu=pt/off" cell of the grid by
+ * borrowing an already-populated cudamem_heap. The heap has already
+ * done the heavy lifting: cuMemAlloc for the device VA range,
+ * cuMemGetHandleForAddressRange to export the range as a dma-buf,
+ * dmabuf_attach + dmabuf_get_lut to enumerate per-device-page PAs into
+ * heap->phys_lut. This constructor just points the LUT-translator
+ * fields on struct dmamem at the already-populated table and marks the
+ * dmamem as wrapping (owned=0) so destroy does not touch the heap's
+ * lifetime.
+ *
+ * The heap's device VA is NOT CPU-mappable; dmem->cpu_va is left NULL,
+ * and callers compose PRPs via dmamem_offset_to_iova() with offsets
+ * measured from heap->vaddr.
+ *
+ * @file dmamem_cuda.h
+ * @version 0.5.2
+ */
+
+/**
+ * Wrap an existing cudamem_heap as a LUT-translator dmamem.
+ *
+ * The cudamem_heap must have been initialised via cudamem_heap_init so
+ * heap->phys_lut is already populated. No new CUDA calls are made
+ * here; the dmamem borrows the LUT and every dmamem_offset_to_iova
+ * lands as heap->phys_lut[offset >> shift] + intra-page offset.
+ *
+ * @param dmem  Pre-allocated dmamem descriptor to fill.
+ * @param heap  Initialised cudamem_heap to borrow.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+dmamem_from_cuda_lut(struct dmamem *dmem, struct cudamem_heap *heap)
+{
+	int shift;
+
+	if (!dmem || !heap || !heap->phys_lut || !heap->config) {
+		return -EINVAL;
+	}
+
+	shift = dmamem_lut_pagesize_shift(heap->config->device_pagesize);
+	if (shift < 0) {
+		UPCIE_DEBUG("FAILED: unsupported device_pagesize(%zu)",
+			    (size_t)heap->config->device_pagesize);
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+	dmem->cpu_va = NULL; /* Device VA; not CPU-mappable. Callers use offsets. */
+	dmem->size = heap->size;
+	dmem->backing = DMAMEM_BACKING_CUDAMEM;
+	dmem->translator = DMAMEM_XLATE_LUT;
+	dmem->phys_lut = heap->phys_lut;
+	dmem->hugepgsz = heap->config->device_pagesize;
+	dmem->hugepgsz_shift = shift;
+	dmem->owned = 0;
+
+	return 0;
+}

--- a/toolbox/third-party/linux/upcie/dmamem_dmabuf.h
+++ b/toolbox/third-party/linux/upcie/dmamem_dmabuf.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem constructor: from an existing dma-buf fd
+ * ===============================================
+ *
+ * Takes a dma-buf fd from any exporter (udmabuf host memory, CUDA VMM,
+ * HIP, libdrm/PRIME, VFIO_DEVICE_FEATURE_DMA_BUF) and imports it into an
+ * iommufd IOAS via IOMMU_IOAS_MAP_FILE. This is the entry point that
+ * answers the "does iommufd's MAP_FILE accept dma-buf-backed fds today?"
+ * question against a running kernel; a failure at the ioctl surfaces the
+ * exact errno so the block (kernel-side, exporter-side, or IOAS
+ * configuration) resolves to a concrete signal.
+ *
+ * The dmamem takes ownership of the dma-buf fd on success and closes it
+ * as part of dmamem_destroy. On failure the caller retains ownership and
+ * must close the fd itself.
+ *
+ * Whether the resulting dmamem exposes a CPU VA is up to the exporter.
+ * udmabuf-backed dma-bufs are CPU-mappable; VRAM-backed dma-bufs from the
+ * GPU runtimes usually are not. If mmap on the dma-buf fd fails we leave
+ * cpu_va NULL and rely on offset-based access.
+ *
+ * @file dmamem_dmabuf.h
+ * @version 0.5.2
+ */
+
+/**
+ * Import an existing dma-buf fd into the given IOAS as a dmamem.
+ *
+ * @param dmem       Pre-allocated dmamem descriptor to fill.
+ * @param iommufd    Open iommufd handle (caller-owned).
+ * @param ioas_id    Target IOAS in the iommufd context.
+ * @param dmabuf_fd  Open dma-buf fd from any exporter.
+ * @param size       Size of the range to map.
+ *
+ * @return 0 on success (dmamem now owns dmabuf_fd), negative errno on
+ * error (caller retains dmabuf_fd).
+ */
+static inline int
+dmamem_from_dmabuf(struct dmamem *dmem, struct iommufd *iommufd, uint32_t ioas_id, int dmabuf_fd,
+		   size_t size)
+{
+	void *cpu_va;
+	int err;
+
+	if (!dmem || !iommufd || iommufd->fd < 0 || dmabuf_fd < 0 || !size) {
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = dmabuf_fd;
+	dmem->iommufd = iommufd;
+	dmem->ioas_id = ioas_id;
+	dmem->size = size;
+	dmem->backing = DMAMEM_BACKING_DMABUF;
+	dmem->translator = DMAMEM_XLATE_ARITHMETIC;
+	dmem->owned = 1;
+
+	/*
+	 * CPU-mappability is exporter-dependent. Try mmap; leave cpu_va
+	 * NULL on failure. This is diagnostic, not fatal.
+	 */
+	cpu_va = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, dmabuf_fd, 0);
+	if (cpu_va != MAP_FAILED) {
+		dmem->cpu_va = cpu_va;
+	}
+
+	err = iommufd_ioas_map_file(iommufd, ioas_id, dmabuf_fd, 0, size,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE,
+				    &dmem->base_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_ioas_map_file(dma-buf); err(%d)", err);
+		if (dmem->cpu_va) {
+			munmap(dmem->cpu_va, size);
+			dmem->cpu_va = NULL;
+		}
+		memset(dmem, 0, sizeof(*dmem));
+		dmem->fd = -1;
+		return err;
+	}
+
+	return 0;
+}

--- a/toolbox/third-party/linux/upcie/dmamem_heap.h
+++ b/toolbox/third-party/linux/upcie/dmamem_heap.h
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem_heap: sub-allocator over a dmamem range
+ * ==============================================
+ *
+ * A minimal offset-space allocator over the (base_iova, size) window of a
+ * dmamem. Block metadata lives out-of-band in host memory (a malloc'd
+ * freelist), not embedded in the dmamem range itself, so the same
+ * allocator works for backings that are not CPU-mappable (VRAM, MMIO).
+ *
+ * Convenience accessors return the CPU VA of an allocation when
+ * available (memfd backing) and always return the IOVA (all backings).
+ *
+ * @file dmamem_heap.h
+ * @version 0.5.2
+ */
+
+struct dmamem_heap_block {
+	size_t offset;
+	size_t size;
+	int free;
+	struct dmamem_heap_block *next;
+};
+
+struct dmamem_heap {
+	struct dmamem *dmem;                 ///< Not owned; caller owns lifetime
+	struct dmamem_heap_block *freelist;  ///< Head of the freelist (offset-ordered)
+	size_t alignment;                    ///< Default allocation alignment in bytes
+};
+
+static inline int
+dmamem_heap_pp(struct dmamem_heap *heap)
+{
+	int wrtn = 0;
+
+	wrtn += printf("dmamem_heap:");
+
+	if (!heap) {
+		wrtn += printf(" ~\n");
+		return 0;
+	}
+
+	wrtn += printf("\n");
+	wrtn += printf("  alignment: %zu\n", heap->alignment);
+	wrtn += printf("  freelist:\n");
+	for (struct dmamem_heap_block *b = heap->freelist; b; b = b->next) {
+		wrtn += printf("  - {offset: %zu, size: %zu, free: %d}\n", b->offset, b->size,
+			       b->free);
+	}
+
+	return wrtn;
+}
+
+/**
+ * Initialise a heap over the given dmamem.
+ *
+ * The dmamem must already be constructed and mapped. The heap does not
+ * take ownership of dmem; the caller's dmamem_destroy is what releases
+ * the memory.
+ */
+static inline int
+dmamem_heap_init(struct dmamem_heap *heap, struct dmamem *dmem, size_t alignment)
+{
+	struct dmamem_heap_block *block;
+
+	if (!heap || !dmem || !alignment) {
+		return -EINVAL;
+	}
+
+	memset(heap, 0, sizeof(*heap));
+	heap->dmem = dmem;
+	heap->alignment = alignment;
+
+	block = calloc(1, sizeof(*block));
+	if (!block) {
+		return -ENOMEM;
+	}
+	block->offset = 0;
+	block->size = dmem->size;
+	block->free = 1;
+	block->next = NULL;
+
+	heap->freelist = block;
+
+	return 0;
+}
+
+/**
+ * Release the freelist. The underlying dmamem is not touched.
+ */
+static inline void
+dmamem_heap_term(struct dmamem_heap *heap)
+{
+	struct dmamem_heap_block *b;
+
+	if (!heap) {
+		return;
+	}
+
+	b = heap->freelist;
+	while (b) {
+		struct dmamem_heap_block *next = b->next;
+		free(b);
+		b = next;
+	}
+
+	memset(heap, 0, sizeof(*heap));
+}
+
+/**
+ * Allocate a sub-range of the heap.
+ *
+ * On success, *offset_out is the offset of the allocation within the
+ * dmamem. Alignment is the heap's default; use dmamem_heap_alloc_aligned
+ * for a stricter constraint.
+ *
+ * @return 0 on success; -ENOMEM if the heap is full or fragmented past
+ * the requested size; negative errno on input error.
+ */
+static inline int
+dmamem_heap_alloc_aligned(struct dmamem_heap *heap, size_t size, size_t alignment,
+			  size_t *offset_out)
+{
+	struct dmamem_heap_block *b, *tail;
+
+	if (!heap || !size || !alignment || !offset_out) {
+		return -EINVAL;
+	}
+
+	for (b = heap->freelist; b; b = b->next) {
+		size_t aligned_offset, front_gap, remaining;
+
+		if (!b->free) {
+			continue;
+		}
+
+		aligned_offset = (b->offset + alignment - 1) & ~(alignment - 1);
+		front_gap = aligned_offset - b->offset;
+
+		if (b->size < front_gap + size) {
+			continue;
+		}
+
+		remaining = b->size - front_gap - size;
+
+		/* Carve off the front gap if any. */
+		if (front_gap) {
+			struct dmamem_heap_block *fg = calloc(1, sizeof(*fg));
+			if (!fg) {
+				return -ENOMEM;
+			}
+			fg->offset = b->offset;
+			fg->size = front_gap;
+			fg->free = 1;
+			fg->next = b;
+			/* Rewire predecessor into fg. */
+			if (heap->freelist == b) {
+				heap->freelist = fg;
+			} else {
+				struct dmamem_heap_block *p = heap->freelist;
+				while (p->next != b) {
+					p = p->next;
+				}
+				p->next = fg;
+			}
+			b->offset = aligned_offset;
+			b->size -= front_gap;
+		}
+
+		/* Carve off the tail if any. */
+		if (remaining) {
+			tail = calloc(1, sizeof(*tail));
+			if (!tail) {
+				return -ENOMEM;
+			}
+			tail->offset = b->offset + size;
+			tail->size = remaining;
+			tail->free = 1;
+			tail->next = b->next;
+			b->next = tail;
+			b->size = size;
+		}
+
+		b->free = 0;
+		*offset_out = b->offset;
+		return 0;
+	}
+
+	return -ENOMEM;
+}
+
+static inline int
+dmamem_heap_alloc(struct dmamem_heap *heap, size_t size, size_t *offset_out)
+{
+	return dmamem_heap_alloc_aligned(heap, size, heap->alignment, offset_out);
+}
+
+/**
+ * Free a previously-allocated range and coalesce with adjacent free blocks.
+ */
+static inline void
+dmamem_heap_free(struct dmamem_heap *heap, size_t offset)
+{
+	struct dmamem_heap_block *b, *prev = NULL;
+
+	if (!heap) {
+		return;
+	}
+
+	for (b = heap->freelist; b; prev = b, b = b->next) {
+		if (b->offset == offset) {
+			break;
+		}
+	}
+	if (!b) {
+		UPCIE_DEBUG("FAILED: no block at offset(%zu)", offset);
+		return;
+	}
+
+	b->free = 1;
+
+	/* Coalesce with the successor if free and contiguous. */
+	if (b->next && b->next->free && b->offset + b->size == b->next->offset) {
+		struct dmamem_heap_block *n = b->next;
+		b->size += n->size;
+		b->next = n->next;
+		free(n);
+	}
+
+	/* Coalesce with the predecessor if free and contiguous. */
+	if (prev && prev->free && prev->offset + prev->size == b->offset) {
+		prev->size += b->size;
+		prev->next = b->next;
+		free(b);
+	}
+}
+
+/**
+ * Return the CPU VA of an allocation, or NULL for non-CPU-mappable backings.
+ */
+static inline void *
+dmamem_heap_at_va(struct dmamem_heap *heap, size_t offset)
+{
+	if (!heap || !heap->dmem || !heap->dmem->cpu_va) {
+		return NULL;
+	}
+	return (char *)heap->dmem->cpu_va + offset;
+}
+
+/**
+ * Return the IOVA of an allocation.
+ *
+ * Delegates to dmamem_offset_to_iova so the LUT translator resolves
+ * correctly. In the arithmetic case this remains base_iova + offset.
+ */
+static inline uint64_t
+dmamem_heap_at_iova(struct dmamem_heap *heap, size_t offset)
+{
+	return dmamem_offset_to_iova(heap->dmem, offset);
+}

--- a/toolbox/third-party/linux/upcie/dmamem_hip.h
+++ b/toolbox/third-party/linux/upcie/dmamem_hip.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem constructor: wrap an existing hipmem_heap (LUT translator)
+ * =================================================================
+ *
+ * Closes the "CPU-init + HIP VRAM + iommu=pt/off" cell of the grid by
+ * borrowing an already-populated hipmem_heap. The heap has already
+ * called hipMalloc for the device VA range,
+ * hipMemGetHandleForAddressRange to export as a dma-buf,
+ * dmabuf_attach + dmabuf_get_lut to enumerate per-device-page PAs into
+ * heap->phys_lut. This constructor just points the LUT-translator
+ * fields on struct dmamem at the already-populated table and marks the
+ * dmamem as wrapping (owned=0) so destroy does not touch the heap's
+ * lifetime.
+ *
+ * The heap's device VA is NOT CPU-mappable; dmem->cpu_va is left NULL,
+ * and callers compose PRPs via dmamem_offset_to_iova() with offsets
+ * measured from heap->vaddr.
+ *
+ * @file dmamem_hip.h
+ * @version 0.5.2
+ */
+
+/**
+ * Wrap an existing hipmem_heap as a LUT-translator dmamem.
+ *
+ * The hipmem_heap must have been initialised via hipmem_heap_init so
+ * heap->phys_lut is already populated. No new HIP calls are made here;
+ * the dmamem borrows the LUT and every dmamem_offset_to_iova lands as
+ * heap->phys_lut[offset >> shift] + intra-page offset.
+ *
+ * @param dmem  Pre-allocated dmamem descriptor to fill.
+ * @param heap  Initialised hipmem_heap to borrow.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+dmamem_from_hip_lut(struct dmamem *dmem, struct hipmem_heap *heap)
+{
+	int shift;
+
+	if (!dmem || !heap || !heap->phys_lut || !heap->config) {
+		return -EINVAL;
+	}
+
+	shift = dmamem_lut_pagesize_shift(heap->config->device_pagesize);
+	if (shift < 0) {
+		UPCIE_DEBUG("FAILED: unsupported device_pagesize(%zu)",
+			    (size_t)heap->config->device_pagesize);
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+	dmem->cpu_va = NULL; /* Device VA; not CPU-mappable. Callers use offsets. */
+	dmem->size = heap->size;
+	dmem->backing = DMAMEM_BACKING_HIPMEM;
+	dmem->translator = DMAMEM_XLATE_LUT;
+	dmem->phys_lut = heap->phys_lut;
+	dmem->hugepgsz = heap->config->device_pagesize;
+	dmem->hugepgsz_shift = shift;
+	dmem->owned = 0;
+
+	return 0;
+}

--- a/toolbox/third-party/linux/upcie/dmamem_hostmem.h
+++ b/toolbox/third-party/linux/upcie/dmamem_hostmem.h
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem constructors: wrap an existing hostmem_hugepage
+ * ======================================================
+ *
+ * The hostmem side already owns hugepage allocation (hostmem_hugepage)
+ * and the buffer allocator (hostmem_heap). What the vfio + iommufd
+ * world needs on top is a single contiguous IOVA mapping over the whole
+ * hostmem region so submission computes PRPs as
+ * iova = base_iova + (va - hostmem_va); the uio + iommu=pt/off world
+ * needs a translator that returns the borrowed phys_lut PA of the
+ * hosting hugepage plus the intra-hugepage offset. Both live behind the
+ * same dmamem_va_to_iova call, discriminated by the translator field.
+ *
+ * Three flavours, one per (engine, translator) shape:
+ *
+ *   dmamem_from_hostmem_iommufd(...) uses IOMMU_IOAS_MAP against the
+ *   hostmem VA range and records the kernel-picked base IOVA.
+ *   translator = ARITHMETIC.
+ *
+ *   dmamem_from_hostmem_type1(...) uses VFIO_IOMMU_MAP_DMA against a
+ *   caller-chosen base IOVA (type1 has no "kernel picks" mode).
+ *   translator = ARITHMETIC.
+ *
+ *   dmamem_from_hostmem_lut(...) installs no mapping. Borrows the
+ *   hugepage's phys_lut for translation so PRPs are PAs. Used with
+ *   uio_pci_generic + iommu=pt/off. translator = LUT.
+ *
+ * All three carry owned=0 so dmamem_destroy() only undoes the DMA
+ * mapping (or nothing, for the LUT case); the hostmem_hugepage stays
+ * with its original owner.
+ *
+ * @file dmamem_hostmem.h
+ * @version 0.5.2
+ */
+
+/**
+ * Wrap an existing hostmem_hugepage as a dmamem via iommufd.
+ *
+ * Installs one IOMMU_IOAS_MAP over the hugepage VA range and records the
+ * kernel-picked base IOVA in dmem->base_iova.
+ */
+static inline int
+dmamem_from_hostmem_iommufd(struct dmamem *dmem, struct iommufd *iommufd, uint32_t ioas_id,
+			    struct hostmem_hugepage *hp)
+{
+	int err;
+
+	if (!dmem || !iommufd || iommufd->fd < 0 || !hp || !hp->virt || !hp->size) {
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+	dmem->cpu_va = hp->virt;
+	dmem->size = hp->size;
+	dmem->iommufd = iommufd;
+	dmem->ioas_id = ioas_id;
+	dmem->backing = DMAMEM_BACKING_HOSTMEM;
+	dmem->translator = DMAMEM_XLATE_ARITHMETIC;
+	dmem->owned = 0;
+
+	err = iommufd_ioas_map(iommufd, ioas_id, (uint64_t)(uintptr_t)dmem->cpu_va, dmem->size,
+			       IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE,
+			       &dmem->base_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_ioas_map(); err(%d)", err);
+		memset(dmem, 0, sizeof(*dmem));
+		dmem->fd = -1;
+		return err;
+	}
+
+	return 0;
+}
+
+/**
+ * Wrap an existing hostmem_hugepage as a dmamem via a vfio type1
+ * container.
+ *
+ * Installs one VFIO_IOMMU_MAP_DMA over the hugepage VA range at the
+ * caller-chosen base IOVA. type1 has no "kernel picks IOVA" mode.
+ */
+static inline int
+dmamem_from_hostmem_type1(struct dmamem *dmem, struct vfio_container *container, uint64_t base_iova,
+			  struct hostmem_hugepage *hp)
+{
+	struct vfio_iommu_type1_dma_map map = {0};
+	int err;
+
+	if (!dmem || !container || !hp || !hp->virt || !hp->size) {
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+	dmem->cpu_va = hp->virt;
+	dmem->size = hp->size;
+	dmem->base_iova = base_iova;
+	dmem->vfio_container = container;
+	dmem->backing = DMAMEM_BACKING_HOSTMEM;
+	dmem->translator = DMAMEM_XLATE_ARITHMETIC;
+	dmem->owned = 0;
+
+	map.argsz = sizeof(map);
+	map.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE;
+	map.vaddr = (uintptr_t)dmem->cpu_va;
+	map.iova = base_iova;
+	map.size = dmem->size;
+	if (vfio_iommu_map_dma(container, &map) < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_iommu_map_dma(); errno(%d)", errno);
+		memset(dmem, 0, sizeof(*dmem));
+		dmem->fd = -1;
+		return err;
+	}
+
+	return 0;
+}
+
+/**
+ * Wrap an existing hostmem_hugepage as a LUT-translator dmamem.
+ *
+ * For uio_pci_generic + iommu=pt / iommu=off: no IOMMU mapping is
+ * installed and DMA addresses are physical, resolved at submission
+ * through the hugepage's phys_lut. No ioctl here, nothing for
+ * dmamem_destroy to undo; a pure translator adapter over borrowed
+ * state. Requires hp->phys_lut != NULL, which means the pagemap read
+ * at hostmem_hugepage_alloc time succeeded (i.e. the process has
+ * CAP_SYS_ADMIN).
+ */
+static inline int
+dmamem_from_hostmem_lut(struct dmamem *dmem, struct hostmem_hugepage *hp)
+{
+	int shift;
+
+	if (!dmem || !hp || !hp->virt || !hp->size || !hp->phys_lut || !hp->config) {
+		return -EINVAL;
+	}
+
+	shift = dmamem_lut_pagesize_shift(hp->config->hugepgsz);
+	if (shift < 0) {
+		UPCIE_DEBUG("FAILED: unsupported hugepgsz(%zu)", hp->config->hugepgsz);
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+	dmem->cpu_va = hp->virt;
+	dmem->size = hp->size;
+	dmem->backing = DMAMEM_BACKING_HOSTMEM;
+	dmem->translator = DMAMEM_XLATE_LUT;
+	dmem->phys_lut = hp->phys_lut;
+	dmem->hugepgsz = hp->config->hugepgsz;
+	dmem->hugepgsz_shift = shift;
+	dmem->owned = 0;
+
+	return 0;
+}

--- a/toolbox/third-party/linux/upcie/dmamem_memfd.h
+++ b/toolbox/third-party/linux/upcie/dmamem_memfd.h
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem constructor: hugepage-backed memfd
+ * =========================================
+ *
+ * Creates a memfd backed by hugepages (memfd_create(MFD_HUGETLB | ...)),
+ * mmaps it for CPU access, and imports the range into an iommufd IOAS
+ * with a single IOMMU_IOAS_MAP_FILE call. The result is a dmamem whose
+ * cpu_va is the mmap base and whose base_iova is the kernel-picked IOVA.
+ *
+ * Caveat: the hugepage pool must be reserved out-of-band (see the
+ * `hugepages` CLI or `echo N > /proc/sys/vm/nr_hugepages`), and the
+ * process must have IPC_LOCK / adequate memlock limits.
+ *
+ * @file dmamem_memfd.h
+ * @version 0.5.2
+ */
+
+#ifndef MFD_HUGE_2MB
+#define MFD_HUGE_2MB (21 << 26)
+#endif
+#ifndef MFD_HUGE_1GB
+#define MFD_HUGE_1GB (30 << 26)
+#endif
+
+/**
+ * Allocate a hugepage-backed memfd and map it into the given IOAS.
+ *
+ * @param dmem     Pre-allocated dmamem descriptor to fill.
+ * @param iommufd  Open iommufd handle (caller-owned).
+ * @param ioas_id  Target IOAS in the iommufd context.
+ * @param size     Size in bytes; must be a multiple of hugepgsz.
+ * @param hugepgsz Hugepage size in bytes; must be 2 MiB or 1 GiB.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+dmamem_from_memfd(struct dmamem *dmem, struct iommufd *iommufd, uint32_t ioas_id, size_t size,
+		  size_t hugepgsz)
+{
+	unsigned int memfd_flags = MFD_HUGETLB;
+	int err;
+
+	if (!dmem || !iommufd || iommufd->fd < 0 || !size) {
+		return -EINVAL;
+	}
+
+	if (size % hugepgsz) {
+		UPCIE_DEBUG("FAILED: size(%zu) not a multiple of hugepgsz(%zu)", size, hugepgsz);
+		return -EINVAL;
+	}
+
+	if (hugepgsz == 2ULL * 1024 * 1024) {
+		memfd_flags |= MFD_HUGE_2MB;
+	} else if (hugepgsz == 1024ULL * 1024 * 1024) {
+		memfd_flags |= MFD_HUGE_1GB;
+	} else {
+		UPCIE_DEBUG("FAILED: unsupported hugepgsz(%zu)", hugepgsz);
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = -1;
+	dmem->iommufd = iommufd;
+	dmem->ioas_id = ioas_id;
+	dmem->size = size;
+	dmem->backing = DMAMEM_BACKING_MEMFD;
+	dmem->translator = DMAMEM_XLATE_ARITHMETIC;
+	dmem->owned = 1;
+
+	dmem->fd = syscall(SYS_memfd_create, "dmamem", memfd_flags);
+	if (dmem->fd < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: memfd_create(); errno(%d)", errno);
+		return err;
+	}
+
+	if (ftruncate(dmem->fd, size) != 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: ftruncate(); errno(%d)", errno);
+		goto err_close;
+	}
+
+	dmem->cpu_va = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, dmem->fd, 0);
+	if (dmem->cpu_va == MAP_FAILED) {
+		err = -errno;
+		dmem->cpu_va = NULL;
+		UPCIE_DEBUG("FAILED: mmap(); errno(%d)", errno);
+		goto err_close;
+	}
+
+	if (mlock(dmem->cpu_va, size) != 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: mlock(); errno(%d)", errno);
+		goto err_munmap;
+	}
+
+	/*
+	 * Zero the range to fault in and pin every backing hugepage before
+	 * the IOAS map. Otherwise IOMMU_IOAS_MAP_FILE may pin a partial or
+	 * still-being-materialised range.
+	 */
+	memset(dmem->cpu_va, 0, size);
+
+	/*
+	 * Ask the kernel to pick an IOVA (FIXED_IOVA not set). base_iova is
+	 * an OUT parameter to iommufd_ioas_map_file(); the returned value is
+	 * the base of the contiguous IOVA window the kernel installed.
+	 */
+	err = iommufd_ioas_map_file(iommufd, ioas_id, dmem->fd, 0, size,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE,
+				    &dmem->base_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_ioas_map_file(); err(%d)", err);
+		goto err_munmap;
+	}
+
+	return 0;
+
+err_munmap:
+	munmap(dmem->cpu_va, size);
+	dmem->cpu_va = NULL;
+err_close:
+	close(dmem->fd);
+	dmem->fd = -1;
+	return err;
+}

--- a/toolbox/third-party/linux/upcie/hostmem_heap.h
+++ b/toolbox/third-party/linux/upcie/hostmem_heap.h
@@ -36,7 +36,7 @@
  * also gains access to those physical addresses—without needing CAP_SYS_ADMIN.
  *
  * @file hostmem.h
- * @version 0.5.1
+ * @version 0.5.2
  */
 
 /**
@@ -98,7 +98,12 @@ hostmem_heap_term(struct hostmem_heap *heap)
 		return;
 	}
 
-	free(heap->phys_lut);
+	/*
+	 * heap->phys_lut is a borrowed pointer to heap->memory.phys_lut;
+	 * hostmem_hugepage_free releases the backing array.
+	 */
+	heap->phys_lut = NULL;
+	heap->nphys = 0;
 	hostmem_hugepage_free(&heap->memory);
 }
 
@@ -135,19 +140,17 @@ hostmem_heap_init(struct hostmem_heap *heap, size_t size, struct hostmem_config 
 	heap->freelist->free = 1;
 	heap->freelist->next = NULL;
 
-	// Setup the LUT
-	heap->nphys = size / heap->config->hugepgsz;
-	heap->phys_lut = calloc(heap->nphys, sizeof(uint64_t));
-
-	for (size_t i = 0; i < heap->nphys; ++i) {
-		void *vaddr = (char *)heap->memory.virt + i * heap->config->hugepgsz;
-
-		err = hostmem_pagemap_virt_to_phys(vaddr, &heap->phys_lut[i]);
-		if (err) {
-			hostmem_heap_term(heap);
-			return err;
-		}
+	/*
+	 * The LUT is now populated on hostmem_hugepage by hostmem_hugepage_alloc.
+	 * heap->phys_lut is a borrowed pointer for backwards compatibility with
+	 * existing hostmem_dma_v2p callers.
+	 */
+	if (!heap->memory.phys_lut) {
+		hostmem_heap_term(heap);
+		return -EPERM;
 	}
+	heap->nphys = heap->memory.nphys;
+	heap->phys_lut = heap->memory.phys_lut;
 
 	if (heap->memory.phys != heap->phys_lut[0]) {
 		hostmem_heap_term(heap);

--- a/toolbox/third-party/linux/upcie/hostmem_hugepage.h
+++ b/toolbox/third-party/linux/upcie/hostmem_hugepage.h
@@ -58,7 +58,7 @@
  * also gains access to those physical addresses—without needing CAP_SYS_ADMIN.
  *
  * @file hostmem_hugepage.h
- * @version 0.5.1
+ * @version 0.5.2
  */
 
 struct hostmem_hugepage {
@@ -68,6 +68,8 @@ struct hostmem_hugepage {
 	uint64_t phys;
 	char path[256];
 	struct hostmem_config *config;
+	size_t nphys;       ///< Number of hugepages backing 'virt'
+	uint64_t *phys_lut; ///< Per-hugepage physical base; NULL when pagemap read is unavailable
 };
 
 static inline int
@@ -100,6 +102,11 @@ hostmem_hugepage_free(struct hostmem_hugepage *hugepage)
 {
 	if (!hugepage)
 		return;
+
+	if (hugepage->phys_lut) {
+		free(hugepage->phys_lut);
+		hugepage->phys_lut = NULL;
+	}
 
 	if (hugepage->virt && hugepage->size) {
 		munmap(hugepage->virt, hugepage->size);
@@ -197,12 +204,42 @@ hostmem_hugepage_alloc(size_t size, struct hostmem_hugepage *hugepage,
 	///< The assumption here is that memset and mlock should lead to pinned pages
 	memset(hugepage->virt, 0, hugepage->size);
 
+	/*
+	 * Best-effort pagemap read: without CAP_SYS_ADMIN we cannot get a PA,
+	 * but arithmetic-translator consumers do not need one. Leave
+	 * hugepage->phys and hugepage->phys_lut at zero / NULL on EPERM; the
+	 * LUT constructors validate that phys_lut is populated at their end.
+	 */
 	err = hostmem_pagemap_virt_to_phys(hugepage->virt, &hugepage->phys);
-	if (err) {
+	if (err && err != -EPERM) {
 		UPCIE_DEBUG("FAILED: hostmem_virt_to_phys(hugepage); err(%d)", err);
 		munmap(hugepage->virt, hugepage->size);
 		close(hugepage->fd);
 		return -ENOMEM;
+	}
+
+	if (!err) {
+		hugepage->nphys = hugepage->size / hugepage->config->hugepgsz;
+		hugepage->phys_lut = calloc(hugepage->nphys, sizeof(uint64_t));
+		if (!hugepage->phys_lut) {
+			munmap(hugepage->virt, hugepage->size);
+			close(hugepage->fd);
+			return -ENOMEM;
+		}
+		for (size_t i = 0; i < hugepage->nphys; ++i) {
+			void *vaddr = (uint8_t *)hugepage->virt + i * hugepage->config->hugepgsz;
+			int lerr = hostmem_pagemap_virt_to_phys(vaddr, &hugepage->phys_lut[i]);
+			if (lerr) {
+				UPCIE_DEBUG("FAILED: hostmem_virt_to_phys(hp[%zu]); err(%d)", i,
+					    lerr);
+				free(hugepage->phys_lut);
+				hugepage->phys_lut = NULL;
+				hugepage->nphys = 0;
+				munmap(hugepage->virt, hugepage->size);
+				close(hugepage->fd);
+				return lerr;
+			}
+		}
 	}
 
 	hugepage->config->count++;

--- a/toolbox/third-party/linux/upcie/iommufd.h
+++ b/toolbox/third-party/linux/upcie/iommufd.h
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * iommufd helper for user-space
+ * =============================
+ *
+ * iommufd is the modern Linux interface for managing I/O address spaces. It
+ * replaces the IOMMU half of the legacy vfio container (see vfioctl.h), exposing
+ * map and unmap of DMA address spaces through a single file-descriptor based API
+ * on /dev/iommu.
+ *
+ * Most functions here are thin wrappers of the ioctls of the same name. The
+ * essential data structures and their relation:
+ *
+ *  /dev/iommu (iommufd)
+ *        |
+ *     IOAS, I/O address space         <- IOMMU_IOAS_ALLOC
+ *        |   map: user_va or fd -> IOVA  (IOMMU_IOAS_MAP / IOMMU_IOAS_MAP_FILE)
+ *        |
+ *   attached device                   <- VFIO_DEVICE_ATTACH_IOMMUFD_PT
+ *        |
+ *   vfio device cdev (/dev/vfio/devices/vfioN)
+ *
+ * A device is taken into the iommufd model by opening its vfio cdev, binding it
+ * to an iommufd handle, allocating an IOAS, and attaching the device to that
+ * IOAS. From there, ranges mapped into the IOAS become valid IOVAs for the
+ * device to DMA against. A dma-buf fd (see dmabuf.h), e.g. exported from CUDA
+ * device memory, can be mapped with iommufd_ioas_map_file to let the device DMA
+ * straight into that memory through the IOMMU.
+ *
+ * Kernel docs: https://docs.kernel.org/userspace-api/iommufd.html
+ *
+ * @file iommufd.h
+ * @version 0.5.1
+ */
+#include <linux/vfio.h>
+#if defined(__has_include) && __has_include(<linux/iommufd.h>) && defined(VFIO_DEVICE_BIND_IOMMUFD)
+#include <linux/iommufd.h>
+#define UPCIE_HAVE_IOMMUFD 1
+#endif
+
+#ifndef UPCIE_HAVE_IOMMUFD
+/* Fallback definitions so callers using these flags in dmamem_from_memfd,
+ * dmamem_from_dmabuf, and dmamem_from_hostmem_iommufd compile against
+ * distros that ship pre-iommufd kernel headers (Linux < 6.6). The
+ * iommufd_* ioctl wrappers below stub to -ENOTSUP in the same case, so
+ * runtime callers can detect and fall back. Values match the mainline
+ * uapi. */
+#define IOMMU_IOAS_MAP_FIXED_IOVA (1U << 0)
+#define IOMMU_IOAS_MAP_WRITEABLE  (1U << 1)
+#define IOMMU_IOAS_MAP_READABLE   (1U << 2)
+#endif
+
+struct iommufd {
+	int fd; ///< Handle to /dev/iommu
+};
+
+struct iommufd_device {
+	int fd;         ///< vfio device cdev file descriptor
+	uint32_t devid; ///< Device id assigned by VFIO_DEVICE_BIND_IOMMUFD
+};
+
+/**
+ * Open an iommufd handle
+ *
+ * @param ctx Assigns the file-descriptor to ctx.fd
+ *
+ * @return On success, 0 is returned and ctx.fd is setup as a handle to
+ * /dev/iommu. On error, negative errno is returned to indicate the error.
+ */
+static inline int
+iommufd_open(struct iommufd *ctx)
+{
+	ctx->fd = open("/dev/iommu", O_RDWR);
+	if (ctx->fd == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+
+/**
+ * Close an iommufd handle
+ *
+ * Closing the handle tears down every IOAS and mapping owned by it.
+ *
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+static inline int
+iommufd_close(struct iommufd *ctx)
+{
+	if (close(ctx->fd) == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+
+/**
+ * Allocate an I/O address space (IOAS)
+ *
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @param ioas_id Assigns the id of the allocated IOAS
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_ioas_alloc(struct iommufd *ctx, uint32_t *ioas_id)
+{
+	struct iommu_ioas_alloc args = {0};
+
+	args.size = sizeof(args);
+
+	if (ioctl(ctx->fd, IOMMU_IOAS_ALLOC, &args) == -1) {
+		return -errno;
+	}
+
+	*ioas_id = args.out_ioas_id;
+
+	return 0;
+}
+#else
+// linux/iommufd.h landed in Linux 6.6; older distro kernel-headers packages
+// don't ship it. Provide -ENOTSUP stubs so the tree compiles; callers that
+// need iommufd should probe iommufd_open() at runtime and fall back.
+static inline int
+iommufd_ioas_alloc(struct iommufd *ctx, uint32_t *ioas_id)
+{
+	(void)ctx;
+	(void)ioas_id;
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Destroy an iommufd object, e.g. an IOAS, by id
+ *
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @param id Identifier of the object to destroy
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_destroy(struct iommufd *ctx, uint32_t id)
+{
+	struct iommu_destroy args = {0};
+
+	args.size = sizeof(args);
+	args.id = id;
+
+	if (ioctl(ctx->fd, IOMMU_DESTROY, &args) == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+#else
+static inline int
+iommufd_destroy(struct iommufd *ctx, uint32_t id)
+{
+	(void)ctx;
+	(void)id;
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Map a host virtual address range into an IOAS
+ *
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @param ioas_id Identifier of the IOAS to map into
+ * @param user_va Host virtual address of the range to map
+ * @param length Length of the range in bytes
+ * @param flags Bitmask of IOMMU_IOAS_MAP_* flags
+ * @param iova In/out. When IOMMU_IOAS_MAP_FIXED_IOVA is set in flags, the
+ * caller provides the desired IOVA. On return it holds the IOVA the mapping was
+ * placed at.
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_ioas_map(struct iommufd *ctx, uint32_t ioas_id, uint64_t user_va, uint64_t length,
+		 uint32_t flags, uint64_t *iova)
+{
+	struct iommu_ioas_map args = {0};
+
+	args.size = sizeof(args);
+	args.flags = flags;
+	args.ioas_id = ioas_id;
+	args.user_va = user_va;
+	args.length = length;
+	args.iova = *iova; // Honoured only when IOMMU_IOAS_MAP_FIXED_IOVA is set in flags
+
+	if (ioctl(ctx->fd, IOMMU_IOAS_MAP, &args) == -1) {
+		return -errno;
+	}
+
+	*iova = args.iova;
+
+	return 0;
+}
+#else
+static inline int
+iommufd_ioas_map(struct iommufd *ctx, uint32_t ioas_id, uint64_t user_va, uint64_t length,
+		 uint32_t flags, uint64_t *iova)
+{
+	(void)ctx;
+	(void)ioas_id;
+	(void)user_va;
+	(void)length;
+	(void)flags;
+	(void)iova;
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Map a range described by a file-descriptor into an IOAS
+ *
+ * Intended for memfd and dma-buf backed memory, where no host virtual mapping is
+ * needed. A dma-buf fd exported from device memory, e.g. CUDA, is mapped this
+ * way to expose it as an IOVA for device DMA.
+ *
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @param ioas_id Identifier of the IOAS to map into
+ * @param fd File-descriptor backing the range, e.g. a dma-buf fd
+ * @param offset Offset into the file of the range to map
+ * @param length Length of the range in bytes
+ * @param flags Bitmask of IOMMU_IOAS_MAP_* flags
+ * @param iova In/out. When IOMMU_IOAS_MAP_FIXED_IOVA is set in flags, the
+ * caller provides the desired IOVA. On return it holds the IOVA the mapping was
+ * placed at.
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef IOMMU_IOAS_MAP_FILE
+static inline int
+iommufd_ioas_map_file(struct iommufd *ctx, uint32_t ioas_id, int fd, uint64_t offset,
+		      uint64_t length, uint32_t flags, uint64_t *iova)
+{
+	struct iommu_ioas_map_file args = {0};
+
+	args.size = sizeof(args);
+	args.flags = flags;
+	args.ioas_id = ioas_id;
+	args.fd = fd;
+	args.start = offset;
+	args.length = length;
+	args.iova = *iova; // Honoured only when IOMMU_IOAS_MAP_FIXED_IOVA is set in flags
+
+	if (ioctl(ctx->fd, IOMMU_IOAS_MAP_FILE, &args) == -1) {
+		return -errno;
+	}
+
+	*iova = args.iova;
+
+	return 0;
+}
+#else
+// IOMMU_IOAS_MAP_FILE was added in Linux 6.14; on older UAPI headers this maps
+// to a stub so callers can fall back to iommufd_ioas_map() with a user_va.
+static inline int
+iommufd_ioas_map_file(struct iommufd *ctx, uint32_t ioas_id, int fd, uint64_t offset,
+		      uint64_t length, uint32_t flags, uint64_t *iova)
+{
+	(void)ctx;
+	(void)ioas_id;
+	(void)fd;
+	(void)offset;
+	(void)length;
+	(void)flags;
+	(void)iova;
+
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Unmap a range from an IOAS
+ *
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @param ioas_id Identifier of the IOAS to unmap from
+ * @param iova IOVA of the range to unmap, as returned by iommufd_ioas_map
+ * @param length Length of the range in bytes
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_ioas_unmap(struct iommufd *ctx, uint32_t ioas_id, uint64_t iova, uint64_t length)
+{
+	struct iommu_ioas_unmap args = {0};
+
+	args.size = sizeof(args);
+	args.ioas_id = ioas_id;
+	args.iova = iova;
+	args.length = length;
+
+	if (ioctl(ctx->fd, IOMMU_IOAS_UNMAP, &args) == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+#else
+static inline int
+iommufd_ioas_unmap(struct iommufd *ctx, uint32_t ioas_id, uint64_t iova, uint64_t length)
+{
+	(void)ctx;
+	(void)ioas_id;
+	(void)iova;
+	(void)length;
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Open a vfio device cdev
+ *
+ * @param path Path to the device cdev, e.g. /dev/vfio/devices/vfio0
+ * @param dev Assigns the file-descriptor to dev.fd
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+static inline int
+iommufd_device_open(const char *path, struct iommufd_device *dev)
+{
+	dev->fd = open(path, O_RDWR);
+	if (dev->fd == -1) {
+		return -errno;
+	}
+
+	dev->devid = 0;
+
+	return 0;
+}
+
+/**
+ * Close a vfio device cdev
+ *
+ * Closing the device detaches it from any IOAS and unbinds it from iommufd.
+ *
+ * @param dev Pointer to a device handle (see iommufd_device_open)
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+static inline int
+iommufd_device_close(struct iommufd_device *dev)
+{
+	if (close(dev->fd) == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+
+/**
+ * Bind a vfio device to an iommufd handle
+ *
+ * @param dev Pointer to a device handle (see iommufd_device_open). On success
+ * dev.devid holds the device id assigned by the kernel.
+ * @param ctx Pointer to an iommufd handle (see iommufd_open)
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_device_bind(struct iommufd_device *dev, struct iommufd *ctx)
+{
+	struct vfio_device_bind_iommufd args = {0};
+
+	args.argsz = sizeof(args);
+	args.iommufd = ctx->fd;
+
+	if (ioctl(dev->fd, VFIO_DEVICE_BIND_IOMMUFD, &args) == -1) {
+		return -errno;
+	}
+
+	dev->devid = args.out_devid;
+
+	return 0;
+}
+#else
+static inline int
+iommufd_device_bind(struct iommufd_device *dev, struct iommufd *ctx)
+{
+	(void)dev;
+	(void)ctx;
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Attach a bound vfio device to an IOAS
+ *
+ * @param dev Pointer to a bound device handle (see iommufd_device_bind)
+ * @param pt_id Identifier of the IOAS to attach to (see iommufd_ioas_alloc)
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_device_attach(struct iommufd_device *dev, uint32_t pt_id)
+{
+	struct vfio_device_attach_iommufd_pt args = {0};
+
+	args.argsz = sizeof(args);
+	args.pt_id = pt_id;
+
+	if (ioctl(dev->fd, VFIO_DEVICE_ATTACH_IOMMUFD_PT, &args) == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+#else
+static inline int
+iommufd_device_attach(struct iommufd_device *dev, uint32_t pt_id)
+{
+	(void)dev;
+	(void)pt_id;
+	return -ENOTSUP;
+}
+#endif
+
+/**
+ * Detach a vfio device from its IOAS
+ *
+ * @param dev Pointer to an attached device handle (see iommufd_device_attach)
+ * @return On success, 0 is returned. On error, negative errno is returned to
+ * indicate the error.
+ */
+#ifdef UPCIE_HAVE_IOMMUFD
+static inline int
+iommufd_device_detach(struct iommufd_device *dev)
+{
+	struct vfio_device_detach_iommufd_pt args = {0};
+
+	args.argsz = sizeof(args);
+
+	if (ioctl(dev->fd, VFIO_DEVICE_DETACH_IOMMUFD_PT, &args) == -1) {
+		return -errno;
+	}
+
+	return 0;
+}
+#else
+static inline int
+iommufd_device_detach(struct iommufd_device *dev)
+{
+	(void)dev;
+	return -ENOTSUP;
+}
+#endif

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller_dmamem_type1.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller_dmamem_type1.h
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * NVMe Controller Extension: dmamem over vfio-pci + type1 container
+ * =================================================================
+ *
+ * Sibling of nvme_controller_dmamem_vfio for the legacy vfio type1
+ * container world. The caller owns the container, the group (already
+ * viable and set_container'd), and the dmamem_heap (backed by a
+ * dmamem_from_hostmem_type1 wrap so the container's TYPE1 IOMMU has
+ * the mapping in place); this module owns the device fd, the mmap'd
+ * BAR0, and the admin queue buffers sub-allocated from the heap.
+ *
+ * The submit/reap path is the existing nvme_qpair primitives; only
+ * the SQ/CQ backing (and the DMA-address arithmetic) is different
+ * from the base upcie hostmem_heap path, so the dmamem-backed admin
+ * queue reuses nvme_qpair_enqueue, nvme_qpair_sqdb_update, and
+ * nvme_qpair_reap_cpl unchanged.
+ *
+ * @file nvme_controller_dmamem_type1.h
+ * @version 0.5.2
+ */
+
+/**
+ * Context for a single NVMe controller reached via vfio type1 + a
+ * group cdev.
+ *
+ * The container and group are caller-owned; container may be shared
+ * across multiple controllers (multiple groups attached to it), while
+ * each controller owns its group binding to its device fd.
+ */
+struct nvme_dmamem_type1_ctx {
+	struct vfio_container *container; ///< Not owned; caller lifetime
+	struct vfio_group *group;         ///< Not owned; caller lifetime
+	int device_fd;                    ///< Owned; obtained from group + BDF
+	void *bar0;                       ///< Owned; mmap'd BAR0
+	size_t bar0_size;                 ///< BAR0 mapping length
+	size_t aq_sq_offset;              ///< Admin SQ offset in the caller-provided heap
+	size_t aq_cq_offset;              ///< Admin CQ offset in the caller-provided heap
+	size_t aq_prp_offset;             ///< Admin PRP-scratch offset in the caller-provided heap
+	int aq_alive;                     ///< Whether aq_{sq,cq,prp}_offset hold live allocations
+};
+
+static inline void
+nvme_dmamem_type1_ctx_init(struct nvme_dmamem_type1_ctx *ctx)
+{
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->device_fd = -1;
+}
+
+/**
+ * Release the type1 device fd + BAR0 mapping.
+ *
+ * The caller-owned container and group stay alive.
+ */
+static inline int
+nvme_dmamem_type1_ctx_close(struct nvme_dmamem_type1_ctx *ctx)
+{
+	if (ctx->bar0 && ctx->bar0_size) {
+		munmap(ctx->bar0, ctx->bar0_size);
+		ctx->bar0 = NULL;
+		ctx->bar0_size = 0;
+	}
+
+	if (ctx->device_fd >= 0) {
+		close(ctx->device_fd);
+	}
+
+	nvme_dmamem_type1_ctx_init(ctx);
+
+	return 0;
+}
+
+/**
+ * Open an NVMe controller through a legacy vfio type1 container.
+ *
+ * Preconditions: container is open, group is open + viable +
+ * set_container'd, container has VFIO_SET_IOMMU(TYPE1) applied, and
+ * heap sits on a dmamem_from_hostmem_type1 wrap that already
+ * VFIO_IOMMU_MAP_DMA'd the underlying hugepage into the container's
+ * IOMMU. Nothing in this function installs a DMA mapping; it walks
+ * the device open + admin queue setup end.
+ *
+ * @param ctrlr     Controller descriptor to populate.
+ * @param ctx       Controller context (owned by caller until close).
+ * @param container The type1 container the group is attached to.
+ * @param group     Viable group already attached to container.
+ * @param heap      dmamem_heap holding admin queue backing storage.
+ *                  The heap must outlive the controller; its SQ/CQ
+ *                  offsets are stored in ctx and freed by
+ *                  nvme_controller_close_dmamem_type1.
+ * @param bdf       PCIe address in "0000:bb:dd.f" form.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+nvme_controller_open_dmamem_type1(struct nvme_controller *ctrlr, struct nvme_dmamem_type1_ctx *ctx,
+				  struct vfio_container *container, struct vfio_group *group,
+				  struct dmamem_heap *heap, const char *bdf)
+{
+	uint64_t sq_iova = 0, cq_iova = 0;
+	uint64_t cap;
+	uint8_t *bar0;
+	int err;
+
+	if (!ctrlr || !ctx || !container || !group || !heap || !bdf) {
+		return -EINVAL;
+	}
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	nvme_dmamem_type1_ctx_init(ctx);
+	ctx->container = container;
+	ctx->group = group;
+
+	nvme_qid_bitmap_init(ctrlr->qids);
+
+	ctx->device_fd = vfio_group_get_device_fd(group, bdf);
+	if (ctx->device_fd < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_get_device_fd('%s'); errno(%d)", bdf, errno);
+		goto fail;
+	}
+
+	err = nvme_vfio_pci_acquire_bar0(ctx->device_fd, ctrlr, &ctx->bar0, &ctx->bar0_size);
+	if (err) {
+		goto fail;
+	}
+	bar0 = ctx->bar0;
+
+	err = nvme_controller_reset_via_bar0(ctrlr, bar0, &cap);
+	if (err) {
+		goto fail;
+	}
+
+	err = nvme_qpair_dmamem_init(&ctrlr->aq, 0, 256, bar0, heap, &ctx->aq_sq_offset,
+				     &ctx->aq_cq_offset, &ctx->aq_prp_offset, &sq_iova, &cq_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_dmamem_init(aq); err(%d)", err);
+		goto fail;
+	}
+	ctx->aq_alive = 1;
+
+	nvme_mmio_aq_setup(bar0, sq_iova, cq_iova, ctrlr->aq.depth);
+
+	err = nvme_controller_enable_via_bar0(ctrlr, bar0, cap);
+	if (err) {
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	if (ctx->aq_alive) {
+		nvme_qpair_dmamem_term(&ctrlr->aq, heap, ctx->aq_sq_offset, ctx->aq_cq_offset,
+				       ctx->aq_prp_offset);
+		ctx->aq_alive = 0;
+	}
+	nvme_dmamem_type1_ctx_close(ctx);
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	return err;
+}
+
+/**
+ * Close a controller opened with nvme_controller_open_dmamem_type1.
+ *
+ * Disables the controller, releases the admin queue's SQ/CQ back to
+ * heap, closes the device fd, and munmaps BAR0. The caller-owned
+ * container, group, and dmamem_heap stay alive.
+ *
+ * @param ctrlr  Controller populated by nvme_controller_open_dmamem_type1;
+ *               memset to zero on return.
+ * @param ctx    Context populated by nvme_controller_open_dmamem_type1;
+ *               reset to a fresh state on return.
+ * @param heap   The same heap that was passed to open.
+ *
+ * @return 0 on success; first negative errno encountered during
+ * teardown otherwise.
+ */
+static inline int
+nvme_controller_close_dmamem_type1(struct nvme_controller *ctrlr, struct nvme_dmamem_type1_ctx *ctx,
+				   struct dmamem_heap *heap)
+{
+	int first_err = 0;
+	int err;
+
+	if (ctx->bar0) {
+		nvme_mmio_cc_disable(ctx->bar0);
+		if (ctrlr->timeout_ms) {
+			err = nvme_mmio_csts_wait_until_not_ready(ctx->bar0, ctrlr->timeout_ms);
+			if (err) {
+				first_err = err;
+			}
+		}
+	}
+
+	if (ctx->aq_alive) {
+		nvme_qpair_dmamem_term(&ctrlr->aq, heap, ctx->aq_sq_offset, ctx->aq_cq_offset,
+				       ctx->aq_prp_offset);
+		ctx->aq_alive = 0;
+	}
+
+	err = nvme_dmamem_type1_ctx_close(ctx);
+	if (err && !first_err) {
+		first_err = err;
+	}
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+
+	return first_err;
+}
+
+/*
+ * IO qpair create/delete and the admin-sync helper are the vfio-cdev
+ * variants from nvme_controller_dmamem_vfio.h; they touch only
+ * nvme_qpair primitives and the caller-provided dmamem_heap, so the
+ * type1 path reuses them unchanged. Once open, the mode is invisible
+ * from here on.
+ */

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller_dmamem_uio.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller_dmamem_uio.h
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * NVMe Controller Extension: dmamem over uio_pci_generic
+ * ======================================================
+ *
+ * Sibling of nvme_controller_dmamem_vfio for the uio_pci_generic + LUT
+ * world. Same submit/reap primitives, same dmamem_heap-backed admin
+ * queue, same IO qpair helpers; only the way BAR0 is acquired differs.
+ * uio_pci_generic exposes BAR0 through /sys/bus/pci/devices/<bdf>/resource0
+ * rather than through a vfio device fd, and DMA addresses on the wire
+ * are physical (iommu=pt or iommu=off) so the caller-provided
+ * dmamem_heap must sit on a LUT-translator dmamem.
+ *
+ * The controller enable dance (CC.EN=0/1, CSTS.RDY, AQA/ASQ/ACQ) is shared
+ * with the vfio-pci path via nvme_controller_reset_via_bar0 and
+ * nvme_controller_enable_via_bar0.
+ *
+ * @file nvme_controller_dmamem_uio.h
+ * @version 0.5.2
+ */
+
+/**
+ * Context for a single NVMe controller reached via uio_pci_generic.
+ *
+ * BAR0 lives inside ctrlr->func.bars[0] once pci_bar_map has run. This ctx
+ * only tracks the admin qpair's heap offsets so close can release them.
+ */
+struct nvme_dmamem_uio_ctx {
+	size_t aq_sq_offset;  ///< Admin SQ offset in the caller-provided heap
+	size_t aq_cq_offset;  ///< Admin CQ offset in the caller-provided heap
+	size_t aq_prp_offset; ///< Admin PRP-scratch offset in the caller-provided heap
+	int bar0_mapped;      ///< Whether ctrlr->func.bars[0] holds a live mmap
+	int aq_alive;         ///< Whether aq_{sq,cq,prp}_offset hold live allocations
+};
+
+static inline void
+nvme_dmamem_uio_ctx_init(struct nvme_dmamem_uio_ctx *ctx)
+{
+	memset(ctx, 0, sizeof(*ctx));
+}
+
+/**
+ * Open an NVMe controller through uio_pci_generic.
+ *
+ * The heap must sit on a LUT-translator dmamem (typically a hostmem
+ * hugepage wrapped via dmamem_from_hostmem_lut) so dmamem_heap_at_iova
+ * yields physical addresses that the device can DMA against with
+ * iommu=pt/off.
+ *
+ * @param ctrlr Controller descriptor to populate.
+ * @param ctx   Controller context (owned by caller until close).
+ * @param heap  dmamem_heap holding admin queue backing storage. The
+ *              heap must outlive the controller; its SQ/CQ offsets are
+ *              stored in ctx and freed by
+ *              nvme_controller_close_dmamem_uio.
+ * @param bdf   PCIe address in "0000:bb:dd.f" form.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+nvme_controller_open_dmamem_uio(struct nvme_controller *ctrlr, struct nvme_dmamem_uio_ctx *ctx,
+				struct dmamem_heap *heap, const char *bdf)
+{
+	uint64_t sq_iova = 0, cq_iova = 0;
+	uint64_t cap;
+	uint8_t *bar0;
+	int err;
+
+	if (!ctrlr || !ctx || !heap || !bdf) {
+		return -EINVAL;
+	}
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	nvme_dmamem_uio_ctx_init(ctx);
+
+	nvme_qid_bitmap_init(ctrlr->qids);
+
+	err = pci_func_open(bdf, &ctrlr->func);
+	if (err) {
+		UPCIE_DEBUG("FAILED: pci_func_open('%s'); err(%d)", bdf, err);
+		goto fail;
+	}
+
+	err = pci_bar_map(ctrlr->func.bdf, 0, &ctrlr->func.bars[0]);
+	if (err) {
+		UPCIE_DEBUG("FAILED: pci_bar_map(BAR0); err(%d)", err);
+		goto fail;
+	}
+	ctx->bar0_mapped = 1;
+	bar0 = ctrlr->func.bars[0].region;
+
+	err = nvme_controller_reset_via_bar0(ctrlr, bar0, &cap);
+	if (err) {
+		goto fail;
+	}
+
+	err = nvme_qpair_dmamem_init(&ctrlr->aq, 0, 256, bar0, heap, &ctx->aq_sq_offset,
+				     &ctx->aq_cq_offset, &ctx->aq_prp_offset, &sq_iova, &cq_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_dmamem_init(aq); err(%d)", err);
+		goto fail;
+	}
+	ctx->aq_alive = 1;
+
+	nvme_mmio_aq_setup(bar0, sq_iova, cq_iova, ctrlr->aq.depth);
+
+	err = nvme_controller_enable_via_bar0(ctrlr, bar0, cap);
+	if (err) {
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	if (ctx->aq_alive) {
+		nvme_qpair_dmamem_term(&ctrlr->aq, heap, ctx->aq_sq_offset, ctx->aq_cq_offset,
+				       ctx->aq_prp_offset);
+		ctx->aq_alive = 0;
+	}
+	if (ctx->bar0_mapped) {
+		pci_func_close(&ctrlr->func);
+		ctx->bar0_mapped = 0;
+	}
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	return err;
+}
+
+/**
+ * Close a controller opened with nvme_controller_open_dmamem_uio.
+ *
+ * Disables the controller, releases the admin queue's SQ/CQ back to
+ * heap (using the offsets ctx recorded at open), and unmaps BAR0. The
+ * dmamem_heap itself stays with the caller.
+ *
+ * @param ctrlr  Controller populated by nvme_controller_open_dmamem_uio;
+ *               memset to zero on return.
+ * @param ctx    Context populated by nvme_controller_open_dmamem_uio;
+ *               reset to a fresh state on return.
+ * @param heap   The same heap that was passed to open; must still be
+ *               valid.
+ *
+ * @return 0 on success; first negative errno encountered during
+ * teardown otherwise.
+ */
+static inline int
+nvme_controller_close_dmamem_uio(struct nvme_controller *ctrlr, struct nvme_dmamem_uio_ctx *ctx,
+				 struct dmamem_heap *heap)
+{
+	int first_err = 0;
+	int err;
+
+	if (ctx->bar0_mapped && ctrlr->func.bars[0].region) {
+		nvme_mmio_cc_disable(ctrlr->func.bars[0].region);
+		if (ctrlr->timeout_ms) {
+			err = nvme_mmio_csts_wait_until_not_ready(ctrlr->func.bars[0].region,
+								  ctrlr->timeout_ms);
+			if (err) {
+				first_err = err;
+			}
+		}
+	}
+
+	if (ctx->aq_alive) {
+		nvme_qpair_dmamem_term(&ctrlr->aq, heap, ctx->aq_sq_offset, ctx->aq_cq_offset,
+				       ctx->aq_prp_offset);
+		ctx->aq_alive = 0;
+	}
+
+	if (ctx->bar0_mapped) {
+		pci_func_close(&ctrlr->func);
+		ctx->bar0_mapped = 0;
+	}
+
+	nvme_dmamem_uio_ctx_init(ctx);
+	memset(ctrlr, 0, sizeof(*ctrlr));
+
+	return first_err;
+}
+
+/*
+ * IO qpair create/delete and the admin-sync helper are the vfio-cdev
+ * variants from nvme_controller_dmamem.h; they touch only nvme_qpair
+ * primitives and the caller-provided dmamem_heap, so the uio path
+ * reuses them unchanged. Once open, the mode is invisible from here on.
+ */

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller_dmamem_vfio.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller_dmamem_vfio.h
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * NVMe Controller Extension: dmamem over vfio-cdev + iommufd
+ * ==========================================================
+ *
+ * Sibling of nvme_controller_vfio for the vfio-cdev + iommufd + dmamem
+ * world. The caller owns the iommufd handle and the target IOAS; this
+ * module owns the vfio device attached to that IOAS, the mmap'd BAR0,
+ * and the admin queue buffers sub-allocated from a caller-provided
+ * dmamem_heap.
+ *
+ * The submit/reap path is the existing nvme_qpair primitives; only the
+ * SQ/CQ backing (and the DMA-address arithmetic) is different, so the
+ * dmamem-backed admin queue reuses nvme_qpair_enqueue,
+ * nvme_qpair_sqdb_update, and nvme_qpair_reap_cpl unchanged.
+ *
+ * @file nvme_controller_dmamem_vfio.h
+ * @version 0.5.2
+ */
+
+/**
+ * Context for a single NVMe controller reached via vfio-cdev + iommufd.
+ *
+ * The iommufd handle and IOAS are caller-owned. The vfio_device_path
+ * (e.g. /dev/vfio/devices/vfio3) identifies the cdev; the caller
+ * resolves it from BDF via sysfs, then hands it in.
+ */
+struct nvme_dmamem_vfio_ctx {
+	struct iommufd *iommufd;   ///< Not owned; caller lifetime
+	uint32_t ioas_id;          ///< Not owned; caller lifetime
+	struct iommufd_device dev; ///< Owned; vfio cdev bound + attached
+	void *bar0;                ///< mmap'd BAR0
+	size_t bar0_size;          ///< BAR0 mapping length
+	size_t aq_sq_offset;       ///< Admin SQ offset in the caller-provided heap
+	size_t aq_cq_offset;       ///< Admin CQ offset in the caller-provided heap
+	size_t aq_prp_offset;      ///< Admin PRP-scratch offset in the caller-provided heap
+	int attached;              ///< Whether dev is attached to ioas_id
+	int aq_alive;              ///< Whether aq_{sq,cq,prp}_offset hold live allocations
+};
+
+static inline void
+nvme_dmamem_vfio_ctx_init(struct nvme_dmamem_vfio_ctx *ctx)
+{
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->dev.fd = -1;
+}
+
+/**
+ * Release the vfio device + BAR0 mapping.
+ *
+ * The caller-owned iommufd handle and IOAS stay alive.
+ */
+static inline int
+nvme_dmamem_vfio_ctx_close(struct nvme_dmamem_vfio_ctx *ctx)
+{
+	int first_err = 0;
+	int err;
+
+	if (ctx->bar0 && ctx->bar0_size) {
+		munmap(ctx->bar0, ctx->bar0_size);
+		ctx->bar0 = NULL;
+		ctx->bar0_size = 0;
+	}
+
+	if (ctx->attached) {
+		err = iommufd_device_detach(&ctx->dev);
+		if (err && !first_err) {
+			first_err = err;
+		}
+		ctx->attached = 0;
+	}
+
+	if (ctx->dev.fd >= 0) {
+		err = iommufd_device_close(&ctx->dev);
+		if (err && !first_err) {
+			first_err = err;
+		}
+	}
+
+	nvme_dmamem_vfio_ctx_init(ctx);
+
+	return first_err;
+}
+
+/**
+ * Allocate SQ, CQ, and a request pool with per-request PRP-list scratch
+ * for a queue pair from a dmamem_heap, and populate the nvme_qpair
+ * fields the submit/reap primitives read.
+ *
+ * The heap stays with the caller; qp->heap is left NULL to signal that
+ * qp is not managed by hostmem_dma_free. Use nvme_qpair_dmamem_term to
+ * free, passing back the same offsets returned here.
+ *
+ * @param qp             Queue pair to populate; fully memset before use.
+ * @param qid            NVMe queue identifier (0 for the admin queue).
+ * @param depth          Queue depth in entries.
+ * @param bar0           mmap'd BAR0 base; used to derive SQ/CQ doorbell
+ *                       addresses via CAP.DSTRD.
+ * @param heap           dmamem_heap the SQ, CQ, and PRP scratch are
+ *                       carved from.
+ * @param sq_offset_out  On success, heap offset of the SQ allocation.
+ * @param cq_offset_out  On success, heap offset of the CQ allocation.
+ * @param prp_offset_out On success, heap offset of the per-request PRP
+ *                       scratch region (needed by nvme_qpair_dmamem_term).
+ * @param sq_iova_out    On success, IOVA of the SQ (for AQA/ASQ or
+ *                       CREATE_IO_SQ).
+ * @param cq_iova_out    On success, IOVA of the CQ (for AQA/ACQ or
+ *                       CREATE_IO_CQ).
+ *
+ * @return 0 on success; negative errno on allocation failure.
+ */
+static inline int
+nvme_qpair_dmamem_init(struct nvme_qpair *qp, uint32_t qid, uint16_t depth, uint8_t *bar0,
+		       struct dmamem_heap *heap, size_t *sq_offset_out, size_t *cq_offset_out,
+		       size_t *prp_offset_out, uint64_t *sq_iova_out, uint64_t *cq_iova_out)
+{
+	int dstrd = nvme_reg_cap_get_dstrd(nvme_mmio_cap_read(bar0));
+	size_t queue_bytes = 1024 * 64;
+	size_t sq_offset = 0, cq_offset = 0, prp_offset = 0;
+	int err;
+
+	memset(qp, 0, sizeof(*qp));
+	qp->qid = qid;
+	qp->depth = depth;
+	qp->phase = 1;
+	qp->tail_last_written = UINT16_MAX;
+	qp->sqdb = bar0 + 0x1000 + ((2 * qid) << (2 + dstrd));
+	qp->cqdb = bar0 + 0x1000 + ((2 * qid + 1) << (2 + dstrd));
+
+	err = dmamem_heap_alloc_aligned(heap, queue_bytes, 4096, &sq_offset);
+	if (err) {
+		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_aligned(sq); err(%d)", err);
+		return err;
+	}
+
+	err = dmamem_heap_alloc_aligned(heap, queue_bytes, 4096, &cq_offset);
+	if (err) {
+		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_aligned(cq); err(%d)", err);
+		dmamem_heap_free(heap, sq_offset);
+		return err;
+	}
+
+	qp->rpool = calloc(1, sizeof(*qp->rpool));
+	if (!qp->rpool) {
+		UPCIE_DEBUG("FAILED: calloc(rpool); errno(%d)", errno);
+		dmamem_heap_free(heap, cq_offset);
+		dmamem_heap_free(heap, sq_offset);
+		return -errno;
+	}
+	nvme_request_pool_init(qp->rpool);
+
+	err = nvme_request_pool_init_prps_dmamem(qp->rpool, heap, &prp_offset);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_request_pool_init_prps_dmamem(); err(%d)", err);
+		free(qp->rpool);
+		qp->rpool = NULL;
+		dmamem_heap_free(heap, cq_offset);
+		dmamem_heap_free(heap, sq_offset);
+		return err;
+	}
+
+	qp->sq = dmamem_heap_at_va(heap, sq_offset);
+	qp->cq = dmamem_heap_at_va(heap, cq_offset);
+	memset(qp->sq, 0, queue_bytes);
+	memset(qp->cq, 0, queue_bytes);
+
+	*sq_offset_out = sq_offset;
+	*cq_offset_out = cq_offset;
+	*prp_offset_out = prp_offset;
+	*sq_iova_out = dmamem_heap_at_iova(heap, sq_offset);
+	*cq_iova_out = dmamem_heap_at_iova(heap, cq_offset);
+
+	return 0;
+}
+
+/**
+ * Release the SQ, CQ, and request pool of a qp initialised by
+ * nvme_qpair_dmamem_init.
+ *
+ * @param qp          Queue pair to release; memset to zero on return.
+ * @param heap        The heap the SQ, CQ, and PRP scratch were carved from.
+ * @param sq_offset   SQ offset returned by nvme_qpair_dmamem_init.
+ * @param cq_offset   CQ offset returned by nvme_qpair_dmamem_init.
+ * @param prp_offset  PRP scratch offset returned by nvme_qpair_dmamem_init.
+ */
+static inline void
+nvme_qpair_dmamem_term(struct nvme_qpair *qp, struct dmamem_heap *heap, size_t sq_offset,
+		       size_t cq_offset, size_t prp_offset)
+{
+	if (qp->rpool) {
+		nvme_request_pool_term_prps_dmamem(qp->rpool, heap, prp_offset);
+		free(qp->rpool);
+		qp->rpool = NULL;
+	}
+	if (qp->sq) {
+		dmamem_heap_free(heap, sq_offset);
+	}
+	if (qp->cq) {
+		dmamem_heap_free(heap, cq_offset);
+	}
+	memset(qp, 0, sizeof(*qp));
+}
+
+/**
+ * Open an NVMe controller through vfio-cdev + iommufd.
+ *
+ * @param ctrlr           Controller descriptor to populate.
+ * @param ctx             Controller context (owned by caller until close).
+ * @param iommufd         Open iommufd handle (caller-owned).
+ * @param ioas_id         Target IOAS the device is attached to.
+ * @param heap            dmamem_heap holding admin queue backing storage.
+ *                        The heap must outlive the controller; its SQ/CQ
+ *                        offsets are stored in ctx and freed by
+ *                        nvme_controller_close_dmamem_vfio.
+ * @param vfio_device_path Path to the vfio cdev, e.g. /dev/vfio/devices/vfio3.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+nvme_controller_open_dmamem_vfio(struct nvme_controller *ctrlr, struct nvme_dmamem_vfio_ctx *ctx,
+			    struct iommufd *iommufd, uint32_t ioas_id, struct dmamem_heap *heap,
+			    const char *vfio_device_path)
+{
+	uint64_t sq_iova = 0, cq_iova = 0;
+	uint64_t cap;
+	void *bar0;
+	int err;
+
+	if (!ctrlr || !ctx || !iommufd || !heap || !vfio_device_path) {
+		return -EINVAL;
+	}
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	nvme_dmamem_vfio_ctx_init(ctx);
+	ctx->iommufd = iommufd;
+	ctx->ioas_id = ioas_id;
+
+	nvme_qid_bitmap_init(ctrlr->qids);
+
+	err = iommufd_device_open(vfio_device_path, &ctx->dev);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_device_open('%s'); err(%d)", vfio_device_path, err);
+		goto fail;
+	}
+
+	err = iommufd_device_bind(&ctx->dev, iommufd);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_device_bind(); err(%d)", err);
+		goto fail;
+	}
+
+	err = iommufd_device_attach(&ctx->dev, ioas_id);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_device_attach(); err(%d)", err);
+		goto fail;
+	}
+	ctx->attached = 1;
+
+	err = nvme_vfio_pci_acquire_bar0(ctx->dev.fd, ctrlr, &ctx->bar0, &ctx->bar0_size);
+	if (err) {
+		goto fail;
+	}
+	bar0 = ctx->bar0;
+
+	err = nvme_controller_reset_via_bar0(ctrlr, bar0, &cap);
+	if (err) {
+		goto fail;
+	}
+
+	err = nvme_qpair_dmamem_init(&ctrlr->aq, 0, 256, bar0, heap, &ctx->aq_sq_offset,
+				     &ctx->aq_cq_offset, &ctx->aq_prp_offset, &sq_iova, &cq_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_dmamem_init(aq); err(%d)", err);
+		goto fail;
+	}
+	ctx->aq_alive = 1;
+
+	nvme_mmio_aq_setup(bar0, sq_iova, cq_iova, ctrlr->aq.depth);
+
+	err = nvme_controller_enable_via_bar0(ctrlr, bar0, cap);
+	if (err) {
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	if (ctx->aq_alive) {
+		nvme_qpair_dmamem_term(&ctrlr->aq, heap, ctx->aq_sq_offset, ctx->aq_cq_offset,
+				       ctx->aq_prp_offset);
+		ctx->aq_alive = 0;
+	}
+	nvme_dmamem_vfio_ctx_close(ctx);
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	return err;
+}
+
+/**
+ * Close a controller opened with nvme_controller_open_dmamem_vfio.
+ *
+ * Disables the controller, releases the admin queue's SQ/CQ back to
+ * heap (using the offsets ctx recorded at open), releases the vfio
+ * device attachment, and munmaps BAR0. The dmamem_heap itself stays
+ * with the caller.
+ *
+ * @param ctrlr  Controller populated by nvme_controller_open_dmamem_vfio;
+ *               memset to zero on return.
+ * @param ctx    Context populated by nvme_controller_open_dmamem_vfio;
+ *               reset to a fresh state on return.
+ * @param heap   The same heap that was passed to open; must still be
+ *               valid.
+ *
+ * @return 0 on success; first negative errno encountered during
+ * teardown otherwise.
+ */
+static inline int
+nvme_controller_close_dmamem_vfio(struct nvme_controller *ctrlr, struct nvme_dmamem_vfio_ctx *ctx,
+			     struct dmamem_heap *heap)
+{
+	int first_err = 0;
+	int err;
+
+	if (ctx->bar0) {
+		nvme_mmio_cc_disable(ctx->bar0);
+		if (ctrlr->timeout_ms) {
+			err = nvme_mmio_csts_wait_until_not_ready(ctx->bar0, ctrlr->timeout_ms);
+			if (err) {
+				first_err = err;
+			}
+		}
+	}
+
+	if (ctx->aq_alive) {
+		nvme_qpair_dmamem_term(&ctrlr->aq, heap, ctx->aq_sq_offset, ctx->aq_cq_offset,
+				       ctx->aq_prp_offset);
+		ctx->aq_alive = 0;
+	}
+
+	err = nvme_dmamem_vfio_ctx_close(ctx);
+	if (err && !first_err) {
+		first_err = err;
+	}
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+
+	return first_err;
+}
+
+/**
+ * Synchronous admin-command helper for the dmamem admin queue.
+ *
+ * The dmamem admin queue does not carry a request pool, so submit_sync
+ * cannot be used. This helper does a manual enqueue + doorbell + reap
+ * with a caller-supplied CID.
+ */
+static inline int
+nvme_admin_sync_dmamem(struct nvme_controller *ctrlr, struct nvme_command *cmd, uint16_t cid,
+		       struct nvme_completion *cpl)
+{
+	int err;
+
+	cmd->cid = cid;
+
+	err = nvme_qpair_enqueue(&ctrlr->aq, cmd);
+	if (err) {
+		return err;
+	}
+	nvme_qpair_sqdb_update(&ctrlr->aq);
+
+	err = nvme_qpair_reap_cpl(&ctrlr->aq, ctrlr->timeout_ms, cpl);
+	if (err) {
+		return err;
+	}
+	if ((cpl->status >> 1) & 0x7FF) {
+		UPCIE_DEBUG("FAILED: admin CQE status=0x%x", cpl->status);
+		return -EIO;
+	}
+	return 0;
+}
+
+/**
+ * Create an I/O queue pair on the dmamem path.
+ *
+ * Allocates SQ/CQ from the caller's dmamem_heap, then programs the
+ * controller via admin CREATE_IO_CQ + CREATE_IO_SQ so the controller
+ * knows about the new qpair. The resulting nvme_qpair is compatible
+ * with the heap-agnostic submit/reap primitives (nvme_qpair_enqueue,
+ * nvme_qpair_sqdb_update, nvme_qpair_reap_cpl).
+ *
+ * The qid is allocated from the controller's bitmap; the caller must
+ * hold on to the returned sq_offset/cq_offset until
+ * nvme_controller_delete_io_qpair_dmamem is called.
+ */
+static inline int
+nvme_controller_create_io_qpair_dmamem(struct nvme_controller *ctrlr, struct nvme_qpair *qp,
+				       uint16_t depth, struct dmamem_heap *heap,
+				       size_t *sq_offset_out, size_t *cq_offset_out,
+				       size_t *prp_offset_out)
+{
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+	uint64_t sq_iova = 0, cq_iova = 0;
+	uint16_t qid;
+	int err;
+
+	err = nvme_qid_find_free(ctrlr->qids);
+	if (err < 1) {
+		return -ENOMEM;
+	}
+	qid = err;
+
+	err = nvme_qid_alloc(ctrlr->qids, qid);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qid_alloc; err(%d)", err);
+		return err;
+	}
+
+	err = nvme_qpair_dmamem_init(qp, qid, depth, ctrlr->func.bars[0].region, heap, sq_offset_out,
+				     cq_offset_out, prp_offset_out, &sq_iova, &cq_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_dmamem_init(io); err(%d)", err);
+		nvme_qid_free(ctrlr->qids, qid);
+		return err;
+	}
+
+	memset(&cmd, 0, sizeof(cmd));
+	cmd.opc = 0x5; /* Create I/O Completion Queue */
+	cmd.prp1 = cq_iova;
+	cmd.cdw10 = ((uint32_t)(depth - 1) << 16) | qid;
+	cmd.cdw11 = 0x1; /* Physically contiguous, no interrupts */
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 2, &cpl);
+	if (err) {
+		UPCIE_DEBUG("FAILED: CREATE_IO_CQ(qid=%u); err(%d)", qid, err);
+		goto rollback_qpair;
+	}
+
+	memset(&cmd, 0, sizeof(cmd));
+	memset(&cpl, 0, sizeof(cpl));
+	cmd.opc = 0x1; /* Create I/O Submission Queue */
+	cmd.prp1 = sq_iova;
+	cmd.cdw10 = ((uint32_t)(depth - 1) << 16) | qid;
+	cmd.cdw11 = ((uint32_t)qid << 16) | 0x1; /* CQID | physically contiguous */
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 3, &cpl);
+	if (err) {
+		struct nvme_command drop = {0};
+		struct nvme_completion drop_cpl = {0};
+
+		UPCIE_DEBUG("FAILED: CREATE_IO_SQ(qid=%u); err(%d)", qid, err);
+		drop.opc = 0x4; /* Delete I/O Completion Queue */
+		drop.cdw10 = qid;
+		(void)nvme_admin_sync_dmamem(ctrlr, &drop, 4, &drop_cpl);
+		goto rollback_qpair;
+	}
+
+	return 0;
+
+rollback_qpair:
+	nvme_qpair_dmamem_term(qp, heap, *sq_offset_out, *cq_offset_out, *prp_offset_out);
+	nvme_qid_free(ctrlr->qids, qid);
+	return err;
+}
+
+/**
+ * Tear down an I/O queue pair created with the dmamem variant.
+ */
+static inline int
+nvme_controller_delete_io_qpair_dmamem(struct nvme_controller *ctrlr, struct nvme_qpair *qp,
+				       struct dmamem_heap *heap, size_t sq_offset, size_t cq_offset,
+				       size_t prp_offset)
+{
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+	uint16_t qid = qp->qid;
+	int first_err = 0;
+	int err;
+
+	cmd.opc = 0x0; /* Delete I/O Submission Queue */
+	cmd.cdw10 = qid;
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 5, &cpl);
+	if (err && !first_err) {
+		first_err = err;
+	}
+
+	memset(&cmd, 0, sizeof(cmd));
+	memset(&cpl, 0, sizeof(cpl));
+	cmd.opc = 0x4; /* Delete I/O Completion Queue */
+	cmd.cdw10 = qid;
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 6, &cpl);
+	if (err && !first_err) {
+		first_err = err;
+	}
+
+	nvme_qpair_dmamem_term(qp, heap, sq_offset, cq_offset, prp_offset);
+	nvme_qid_free(ctrlr->qids, qid);
+	return first_err;
+}

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller_vfio.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller_vfio.h
@@ -6,7 +6,7 @@
 /**
  * VFIO NVMe Controller Extension
  * ==============================
- * 
+ *
  * @file nvme_controller_vfio.h
  * @version 0.5.1
  */
@@ -22,36 +22,6 @@ struct vfio_ctx {
 	size_t bar0_size;
 	int iommu_set;
 };
-
-static inline int
-nvme_vfio_pci_bus_master_enable(int device_fd)
-{
-	struct vfio_region_info config = {0};
-	uint16_t cmd;
-	ssize_t ret;
-	int err;
-
-	config.index = VFIO_PCI_CONFIG_REGION_INDEX;
-	err = vfio_device_get_region_info(device_fd, &config);
-	if (err < 0) {
-		return -errno;
-	}
-
-	ret = pread(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
-	if (ret != (ssize_t)sizeof(cmd)) {
-		return ret < 0 ? -errno : -EIO;
-	}
-
-	if (!(cmd & PCI_COMMAND_MASTER)) {
-		cmd |= PCI_COMMAND_MASTER;
-		ret = pwrite(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
-		if (ret != (ssize_t)sizeof(cmd)) {
-			return ret < 0 ? -errno : -EIO;
-		}
-	}
-
-	return 0;
-}
 
 static inline void
 nvme_vfio_ctx_init(struct vfio_ctx *vfio)
@@ -218,7 +188,6 @@ static inline int
 nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, const char *bdf,
 			  struct hostmem_heap *heap)
 {
-	struct vfio_region_info region = {0};
 	int api_version = 0;
 	int group_id = -1;
 	uint64_t cap;
@@ -316,44 +285,14 @@ nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, 
 		goto fail;
 	}
 
-	err = nvme_vfio_pci_bus_master_enable(vfio->device_fd);
+	err = nvme_vfio_pci_acquire_bar0(vfio->device_fd, ctrlr, &vfio->bar0, &vfio->bar0_size);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_vfio_pci_bus_master_enable(); err(%d)", err);
 		goto fail;
 	}
+	bar0 = vfio->bar0;
 
-	region.index = VFIO_PCI_BAR0_REGION_INDEX;
-	err = vfio_device_get_region_info(vfio->device_fd, &region);
-	if (err < 0) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
-		goto fail;
-	}
-
-	bar0 = vfio_map_region(vfio->device_fd, region.size, region.offset);
-	if (bar0 == MAP_FAILED) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
-		goto fail;
-	}
-
-	vfio->bar0 = bar0;
-	vfio->bar0_size = region.size;
-	ctrlr->func.bars[0].region = bar0;
-	ctrlr->func.bars[0].size = region.size;
-	ctrlr->func.bars[0].id = 0;
-	ctrlr->func.bars[0].fd = vfio->device_fd;
-
-	// Continue with the common NVMe controller initialization
-	cap = nvme_mmio_cap_read(bar0);
-	// CAP.TO is encoded in units of 500 ms.
-	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
-
-	nvme_mmio_cc_disable(bar0);
-
-	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	err = nvme_controller_reset_via_bar0(ctrlr, bar0, &cap);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
 		goto fail;
 	}
 
@@ -366,24 +305,8 @@ nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, 
 	nvme_mmio_aq_setup(bar0, hostmem_dma_v2p(heap, ctrlr->aq.sq),
 			   hostmem_dma_v2p(heap, ctrlr->aq.cq), ctrlr->aq.depth);
 
-	{
-		uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
-		uint32_t cc = 0;
-
-		cc = nvme_reg_cc_set_css(cc, css);
-		cc = nvme_reg_cc_set_shn(cc, 0x0);
-		cc = nvme_reg_cc_set_mps(cc, 0x0);
-		cc = nvme_reg_cc_set_ams(cc, 0x0);
-		cc = nvme_reg_cc_set_iosqes(cc, 6);
-		cc = nvme_reg_cc_set_iocqes(cc, 4);
-		cc = nvme_reg_cc_set_en(cc, 0x1);
-
-		nvme_mmio_cc_write(bar0, cc);
-	}
-
-	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	err = nvme_controller_enable_via_bar0(ctrlr, bar0, cap);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
 		goto fail;
 	}
 

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller_vfio_pci.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller_vfio_pci.h
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * NVMe controller bring-up helpers shared across vfio-pci backings
+ * ================================================================
+ *
+ * From a caller-supplied vfio device fd, acquire BAR0 and drive the
+ * NVMe controller enable sequence. Both nvme_controller_open_vfio
+ * (legacy vfio type1 container) and nvme_controller_open_dmamem_vfio
+ * (iommufd + dmamem) reach the same code once they have a device fd:
+ * bus-master enable, BAR0 mmap, CC.EN=0/1 dance, CAP/CSTS handshake.
+ * That invariant middle lives here. The parts that vary (how the fd
+ * was obtained, how DMA is mapped, which heap backs the admin queue)
+ * stay with each caller.
+ *
+ * @file nvme_controller_vfio_pci.h
+ * @version 0.5.1
+ */
+
+/**
+ * Enable PCI bus master on a vfio device via config-space write.
+ *
+ * The controller needs BM=1 to DMA into any host- or peer-mapped
+ * memory, regardless of which DMA API installed the mapping.
+ */
+static inline int
+nvme_vfio_pci_bus_master_enable(int device_fd)
+{
+	struct vfio_region_info config = {0};
+	uint16_t cmd;
+	ssize_t ret;
+	int err;
+
+	config.index = VFIO_PCI_CONFIG_REGION_INDEX;
+	err = vfio_device_get_region_info(device_fd, &config);
+	if (err < 0) {
+		return -errno;
+	}
+
+	ret = pread(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
+	if (ret != (ssize_t)sizeof(cmd)) {
+		return ret < 0 ? -errno : -EIO;
+	}
+
+	if (!(cmd & PCI_COMMAND_MASTER)) {
+		cmd |= PCI_COMMAND_MASTER;
+		ret = pwrite(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
+		if (ret != (ssize_t)sizeof(cmd)) {
+			return ret < 0 ? -errno : -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * Acquire BAR0 for the given vfio device.
+ *
+ * Enables bus master, mmap's BAR0 through the vfio fd, and populates
+ * ctrlr->func.bars[0] so the submit/reap primitives can find the
+ * doorbell region.
+ *
+ * @param device_fd      Open vfio device fd (obtained from a group or
+ *                       from an iommufd cdev bind).
+ * @param ctrlr          Controller descriptor; func.bars[0] is filled in.
+ * @param bar0_out       On success, the mmap'd BAR0 base.
+ * @param bar0_size_out  On success, the mapping length.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+nvme_vfio_pci_acquire_bar0(int device_fd, struct nvme_controller *ctrlr, void **bar0_out,
+			   size_t *bar0_size_out)
+{
+	struct vfio_region_info region = {0};
+	void *bar0;
+	int err;
+
+	err = nvme_vfio_pci_bus_master_enable(device_fd);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_vfio_pci_bus_master_enable(); err(%d)", err);
+		return err;
+	}
+
+	region.index = VFIO_PCI_BAR0_REGION_INDEX;
+	err = vfio_device_get_region_info(device_fd, &region);
+	if (err < 0) {
+		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
+		return -errno;
+	}
+
+	bar0 = vfio_map_region(device_fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
+		return -errno;
+	}
+
+	ctrlr->func.bars[0].region = bar0;
+	ctrlr->func.bars[0].size = region.size;
+	ctrlr->func.bars[0].id = 0;
+	ctrlr->func.bars[0].fd = device_fd;
+
+	*bar0_out = bar0;
+	*bar0_size_out = region.size;
+
+	return 0;
+}
+
+/**
+ * Read CAP, derive controller timeout, disable the controller, wait
+ * for CSTS.RDY=0.
+ *
+ * The caller uses *cap_out when programming CC on enable.
+ */
+static inline int
+nvme_controller_reset_via_bar0(struct nvme_controller *ctrlr, uint8_t *bar0, uint64_t *cap_out)
+{
+	uint64_t cap = nvme_mmio_cap_read(bar0);
+	int err;
+
+	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
+
+	nvme_mmio_cc_disable(bar0);
+
+	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
+		return err;
+	}
+
+	*cap_out = cap;
+	return 0;
+}
+
+/**
+ * Program CC with the standard defaults and wait for CSTS.RDY=1.
+ *
+ * The AQA/ASQ/ACQ programming must have already happened (via
+ * nvme_mmio_aq_setup) so the controller finds the admin queue on
+ * enable.
+ */
+static inline int
+nvme_controller_enable_via_bar0(struct nvme_controller *ctrlr, uint8_t *bar0, uint64_t cap)
+{
+	uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
+	uint32_t cc = 0;
+	int err;
+
+	cc = nvme_reg_cc_set_css(cc, css);
+	cc = nvme_reg_cc_set_shn(cc, 0x0);
+	cc = nvme_reg_cc_set_mps(cc, 0x0);
+	cc = nvme_reg_cc_set_ams(cc, 0x0);
+	cc = nvme_reg_cc_set_iosqes(cc, 6);
+	cc = nvme_reg_cc_set_iocqes(cc, 4);
+	cc = nvme_reg_cc_set_en(cc, 0x1);
+
+	nvme_mmio_cc_write(bar0, cc);
+
+	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
+		return err;
+	}
+
+	return 0;
+}

--- a/toolbox/third-party/linux/upcie/nvme/nvme_request.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_request.h
@@ -24,7 +24,7 @@
  * The stack implementation has an upper-bound of NVME_REQUEST_POOL_LEN elements.
  *
  * @file nvme_request.h
- * @version 0.5.1
+ * @version 0.5.2
  */
 
 #define NVME_REQUEST_POOL_LEN 1024
@@ -82,6 +82,68 @@ nvme_request_pool_init_prps(struct nvme_request_pool *pool, struct hostmem_heap 
 		pool->reqs[i].prp_addr = hostmem_dma_v2p(heap, pool->reqs[i].prp);
 	}
 
+	return 0;
+}
+
+/**
+ * Release the PRP-list scratch region held by a dmamem-backed request pool.
+ *
+ * The counterpart to nvme_request_pool_init_prps_dmamem. The caller
+ * provides the same heap and the prp_offset returned by init; the pool
+ * struct itself is caller-owned.
+ */
+static inline void
+nvme_request_pool_term_prps_dmamem(struct nvme_request_pool *pool, struct dmamem_heap *heap,
+				   size_t prp_offset)
+{
+	if (!pool || !pool->prps) {
+		return;
+	}
+	dmamem_heap_free(heap, prp_offset);
+	pool->prps = NULL;
+}
+
+/**
+ * Populate a request pool with per-request PRP-list scratch from a dmamem_heap.
+ *
+ * Sibling of nvme_request_pool_init_prps: same layout (one 4 KiB page
+ * per request, addressed through pool->reqs[i].prp / .prp_addr), but the
+ * scratch region is carved from a single contiguous IOAS-mapped block so
+ * translation is arithmetic rather than a per-page phys_lut walk.
+ *
+ * @param pool           Caller-owned request pool (already nvme_request_pool_init'd).
+ * @param heap           dmamem_heap the scratch region is carved from.
+ * @param prp_offset_out Heap offset of the scratch region, for later term.
+ *
+ * @return 0 on success, negative errno on allocation failure.
+ */
+static inline int
+nvme_request_pool_init_prps_dmamem(struct nvme_request_pool *pool, struct dmamem_heap *heap,
+				   size_t *prp_offset_out)
+{
+	const size_t pagesize = 4096;
+	size_t prp_offset = 0;
+	uint8_t *prps_va;
+	uint64_t prps_iova;
+	int err;
+
+	err = dmamem_heap_alloc_aligned(heap, (size_t)NVME_REQUEST_POOL_LEN * pagesize, pagesize,
+					&prp_offset);
+	if (err) {
+		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_aligned(prps); err(%d)", err);
+		return err;
+	}
+
+	prps_va = dmamem_heap_at_va(heap, prp_offset);
+	prps_iova = dmamem_heap_at_iova(heap, prp_offset);
+
+	pool->prps = prps_va;
+	for (uint16_t i = 0; i < NVME_REQUEST_POOL_LEN; ++i) {
+		pool->reqs[i].prp = prps_va + ((size_t)i * pagesize);
+		pool->reqs[i].prp_addr = prps_iova + ((uint64_t)i * pagesize);
+	}
+
+	*prp_offset_out = prp_offset;
 	return 0;
 }
 
@@ -283,6 +345,169 @@ nvme_request_prep_command_prps_iov(struct nvme_request *request, struct hostmem_
 
 		while (remaining > 0) {
 			prp_list[prp_idx++] = hostmem_dma_v2p(heap, base + offset);
+
+			offset += pagesize;
+			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
+		}
+	}
+
+	if (prp_idx == 1) {
+		cmd->prp2 = prp_list[0];
+	} else if (prp_idx > 1) {
+		cmd->prp2 = request->prp_addr;
+	}
+}
+
+/**
+ * Prepare the PRP entries for a command whose contiguous data buffer
+ * lives inside a dmamem_heap.
+ *
+ * Sibling of nvme_request_prep_command_prps_contig for the dmamem
+ * world. Behaviour depends on the underlying dmamem's translator:
+ *
+ *   ARITHMETIC: the heap sits on one contiguous IOAS mapping, so
+ *   every subsequent page is at prp1 + i * pagesize. Single
+ *   dmamem_va_to_iova at the start; the rest is arithmetic.
+ *
+ *   LUT: pages inside a hugepage still stride physically from prp1,
+ *   but crossing a hugepage boundary requires re-translation. Same
+ *   shape as the hostmem_heap variant above: stride within the
+ *   hugepage, dmamem_va_to_iova (via phys_lut) at each boundary.
+ *
+ * The translator dispatch is one predictable compare; a process
+ * runs one translator for its lifetime, so it predicts perfectly
+ * after warmup.
+ *
+ * Caveats
+ * -------
+ *
+ * - dbuf must be allocated from heap.
+ * - dbuf must be dword (4-byte) aligned.
+ * - PRP list chaining is not supported: dbuf may span at most 513
+ *   pages (PRP1 plus a single 512-entry PRP list page).
+ *
+ * @param request      NVMe request context; the PRP list is written
+ *                     into request->prp with iova request->prp_addr.
+ * @param heap         dmamem_heap that dbuf was carved from.
+ * @param dbuf         Virtually contiguous data buffer.
+ * @param dbuf_nbytes  Size of dbuf in bytes.
+ * @param cmd          Command to populate prp1 (and prp2 / PRP list)
+ *                     on.
+ */
+static inline void
+nvme_request_prep_command_prps_contig_dmamem(struct nvme_request *request,
+					     struct dmamem_heap *heap, void *dbuf,
+					     size_t dbuf_nbytes, struct nvme_command *cmd)
+{
+	const uint64_t pagesize = 4096;
+	const int page_shift = 12;
+	struct dmamem *dmem = heap->dmem;
+	const uint64_t page_off = (uintptr_t)dbuf & (pagesize - 1);
+	const uint64_t npages = (page_off + dbuf_nbytes + pagesize - 1) >> page_shift;
+
+	cmd->prp1 = dmamem_va_to_iova(dmem, dbuf);
+
+	/* Chaining is not supported, thus assert that the given dbuf fits. */
+	assert(npages <= 1 + 512);
+
+	if (npages == 1) {
+		return;
+	}
+
+	if (DMAMEM_XLATE_ARITHMETIC == dmem->translator) {
+		const uint64_t page_iova = cmd->prp1 - page_off;
+
+		if (npages == 2) {
+			cmd->prp2 = page_iova + pagesize;
+			return;
+		}
+
+		uint64_t *prp_list = request->prp;
+
+		cmd->prp2 = request->prp_addr;
+		for (uint64_t i = 1; i < npages; ++i) {
+			prp_list[i - 1] = page_iova + (i << page_shift);
+		}
+		return;
+	}
+
+	/* LUT: stride within the hugepage from prp1; re-translate on
+	 * hugepage boundaries. Buffers that fit inside a single hugepage
+	 * (the common case) never cross, so this reduces to the stride
+	 * of a contiguous buffer. */
+	uint8_t *vbase = (uint8_t *)dbuf - page_off;
+	const uint64_t hp_off =
+		(uint64_t)(vbase - (uint8_t *)dmem->cpu_va) & (dmem->hugepgsz - 1);
+	uint64_t strides_left = ((dmem->hugepgsz - hp_off) >> page_shift) - 1;
+	uint64_t page_phys = cmd->prp1 - page_off;
+
+	if (npages == 2) {
+		cmd->prp2 = strides_left ? page_phys + pagesize
+					 : dmamem_va_to_iova(dmem, vbase + pagesize);
+		return;
+	}
+
+	uint64_t *prp_list = request->prp;
+
+	cmd->prp2 = request->prp_addr;
+	for (uint64_t i = 1; i < npages; ++i) {
+		if (strides_left) {
+			page_phys += pagesize;
+			strides_left--;
+		} else {
+			page_phys = dmamem_va_to_iova(dmem, vbase + (i << page_shift));
+			strides_left = (dmem->hugepgsz >> page_shift) - 1;
+		}
+		prp_list[i - 1] = page_phys;
+	}
+}
+
+/**
+ * Prepare the PRP entries for a command with a scatter-gather data
+ * buffer whose iovec elements live inside a dmamem_heap.
+ *
+ * Sibling of nvme_request_prep_command_prps_iov for the dmamem
+ * world. Each iovec base is translated via dmamem_va_to_iova so
+ * both ARITHMETIC and LUT dmamems work.
+ *
+ * Caveats
+ * -------
+ *
+ * - Each iovec base must be page-aligned and allocated from heap.
+ * - PRP list chaining is not supported; only a single list page is
+ *   constructed.
+ *
+ * @param request   NVMe request context.
+ * @param heap      dmamem_heap the iovec buffers were carved from.
+ * @param dvec      Array of iovec structures.
+ * @param dvec_cnt  Element count of dvec.
+ * @param cmd       Command to populate prp1 (and prp2 / PRP list) on.
+ */
+static inline void
+nvme_request_prep_command_prps_iov_dmamem(struct nvme_request *request,
+					  struct dmamem_heap *heap, struct iovec *dvec,
+					  size_t dvec_cnt, struct nvme_command *cmd)
+{
+	const uint64_t pagesize = 4096;
+	struct dmamem *dmem = heap->dmem;
+	uint64_t *prp_list = request->prp;
+	size_t prp_idx = 0;
+
+	cmd->prp1 = dmamem_va_to_iova(dmem, dvec[0].iov_base);
+
+	for (size_t i = 0; i < dvec_cnt; ++i) {
+		uint8_t *base = dvec[i].iov_base;
+		size_t remaining = dvec[i].iov_len;
+		size_t offset = 0;
+
+		/* Skip the first page of the first iovec — it is PRP1 */
+		if (i == 0) {
+			offset = pagesize;
+			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
+		}
+
+		while (remaining > 0) {
+			prp_list[prp_idx++] = dmamem_va_to_iova(dmem, base + offset);
 
 			offset += pagesize;
 			remaining = (remaining > pagesize) ? remaining - pagesize : 0;

--- a/toolbox/third-party/linux/upcie/upcie.h
+++ b/toolbox/third-party/linux/upcie/upcie.h
@@ -76,9 +76,15 @@ extern "C" {
 #include <upcie/hostmem_hugepage.h>
 #include <upcie/hostmem_heap.h>
 #include <upcie/hostmem_dma.h>
+#include <upcie/iommufd.h>
 #include <upcie/mmio.h>
 #include <upcie/pci.h>
 #include <upcie/vfioctl.h>
+#include <upcie/dmamem.h>
+#include <upcie/dmamem_memfd.h>
+#include <upcie/dmamem_dmabuf.h>
+#include <upcie/dmamem_hostmem.h>
+#include <upcie/dmamem_heap.h>
 
 // uPCIe NVMe libraries
 #ifdef _UPCIE_WITH_NVME
@@ -88,7 +94,11 @@ extern "C" {
 #include <upcie/nvme/nvme_qid.h>
 #include <upcie/nvme/nvme_qpair.h>
 #include <upcie/nvme/nvme_controller.h>
+#include <upcie/nvme/nvme_controller_vfio_pci.h>
 #include <upcie/nvme/nvme_controller_vfio.h>
+#include <upcie/nvme/nvme_controller_dmamem_vfio.h>
+#include <upcie/nvme/nvme_controller_dmamem_uio.h>
+#include <upcie/nvme/nvme_controller_dmamem_type1.h>
 #endif
 
 #ifdef __cplusplus

--- a/toolbox/third-party/linux/upcie/upcie_cuda.h
+++ b/toolbox/third-party/linux/upcie/upcie_cuda.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <upcie/cudamem_heap.h>
 #include <upcie/cudamem_dma.h>
 #include <upcie/cudamem_mapping.h>
+#include <upcie/dmamem_cuda.h>
 
 // CUDA uPCIe NVMe libraries
 #ifdef _UPCIE_WITH_NVME

--- a/toolbox/third-party/linux/upcie/upcie_hip.h
+++ b/toolbox/third-party/linux/upcie/upcie_hip.h
@@ -42,6 +42,7 @@ extern "C" {
 #include <upcie/hipmem_heap.h>
 #include <upcie/hipmem_dma.h>
 #include <upcie/hipmem_mapping.h>
+#include <upcie/dmamem_hip.h>
 
 // HIP/ROCm uPCIe NVMe libraries
 //

--- a/toolbox/third-party/linux/upcie/vfioctl.h
+++ b/toolbox/third-party/linux/upcie/vfioctl.h
@@ -245,3 +245,73 @@ vfio_device_pci_hot_reset(struct vfio_device *dev, struct vfio_pci_hot_reset *re
 {
 	return ioctl(dev->fd, VFIO_DEVICE_PCI_HOT_RESET, reset);
 }
+
+/**
+ * Export a slice of a vfio-pci device region as a dma-buf fd.
+ *
+ * Wraps VFIO_DEVICE_FEATURE | GET | DMA_BUF. The returned fd is a
+ * regular dma-buf that iommufd's IOMMU_IOAS_MAP_FILE accepts on mainline
+ * 6.19+ because the exporter is vfio-pci (private interconnect via
+ * vfio_pci_dma_buf_iommufd_map).
+ *
+ * @param device_fd    vfio-cdev device fd (see iommufd_device_open).
+ * @param region_index BAR/region index, e.g. VFIO_PCI_BAR1_REGION_INDEX.
+ * @param offset       Offset within the region.
+ * @param length       Length of the slice.
+ * @return dma-buf fd (>= 0) on success, negative errno on failure.
+ */
+#ifdef VFIO_DEVICE_FEATURE_DMA_BUF
+static inline int
+vfio_device_bar_export_dmabuf(int device_fd, uint32_t region_index, uint64_t offset,
+			      uint64_t length)
+{
+	size_t bufsz = sizeof(struct vfio_device_feature) +
+		       sizeof(struct vfio_device_feature_dma_buf) +
+		       sizeof(struct vfio_region_dma_range);
+	struct vfio_device_feature *feat;
+	struct vfio_device_feature_dma_buf *dbuf;
+	struct vfio_region_dma_range *range;
+	int fd_or_err;
+
+	feat = calloc(1, bufsz);
+	if (!feat) {
+		return -ENOMEM;
+	}
+
+	feat->argsz = bufsz;
+	feat->flags = VFIO_DEVICE_FEATURE_GET | VFIO_DEVICE_FEATURE_DMA_BUF;
+
+	dbuf = (struct vfio_device_feature_dma_buf *)feat->data;
+	dbuf->region_index = region_index;
+	dbuf->open_flags = O_RDWR | O_CLOEXEC;
+	dbuf->flags = 0;
+	dbuf->nr_ranges = 1;
+
+	range = &dbuf->dma_ranges[0];
+	range->offset = offset;
+	range->length = length;
+
+	fd_or_err = ioctl(device_fd, VFIO_DEVICE_FEATURE, feat);
+	if (fd_or_err < 0) {
+		fd_or_err = -errno;
+	}
+
+	free(feat);
+	return fd_or_err;
+}
+#else
+// VFIO_DEVICE_FEATURE_DMA_BUF landed in Linux 6.19; on older UAPI headers
+// this stub lets callers link and fail at runtime with a clear -ENOTSUP
+// instead of breaking the build on distros that ship an older linux/vfio.h.
+static inline int
+vfio_device_bar_export_dmabuf(int device_fd, uint32_t region_index, uint64_t offset,
+			      uint64_t length)
+{
+	(void)device_fd;
+	(void)region_index;
+	(void)offset;
+	(void)length;
+
+	return -ENOTSUP;
+}
+#endif


### PR DESCRIPTION
## Summary

Introduces `be_dmamem` on xNVMe as a single backend covering
CPU-initiated NVMe I/O with hostmem-backed data buffers across
all three DMA APIs in use on Linux:

- vfio-cdev + iommufd + memfd + arithmetic translator (modern)
- vfio-pci + legacy type1 container + hostmem hugepage + arithmetic
- uio_pci_generic + hostmem hugepage + LUT translator
  (`iommu=pt` / `iommu=off`)

The CLI sees one id (`--be dmamem`); the mode is decided at
ctrlr_init by reading the kernel driver bound to the target BDF
via `/sys/bus/pci/devices/<bdf>/driver`. uio_pci_generic maps to
UIO_LUT; vfio-pci maps to VFIO_CDEV when `/dev/iommu` is usable
and a vfio-cdev entry for the device exists, else VFIO_TYPE1. The
`XNVME_DMAMEM_VFIO_MODE` env var (`iommufd` | `type1` | `auto`)
overrides the vfio-pci default. Anything else fails with
-EOPNOTSUPP.

A single process-wide RTE holds:

- vfio-cdev mode: iommufd handle + IOAS + hugepage-backed memfd
- vfio-type1 mode: vfio type1 container + hostmem_hugepage; the
  container is shared across controllers (each attaches its own
  group), and the first controller's ctrlr_init also does
  set_iommu(TYPE1) + MAP_DMA + dmamem_heap init
- uio mode: hostmem_hugepage with phys_lut populated

Either way a `dmamem_heap` sits on top and every controller
allocates SQ/CQ/PRP scratch from the same offset space. Submit is
mode-agnostic: `dmamem_va_to_iova` branches once on the
translator (be_dmamem uses one translator throughout, so that branch has a stable direction); the NVMe qpair side
reuses the shared `nvme_qpair_dmamem_init` family from uPCIe; PRP
composition routes through
`nvme_request_prep_command_prps_{contig,iov}_dmamem` from uPCIe
(introduced there with the translator in the same commit), so
this backend carries no local PRP helpers.

## Scope

Deliberately scoped to CPU-init + hostmem. VRAM data heaps
(`upcie-cuda`, `upcie-hip`) stay in their existing backends;
future work folds them onto a second `dmamem_heap` alongside the
control heap the RTE already brings up.

## Depends on upstream

Vendored uPCIe snapshot bumps from 0.5.1 to 0.5.2. That version
is the tip of the uPCIe PR stack, not yet merged. Landing order:

- safl/upcie#37 (dmamem umbrella + iommufd + NVMe extension)
- safl/upcie#38 (dma-buf constructor + NVMe DMA into GPU VRAM)
- safl/upcie#39 (unify vfio-pci path + shared bring-up helpers)
- safl/upcie#40 (discriminated LUT translator + PRP-prep helpers +
  hostmem/cuda/hip importers + `nvme_controller_dmamem_uio` +
  `nvme_controller_dmamem_type1`)
- then this PR.

## Correctness

`xnvme_tests_ioworker verify` + `verify-sync` against a real NVMe
device across all three modes on two operator hosts (`iommu=pt`
kernel cmdline). All rows 32768 / 32768 / 0 exit-stats:

| host  | binding          | mode         | verify-sync | verify |
|-------|------------------|--------------|-------------|--------|
| wave  | vfio-pci         | VFIO_CDEV    | pass | pass |
| wave  | vfio-pci         | VFIO_TYPE1   | pass | pass |
| wave  | uio_pci_generic  | UIO_LUT      | pass | pass |
| warp  | vfio-pci         | VFIO_CDEV    | pass | pass |
| warp  | vfio-pci         | VFIO_TYPE1   | pass | pass |
| warp  | uio_pci_generic  | UIO_LUT      | pass | pass |

## Throughput

`xnvmeperf run --iopattern randread --nqueues 1 --iosize 512
--runtime 10 --cpumask 0x1` on a post-format Samsung 9100 PRO
2 TB (kernel 7.0.6, PCIe Gen4 x4), `iommu=pt`:

| host | mode        | qd=16 IOPS | qd=128 IOPS |
|------|-------------|------------|-------------|
| wave | VFIO_CDEV   | 2.08 M     | 4.006 M     |
| wave | VFIO_TYPE1  | 2.08 M     | 4.007 M     |
| wave | UIO_LUT     | 2.08 M     | 4.006 M     |
| warp | VFIO_CDEV   | 1.95 M     | 3.95 M      |
| warp | VFIO_TYPE1  | 1.93 M     | 3.88 M      |
| warp | UIO_LUT     | 1.95 M     | 3.76 M      |

On wave the three modes are indistinguishable at both qds. On
warp there is a small hierarchy at qd=128 (VFIO_CDEV ~4.7%
ahead of UIO_LUT) that tracks the earlier warp-specific
iommu-configuration jitter, not a code-path bug. The point is
that all three modes hit the same envelope on the same drive
from the same CLI id.

## Reproduce

    ./configure --backend=dmamem  # or via meson: -Dbe_dmamem=true
    make
    # binding decides the default mode
    xnvme_tests_ioworker verify 0000:01:00.0 --be dmamem
    # force type1 while the device is on vfio-pci
    XNVME_DMAMEM_VFIO_MODE=type1 xnvme_tests_ioworker verify \
        0000:01:00.0 --be dmamem
    xnvmeperf run 0000:01:00.0 --be dmamem --iopattern randread \
        --nqueues 1 --qdepth 128 --iosize 512 --runtime 10 --cpumask 0x1