### PR TITLE
Generic CPU id CLI argument parsing (and added `--cpulist` argument)

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_cli.py
+++ b/cijoe/tests/logic/test_xnvme_tests_cli.py
@@ -17,3 +17,67 @@ def test_optional_all(cijoe, device, be_opts, cli_args):
         f"--admin {be_opts['admin']} "
     )
     assert not err
+
+
+def test_cpuids_none(cijoe):
+    err, state = cijoe.run("xnvme_tests_cli cpu-ids")
+    assert not err
+
+    assert "cpumask: 'NULL', given: 0" in state.output()
+    assert "cpulist: 'NULL', given: 0" in state.output()
+    assert "ncpus: 0" in state.output()
+
+
+def test_cpuids_cpumask_0x(cijoe):
+    err, state = cijoe.run("xnvme_tests_cli cpu-ids --cpumask 0x3")
+    assert not err
+
+    assert "cpulist: 'NULL', given: 0" in state.output()
+    assert "ncpus: 2" in state.output()
+    for i, cpu in enumerate([0, 1]):
+        assert f"cpus[{i}]: {cpu}" in state.output()
+
+
+def test_cpuids_cpumask(cijoe):
+    err, state = cijoe.run("xnvme_tests_cli cpu-ids --cpumask 3")
+    assert not err
+
+    assert "cpulist: 'NULL', given: 0" in state.output()
+    assert "ncpus: 2" in state.output()
+    for i, cpu in enumerate([0, 1]):
+        assert f"cpus[{i}]: {cpu}" in state.output()
+
+
+def test_cpuids_cpulist(cijoe):
+    err, state = cijoe.run("xnvme_tests_cli cpu-ids --cpulist 2-4,6")
+    assert not err
+
+    assert "cpumask: 'NULL', given: 0" in state.output()
+    assert "ncpus: 4" in state.output()
+    for i, cpu in enumerate([2, 3, 4, 6]):
+        assert f"cpus[{i}]: {cpu}" in state.output()
+
+
+def test_cpuids_invalid(cijoe):
+    cases = [
+        "--cpumask 0x1 --cpulist 1",  # mutually exclusive
+        "--cpumask 0x0",  # zero mask
+        "--cpumask zz",  # not hex
+        "--cpulist ''",  # empty list
+        "--cpulist 2-1",  # reversed range
+        "--cpulist 1,",  # trailing comma
+        "--cpulist 1024",  # id out of range
+        "--cpulist 0,0",  # repeated id
+        "--cpulist 0-4,1",  # repeated id inside range
+        "--cpulist 0-4,3-6",  # repeated id inside ranges
+        "--cpulist 0-1023,0-1023",  # repeated id, would overflow cpus[]
+    ]
+
+    # Collect instead of asserting per case, to see every offender in one run
+    unexpected = []
+    for args in cases:
+        err, _ = cijoe.run(f"xnvme_tests_cli cpu-ids {args}")
+        if not err:
+            unexpected.append(args)
+
+    assert not unexpected, f"We expected these to fail: {unexpected}"

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -26,6 +26,8 @@
 #define XNVME_CLI_ASYNC_OPTS \
 	XNVME_CLI_SYNC_OPTS, { XNVME_CLI_OPT_ASYNC, XNVME_CLI_LOPT }
 
