### PR TITLE
test: make backend-grouped ordering work on FreeBSD

### DIFF
--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -321,12 +321,7 @@ def pytest_collection_modifyitems(config, items):
     boundaries in the run and clustering failures by backend. Tests without
     parametrization sort before the parametrized batches with their
     relative order preserved.
-
-    Linux only. FreeBSD's kqueue async write/verify fails when reordered
-    this way, so leave it at the original collection order.
     """
-    if get_osname() == "freebsd":
-        return
 
     def key(item):
         callspec = getattr(item, "callspec", None)

--- a/cijoe/tests/tools/test_lblk.py
+++ b/cijoe/tests/tools/test_lblk.py
@@ -64,6 +64,10 @@ def test_write_uncor(cijoe, device, be_opts, cli_args):
     err, _ = cijoe.run(f"lblk write-uncor {cli_args} --slba 0x0 --nlb 0")
     assert not err
 
+    # Rewrite the LBA to clear the uncorrectable status
+    err, _ = cijoe.run(f"lblk write {cli_args} --slba 0x0 --nlb 0")
+    assert not err
+
 
 @xnvme_parametrize(labels=["write_zeroes"], opts=["be", "admin"])
 def test_write_zeroes(cijoe, device, be_opts, cli_args):

--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -166,7 +166,18 @@ def test_format(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "ramdisk":
         pytest.skip(reason="[be=ramdisk] does not implement format")
 
-    err, _ = cijoe.run(f"xnvme format {cli_args}")
+    # Reformat with the current LBA format to avoid changing the block size.
+    err, state = cijoe.run(f"xnvme idfy-ns {cli_args} --nsid {device['nsid']}")
+    assert not err
+
+    lbafl, lbafu = 0, 0
+    for line in state.output().split("\n"):
+        if "format_lsb:" in line:
+            lbafl = int(line.split(":")[1].strip())
+        elif "format_msb:" in line:
+            lbafu = int(line.split(":")[1].strip())
+
+    err, _ = cijoe.run(f"xnvme format {cli_args} --lbafl {lbafl} --lbafu {lbafu}")
     assert not err
 
 

--- a/lib/xnvme_be_freebsd_async.c
+++ b/lib/xnvme_be_freebsd_async.c
@@ -129,8 +129,7 @@ xnvme_be_freebsd_kqueue_poke(struct xnvme_queue *q, uint32_t max)
 		}
 
 		err = aio_error(&req->aiocb);
-		if (err == 0)
-			res = aio_return(&req->aiocb);
+		res = aio_return(&req->aiocb);
 
 		ctx = req->ctx;
 		ctx->cpl.result = res;

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -440,13 +440,7 @@ def pytest_collection_modifyitems(config, items):
     boundaries in the run and clustering failures by backend. Tests without
     parametrization sort before the parametrized batches with their
     relative order preserved.
-
-    Linux only. FreeBSD's kqueue async write/verify fails when reordered
-    this way, so leave it at the original collection order.
     """
-    osname = pytest.cijoe_instance.config.options.get("os", {}).get("name", "linux")
-    if osname == "freebsd":
-        return
 
     def key(item):
         callspec = getattr(item, "callspec", None)


### PR DESCRIPTION
Enables the backend-grouped test ordering (`pytest_collection_modifyitems`, added in #682) on FreeBSD, which was previously skipped because the kqueue async write/verify tests failed under it.

Root cause was **not** the kqueue backend — it's the test-isolation issue from #434: `test_format` reformatted the shared namespaces from their provisioned 4K format to 512B and never restored them. With tests grouped by backend, the `emu` group's `test_format` runs before the `kqueue` group's async I/O, so those ops hit a 512B namespace while FreeBSD's `nda` disk layer still advertises the original 4K sector (a passthru Format doesn't inform the OS). The kqueue path is the only one issuing I/O through the kernel disk/physio layer (`aio_read`/`aio_write`), so it's the only one that surfaced the mismatch as EIO; all other paths use the NVMe passthru ioctl and were unaffected.

Closes #685. Closes #434.

## Changes

- **test(format): reformat using the namespace's current LBA format** — detect the current lbaf via `idfy-ns` and pass it back to `format`, so the block size is preserved and the test is side-effect free. This is the actual fix.
- **test(conftest): enable backend ordering on FreeBSD** — drop the FreeBSD early-return in both `cijoe/tests/conftest.py` and `python/tests/conftest.py`.
- **test(lblk): clear uncorrectable status after write-uncor** — `test_write_uncor` left LBA 0 unreadable with no cleanup; rewrite the LBA afterward so later reads on the same device don't fail. (Latent hazard found during the same audit.)
- **fix(be_freebsd): reap errored aio requests with `aio_return()`** — `poke()` only reaped successful aiocbs, leaking kernel aio resources on error. Independent robustness fix surfaced by this investigation.