+#define XNVME_CLI_CPU_MAX_ID 1024
+
 /**
  * Options are stored in an instance of this structure
  *
@@ -173,7 +175,11 @@ struct xnvme_cli_args {
 
 	uint32_t runtime;
 	const char *iopattern;
+
 	const char *cpumask;
+	uint16_t cpus[XNVME_CLI_CPU_MAX_ID]; //< Maximum of 1024 pinned CPUs
+	uint16_t ncpus;
+
 	uint32_t nqueues;
 
 	const char **posn; //< Remaining positional args (points into argv)

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -177,6 +177,8 @@ struct xnvme_cli_args {
 	const char *iopattern;
 
 	const char *cpumask;
+
+	const char *cpulist;
 	uint16_t cpus[XNVME_CLI_CPU_MAX_ID]; //< Maximum of 1024 pinned CPUs
 	uint16_t ncpus;
 
@@ -364,7 +366,9 @@ enum xnvme_cli_opt {
 
 	XNVME_CLI_OPT_GPU_ID = 131, ///< XNVME_CLI_OPT_GPU_ID
 
-	XNVME_CLI_OPT_END = 132, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_CPULIST = 132, ///< XNVME_CLI_OPT_CPULIST
+
+	XNVME_CLI_OPT_END = 133, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/include/libxnvme_util.h
+++ b/include/libxnvme_util.h
@@ -315,6 +315,18 @@ xnvme_is_pow2(uint32_t val)
 	return val && !(val & (val - 1));
 }
 
+static inline int
+xnvme_hex_digit_val(char c)
+{
+	if (c >= '0' && c <= '9') {
+		return c - '0';
+	}
+	if (c >= 'a' && c <= 'f') {
+		return c - 'a' + 10;
+	}
+	return c - 'A' + 10;
+}
+
 #ifdef XNVME_DEBUG_ENABLED
 
 #define XNVME_DEBUG_FCALL(x) x

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -1141,6 +1141,68 @@ xnvme_cli_usage(struct xnvme_cli *cli)
 	}
 }
 
+/**
+ * Parse a CPU hex mask into a list of CPU ids and save it in args->cpus
+ */
+static int
+parse_cpumask(struct xnvme_cli_args *args, const char *hex)
+{
+	int len, count = 0, err;
+	bool nonzero = false;
+
+	len = strlen(hex);
+
+	if (len > 1 && (!memcmp(hex, "0x", 2) || !memcmp(hex, "0X", 2))) {
+		hex += 2;
+		len -= 2;
+	}
+
+	if (len == 0) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --cpumask must be a non-zero hex value", err);
+		return err;
+	}
+
+	if (len > XNVME_CLI_CPU_MAX_ID / 4) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --cpumask cannot define a CPU id > 1023", err);
+		return err;
+	}
+
+	for (int i = 0; i < len; i++) {
+		char c = hex[i];
+		if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+		      (c >= 'A' && c <= 'F'))) {
+			err = -EINVAL;
+			xnvme_cli_perr("Error: --cpumask must be a non-zero hex value", err);
+			return err;
+		}
+		if (c != '0') {
+			nonzero = true;
+		}
+	}
+	if (!nonzero) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --cpumask must be a non-zero hex value", err);
+		return err;
+	}
+
+	// Extract CPU indices; rightmost digit = lowest bits
+	count = 0;
+	for (int i = len - 1; i >= 0; i--) {
+		int value = xnvme_hex_digit_val(hex[i]);
+		int bit_offset = (len - 1 - i) * 4;
+		for (int b = 0; b < 4; b++) {
+			if ((value >> b) & 1) {
+				args->cpus[count++] = bit_offset + b;
+			}
+		}
+	}
+
+	args->ncpus = count;
+	return 0;
+}
+
 int
 xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr, char *arg,
 		     enum xnvme_cli_opt_type opt_type)
@@ -1148,6 +1210,7 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 	struct xnvme_cli_args *args = &cli->args;
 	char *endptr = NULL;
 	uint64_t num = 0;
+	int err;
 
 	// Check numerical args
 	if (arg && (opt_type != XNVME_CLI_LFLG)) {
@@ -1594,7 +1657,15 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 		args->iopattern = arg ? arg : "INVALID_INPUT";
 		break;
 	case XNVME_CLI_OPT_CPUMASK:
-		args->cpumask = arg ? arg : "INVALID_INPUT";
+		args->cpumask = arg;
+
+		if (args->cpumask) {
+			err = parse_cpumask(args, args->cpumask);
+			if (err) {
+				errno = -err;
+				return -1;
+			}
+		}
 		break;
 	case XNVME_CLI_OPT_NQUEUES:
 		args->nqueues = num;

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -894,6 +894,13 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "Hex CPU bitmask for thread pinning (e.g. 0x3)",
 	},
 	{
+		.opt = XNVME_CLI_OPT_CPULIST,
+		.vtype = XNVME_CLI_OPT_VTYPE_STR,
+		.name = "cpulist",
+		.descr = "Comma-separated list of CPU ids or CPU id ranges for thread pinning "
+			 "(e.g. 0-3,4,6)",
+	},
+	{
 		.opt = XNVME_CLI_OPT_NQUEUES,
 		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
 		.name = "nqueues",
@@ -1196,6 +1203,106 @@ parse_cpumask(struct xnvme_cli_args *args, const char *hex)
 			if ((value >> b) & 1) {
 				args->cpus[count++] = bit_offset + b;
 			}
+		}
+	}
+
+	args->ncpus = count;
+	return 0;
+}
+
+/**
+ * Reads one "<cpu>" or "<first>-<last>" element at the cursor, advancing it
+ * past the element and any separating comma.
+ *
+ * Ids that no CPU corresponds to are not rejected here; they are caught when
+ * the thread fails to pin.
+ */
+static int
+parse_cpulist_elem(const char **cur, uint32_t *first_out, uint32_t *last_out)
+{
+	unsigned long first, last;
+	char *end;
+
+	errno = 0; // strtoul does not modify errno on success, so clear before calling
+	first = strtoul(*cur, &end, 10);
+	if (errno || *cur == end) {
+		XNVME_DEBUG("FAILED: strtoul(), errno: %d, cur: %s", errno, *cur);
+		return -EINVAL;
+	}
+	if (first >= XNVME_CLI_CPU_MAX_ID) {
+		XNVME_DEBUG("ERROR: Parsed CPU(%lu) cannot exceed 1023", first);
+		return -EINVAL;
+	}
+	*cur = end;
+
+	last = first;
+	if (**cur == '-') {
+		*cur += 1;
+		last = strtoul(*cur, &end, 10);
+		if (errno || *cur == end) {
+			XNVME_DEBUG("FAILED: strtoul(), errno: %d, cur: %s", errno, *cur);
+			return -EINVAL;
+		}
+		if (last >= XNVME_CLI_CPU_MAX_ID) {
+			XNVME_DEBUG("ERROR: Parsed CPU(%lu) cannot exceed 1023", last);
+			return -EINVAL;
+		}
+		*cur = end;
+	}
+
+	if (first > last) {
+		// do not allow ranges like 3-1
+		return -EINVAL;
+	}
+
+	if (**cur == ',') {
+		*cur += 1;
+		if (**cur == '\0') {
+			// do not allow trailing commas
+			return -EINVAL;
+		}
+	} else if (**cur != '\0') {
+		return -EINVAL;
+	}
+
+	*first_out = first;
+	*last_out = last;
+	return 0;
+}
+
+static int
+parse_cpulist(struct xnvme_cli_args *args, const char *list)
+{
+	uint64_t seen[(XNVME_CLI_CPU_MAX_ID + 63) / 64] = {0};
+	const char *cur = list;
+	uint32_t first, last;
+	int count = 0, err;
+
+	if (!list || !list[0]) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --cpulist must be a non-empty list of CPU ids", err);
+		return err;
+	}
+
+	// Expand each element in the order given
+	while (*cur) {
+		err = parse_cpulist_elem(&cur, &first, &last);
+		if (err) {
+			return err;
+		}
+		// since first and last both a < XNVME_CLI_CPU_MAX_ID, no need to
+		// guard against overflowing the cpus array. Rejecting repeated ids
+		// is what caps the number of writes at XNVME_CLI_CPU_MAX_ID.
+		for (uint32_t cpu = first; cpu <= last; cpu++) {
+			if (seen[cpu / 64] & (1ULL << (cpu % 64))) {
+				err = -EINVAL;
+				xnvme_cli_perr("Error: --cpulist must not repeat CPU ids", err);
+				XNVME_DEBUG("FAILED: CPU(%u) given more than once", cpu);
+				return err;
+			}
+			seen[cpu / 64] |= 1ULL << (cpu % 64);
+
+			args->cpus[count++] = cpu;
 		}
 	}
 
@@ -1657,6 +1764,12 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 		args->iopattern = arg ? arg : "INVALID_INPUT";
 		break;
 	case XNVME_CLI_OPT_CPUMASK:
+		if (cli->given[XNVME_CLI_OPT_CPULIST]) {
+			errno = EINVAL;
+			xnvme_cli_perr("--cpulist and --cpumask are mutually exclusive", errno);
+			return -1;
+		}
+
 		args->cpumask = arg;
 
 		if (args->cpumask) {
@@ -1666,6 +1779,25 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 				return -1;
 			}
 		}
+
+		break;
+	case XNVME_CLI_OPT_CPULIST:
+		if (cli->given[XNVME_CLI_OPT_CPUMASK]) {
+			errno = EINVAL;
+			xnvme_cli_perr("--cpulist and --cpumask are mutually exclusive", errno);
+			return -1;
+		}
+
+		args->cpulist = arg;
+
+		if (args->cpulist) {
+			err = parse_cpulist(args, args->cpulist);
+			if (err) {
+				errno = -err;
+				return -1;
+			}
+		}
+
 		break;
 	case XNVME_CLI_OPT_NQUEUES:
 		args->nqueues = num;

--- a/tests/cli.c
+++ b/tests/cli.c
@@ -19,6 +19,24 @@ sub_optional(struct xnvme_cli *cli)
 	return err;
 }
 
+static int
+sub_cpuids(struct xnvme_cli *cli)
+{
+	int err = 0;
+
+	xnvme_cli_pinf("cpumask: '%s', given: %d", cli->args.cpumask ? cli->args.cpumask : "NULL",
+		       cli->given[XNVME_CLI_OPT_CPUMASK]);
+	xnvme_cli_pinf("cpulist: '%s', given: %d", cli->args.cpulist ? cli->args.cpulist : "NULL",
+		       cli->given[XNVME_CLI_OPT_CPULIST]);
+
+	xnvme_cli_pinf("ncpus: %d", cli->args.ncpus);
+	for (int i = 0; i < cli->args.ncpus; i++) {
+		xnvme_cli_pinf("cpus[%d]: %d", i, cli->args.cpus[i]);
+	}
+
+	return err;
+}
+
 static struct xnvme_cli_sub g_subs[] = {
 	{
 		"optional",
@@ -27,6 +45,16 @@ static struct xnvme_cli_sub g_subs[] = {
 		sub_optional,
 		{
 			XNVME_CLI_ASYNC_OPTS,
+		},
+	},
+	{
+		"cpu-ids",
+		"Command-line arguments for pinning CPUs",
+		"Command-line arguments for pinning CPUs",
+		sub_cpuids,
+		{
+			{XNVME_CLI_OPT_CPUMASK, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_CPULIST, XNVME_CLI_LOPT},
 		},
 	},
 };

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -3,6 +3,7 @@
 #endif
 
 #include <errno.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -38,7 +39,7 @@ struct xnvmeperf_job {
 };
 
 struct xnvmeperf_thread {
-	int cpu;
+	uint16_t cpu;
 	int njobs;
 	int job_start;
 	struct xnvmeperf_job *jobs;
@@ -82,87 +83,6 @@ pin_to_cpu(int cpu)
 	fprintf(stderr, "Warning: CPU pinning not supported on this platform\n");
 	return 0;
 #endif
-}
-
-// Returns the integer value of a hexadecimal digit character.
-static int
-hex_digit_val(char c)
-{
-	if (c >= '0' && c <= '9') {
-		return c - '0';
-	}
-	if (c >= 'a' && c <= 'f') {
-		return c - 'a' + 10;
-	}
-	return c - 'A' + 10;
-}
-
-static int
-parse_cpumask(const char *hex, int **cpus_out, int *ncpus_out)
-{
-	int len, count = 0, err;
-	int *cpus;
-	bool nonzero = false;
-
-	len = strlen(hex);
-
-	if (len > 1 && (!memcmp(hex, "0x", 2) || !memcmp(hex, "0X", 2))) {
-		hex += 2;
-		len -= 2;
-	}
-
-	if (len == 0) {
-		err = -EINVAL;
-		xnvme_cli_perr("Error: --cpumask must be a non-zero hex value", err);
-		return err;
-	}
-
-	for (int i = 0; i < len; i++) {
-		char c = hex[i];
-		if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
-		      (c >= 'A' && c <= 'F'))) {
-			err = -EINVAL;
-			xnvme_cli_perr("Error: --cpumask must be a non-zero hex value", err);
-			return err;
-		}
-		if (c != '0') {
-			nonzero = true;
-		}
-	}
-	if (!nonzero) {
-		err = -EINVAL;
-		xnvme_cli_perr("Error: --cpumask must be a non-zero hex value", err);
-		return err;
-	}
-
-	// Count set bits across all hex digits
-	for (int i = 0; i < len; i++) {
-		int value = hex_digit_val(hex[i]);
-		for (int b = 0; b < 4; b++) {
-			count += (value >> b) & 1;
-		}
-	}
-
-	cpus = malloc(sizeof(int) * count);
-	if (!cpus) {
-		return -errno;
-	}
-
-	// Extract CPU indices; rightmost digit = lowest bits
-	count = 0;
-	for (int i = len - 1; i >= 0; i--) {
-		int value = hex_digit_val(hex[i]);
-		int bit_offset = (len - 1 - i) * 4;
-		for (int b = 0; b < 4; b++) {
-			if ((value >> b) & 1) {
-				cpus[count++] = bit_offset + b;
-			}
-		}
-	}
-
-	*cpus_out = cpus;
-	*ncpus_out = count;
-	return 0;
 }
 
 /**
@@ -414,7 +334,7 @@ thread_fn(void *arg)
 
 	err = pin_to_cpu(thread->cpu);
 	if (err) {
-		fprintf(stderr, "Warning: failed to pin thread to CPU %d\n", thread->cpu);
+		fprintf(stderr, "Warning: failed to pin thread to CPU %" PRIu16 "\n", thread->cpu);
 	}
 
 	// Fill each job buffer with a known pattern. xnvme_buf_fill() routes
@@ -518,9 +438,9 @@ print_run_args(struct xnvmeperf_args *args, const char *pattern)
 			if (i) {
 				printf(", ");
 			}
-			printf("%d", args->cpus[i]);
+			printf("%" PRIu16, args->cpus[i]);
 		}
-		printf("] (total: %d)\n", args->ncpus);
+		printf("] (total: %" PRIu16 ")\n", args->ncpus);
 	}
 }
 
@@ -629,8 +549,8 @@ print_results(struct xnvmeperf_thread *threads, struct xnvmeperf_args *args)
 					cpus_len += snprintf(cpus_bufs[d] + cpus_len,
 							     256 - cpus_len, ",");
 				}
-				cpus_len += snprintf(cpus_bufs[d] + cpus_len, 256 - cpus_len, "%d",
-						     thread->cpu);
+				cpus_len += snprintf(cpus_bufs[d] + cpus_len, 256 - cpus_len,
+						     "%" PRIu16, thread->cpu);
 			}
 		}
 
@@ -736,7 +656,7 @@ xnvmeperf_run(struct xnvmeperf_args *args)
 	// queue, which is not safe. Require at least one queue per thread.
 	if (args->ncpus > total_jobs) {
 		fprintf(stderr,
-			"Error: --cpumask specifies %d threads but only %d queue(s) "
+			"Error: --cpumask specifies %" PRIu16 " threads but only %d queue(s) "
 			"(%d device(s) x %d queue(s) each); "
 			"increase --nqueues so every thread has its own queue\n",
 			args->ncpus, total_jobs, args->ndevs, args->nqueues);
@@ -879,7 +799,7 @@ static int
 xnvmeperf_verify(struct xnvmeperf_args *args)
 {
 	struct xnvme_dev **devs;
-	int nios = (int)args->count;
+	uint32_t nios = args->count;
 	int err;
 
 	printf("\nxnvmeperf verify: iosize=%u, nios=%d\n", args->iosize, nios);
@@ -1202,7 +1122,6 @@ parse_common_args(struct xnvme_cli *cli, struct xnvmeperf_args *args)
 /**
  * Parse the full set of run sub-command arguments into @p args.
  * Calls parse_common_args() then adds iopattern, qdepth, and runtime.
- * Does not parse cpumask or nqueues; those are the caller's responsibility.
  *
  * @return 0 on success, negative errno on validation failure
  */
@@ -1245,6 +1164,9 @@ parse_run_args(struct xnvme_cli *cli, struct xnvmeperf_args *args)
 
 	args->nqueues = cli->args.nqueues ? cli->args.nqueues : 1;
 
+	args->ncpus = cli->args.ncpus;
+	args->cpus = cli->args.cpus;
+
 	return err;
 }
 
@@ -1286,17 +1208,10 @@ sub_run(struct xnvme_cli *cli)
 		return err;
 	}
 
-	err = parse_cpumask(cli->args.cpumask, &args.cpus, &args.ncpus);
-	if (err) {
-		xnvme_cli_perr("Failed: parse_cpumask()", err);
-		return err;
-	}
-
 	print_run_args(&args, cli->args.iopattern);
 	derive_heap_sizes(&args);
 
 	err = xnvmeperf_run(&args);
-	free(args.cpus);
 	return err;
 }
 

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -656,8 +656,8 @@ xnvmeperf_run(struct xnvmeperf_args *args)
 	// queue, which is not safe. Require at least one queue per thread.
 	if (args->ncpus > total_jobs) {
 		fprintf(stderr,
-			"Error: --cpumask specifies %" PRIu16 " threads but only %d queue(s) "
-			"(%d device(s) x %d queue(s) each); "
+			"Error: --cpumask or --cpulist specifies %" PRIu16 " threads but only %d "
+			"queue(s) (%d device(s) x %d queue(s) each); "
 			"increase --nqueues so every thread has its own queue\n",
 			args->ncpus, total_jobs, args->ndevs, args->nqueues);
 		err = -EINVAL;
@@ -1208,6 +1208,12 @@ sub_run(struct xnvme_cli *cli)
 		return err;
 	}
 
+	if (!args.ncpus) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: Either --cpumask or --cpulist must be given", err);
+		return err;
+	}
+
 	print_run_args(&args, cli->args.iopattern);
 	derive_heap_sizes(&args);
 
@@ -1306,7 +1312,7 @@ static struct xnvme_cli_sub g_subs[] = {
 		"run",
 		"Run a benchmark against the given devices",
 		"Run a time-bounded async IO benchmark against one or more NVMe devices.\n"
-		"Devices are distributed across CPU threads pinned by --cpumask.",
+		"Devices are distributed across CPU threads pinned by --cpumask or --cpulist.",
 		sub_run,
 		{
 			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
@@ -1317,7 +1323,8 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_IOSIZE, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_RUNTIME, XNVME_CLI_LREQ},
-			{XNVME_CLI_OPT_CPUMASK, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_CPUMASK, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_CPULIST, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_SUBNQN, XNVME_CLI_LOPT},

--- a/tools/xnvmeperf/xnvmeperf.h
+++ b/tools/xnvmeperf/xnvmeperf.h
@@ -22,8 +22,8 @@ enum iopattern {
 struct xnvmeperf_args {
 	int ndevs;
 	const char **dev_uris;
-	int ncpus;
-	int *cpus;
+	uint16_t ncpus;
+	uint16_t *cpus;
 	uint32_t qdepth;
 	uint32_t iosize;
 	uint32_t time;


### PR DESCRIPTION
This PR moves the parsing of the `--cpumask` to the xNVMe CLI module, such that the parsing of input of the CLI argument does not need to be rewritten if ever reused. Also, we add a `--cpulist` argument, which allows the user to provide a list of CPU ids instead of a hexmask. A such list has a combination of specific ids and id ranges, e.g. "0,4-7", which would parse to `[0,4,5,6,7]`.

This closes #654 .