### PR TITLE
Parallelize CI verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -233,7 +233,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container:
+        include:
         # Using an alpine container which is the same as upstream but with bash
         # alpine: SPDK not supported, --with-spdk=disabled
         - {os: 'alpine', dh: 'refenv/alpine-bash', ver: 'latest'}
@@ -255,11 +255,11 @@ jobs:
         - {os: 'ubuntu', dh: 'ubuntu', ver: 'resolute'}
 
     container:
-      image: ghcr.io/xnvme/xnvme-deps-${{ matrix.container.os }}-${{ matrix.container.ver }}:main
+      image: ghcr.io/xnvme/xnvme-deps-${{ matrix.os }}-${{ matrix.ver }}:main
 
     steps:
     - name: Container-preparation, openSUSE does not have tar and gzip...
-      if: contains(matrix.container.os, 'opensuse')
+      if: contains(matrix.os, 'opensuse')
       run: zypper --non-interactive --no-refresh install -y tar gzip
 
     - name: Retrieve and unpack the xNVMe source archive
@@ -269,14 +269,14 @@ jobs:
         name: xnvme-src-archive-with-subprojects
 
     - name: Configure with and build with debug enabled (without spdk)
-      if: ${{ contains(matrix.container.os, 'alpine') }}
+      if: ${{ contains(matrix.os, 'alpine') }}
       run: |
         meson setup builddir --buildtype=debug -Dwith-spdk=disabled
         meson compile -C builddir
         make clean # prepare for building without debug
 
     - name: Configure with debug enabled
-      if: ${{ ! contains(matrix.container.os, 'alpine') }}
+      if: ${{ ! contains(matrix.os, 'alpine') }}
       run: |
         meson setup builddir --buildtype=debug
         meson compile -C builddir
@@ -285,15 +285,14 @@ jobs:
     - name: Configure, Build, and Install
       env:
         BSCRIPT_DEF: toolbox/pkgs/default-build.sh
-        BSCRIPT: toolbox/pkgs/${{ matrix.container.os }}-${{ matrix.container.ver }}-build.sh
+        BSCRIPT: toolbox/pkgs/${{ matrix.os }}-${{ matrix.ver }}-build.sh
       run: |
         if [[ -f "${BSCRIPT}" ]]; then source ${BSCRIPT}; else source ${BSCRIPT_DEF}; fi
 
     - name: Execute 'ldconfig'
       # ldconfig doesn't work on alpine
       # centos7 needs "ldconfig /usr/lib/local" for python3 to work
-      if: ${{!contains(matrix.container.os, 'alpine') && !contains(matrix.container.ver, 'centos7') && !contains(matrix.container.ver,
-        'stream8')}}
+      if: ${{!contains(matrix.os, 'alpine') && !contains(matrix.ver, 'centos7') && !contains(matrix.ver, 'stream8')}}
       run: ldconfig
 
     - name: meson-log-dump
@@ -340,7 +339,7 @@ jobs:
 
     # Setup Python virtual-environment for cijoe and Python xNVMe bindings to run ramdisk testing
     - name: CIJOE, setup pipx environment
-      if: (!contains('focal', matrix.container.ver))
+      if: (!contains('focal', matrix.ver))
       run: |
         # cijoe requires Python >= 3.10; on RHEL9-family the default is 3.9,
         # so grab python3.11 from AppStream and steer pipx at it.
@@ -354,12 +353,12 @@ jobs:
         make cijoe-install
 
     - name: CIJOE, check that it is available
-      if: (!contains('focal', matrix.container.ver))
+      if: (!contains('focal', matrix.ver))
       run: |
         cijoe -r
 
     - name: Python-bindings (ctypes), install and test
-      if: (!contains('focal', matrix.container.ver))
+      if: (!contains('focal', matrix.ver))
       run: |
         python3 -m pipx inject xnvme-cijoe "${{ steps.source.outputs.directory }}/xnvme-py-sdist.tar.gz" --force
         pytest --pyargs xnvme.ctypes_bindings
@@ -370,29 +369,29 @@ jobs:
     # Skipping on distros with too old gcc/clang to build fio, and too old a Python to run cijoe (requires 3.9)
     #
     - name: CIJOE, run ramdisk verification
-      if: (!contains('focal', matrix.container.ver))
-      run: make verify-ramdisk CIJOE_OUTPUT="${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}"
+      if: (!contains('focal', matrix.ver))
+      run: make verify-ramdisk CIJOE_OUTPUT="${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
 
     - name: CIJOE, upload report.html
-      if: always() && (!contains('focal', matrix.container.ver))
+      if: always() && (!contains('focal', matrix.ver))
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive build-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports
-      if: always() && (!contains('focal', matrix.container.ver))
+    - name: CIJOE, archive build-${{ matrix.os }}-${{ matrix.ver }}-reports
+      if: always() && (!contains('focal', matrix.ver))
       run: |
-        tar czf ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-*
+        tar czf ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*
 
-    - name: CIJOE, upload build-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports
-      if: always() && (!contains('focal', matrix.container.ver))
+    - name: CIJOE, upload build-${{ matrix.os }}-${{ matrix.ver }}-reports
+      if: always() && (!contains('focal', matrix.ver))
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports
-        path: ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports
+        path: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz
         if-no-files-found: error
 
   #
@@ -400,13 +399,13 @@ jobs:
   #
   build-macos:
     needs: [source-archive, source-format-check, build-python]
-    runs-on: ${{ matrix.runner.os }}-${{ matrix.runner.ver }}
+    runs-on: ${{ matrix.os }}-${{ matrix.ver }}
     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
     strategy:
       fail-fast: false
       matrix:
-        runner:
+        include:
         - {os: 'macos', ver: '14'}
         - {os: 'macos', ver: '15'}
 
@@ -419,7 +418,7 @@ jobs:
 
     - name: Install build-requirements
       run: |
-        source toolbox/pkgs/${{ matrix.runner.os }}-${{ matrix.runner.ver }}.sh || true
+        source toolbox/pkgs/${{ matrix.os }}-${{ matrix.ver }}.sh || true
 
     - name: Prep, environment GITHUB_PATH
       run: |
@@ -434,7 +433,7 @@ jobs:
     - name: Configure, Build, and Install
       env:
         BSCRIPT_DEF: toolbox/pkgs/default-build.sh
-        BSCRIPT: toolbox/pkgs/${{ matrix.runner.os }}-${{ matrix.runner.ver }}-build.sh
+        BSCRIPT: toolbox/pkgs/${{ matrix.os }}-${{ matrix.ver }}-build.sh
       run: |
         if [[ -f "${BSCRIPT}" ]]; then source ${BSCRIPT}; else source ${BSCRIPT_DEF}; fi
 
@@ -503,28 +502,28 @@ jobs:
         --monitor \
         --config "configs/ramdisk-macos.toml" \
         --config "configs/xnvme.toml" \
-        --output "${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-test-ramdisk"
+        --output "${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-test-ramdisk"
 
     - name: CIJOE, upload report.html
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive build-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
+    - name: CIJOE, archive build-${{ matrix.os }}-${{ matrix.ver }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*
+        tar czf ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*
 
-    - name: CIJOE, upload build-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
+    - name: CIJOE, upload build-${{ matrix.os }}-${{ matrix.ver }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
-        path: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports
+        path: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz
         if-no-files-found: error
 
   #
@@ -532,7 +531,7 @@ jobs:
   #
   build-windows:
     needs: [source-archive, source-format-check, build-python]
-    runs-on: ${{ matrix.runner.os }}-${{ matrix.runner.ver }}
+    runs-on: ${{ matrix.os }}-${{ matrix.ver }}
     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
     defaults:
@@ -542,7 +541,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
+        include:
         - {os: 'windows', ver: '2025'}
 
     steps:
@@ -662,28 +661,28 @@ jobs:
         cd cijoe; cijoe "workflows/test-ramdisk-windows.yaml" \
         --monitor \
         --config "configs/ramdisk-windows.toml" \
-        --output "${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-test-ramdisk"
+        --output "${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-test-ramdisk"
 
     - name: CIJOE, upload report.html
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive build-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
+    - name: CIJOE, archive build-${{ matrix.os }}-${{ matrix.ver }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*
+        tar czf ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*
 
-    - name: CIJOE, upload build-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
+    - name: CIJOE, upload build-${{ matrix.os }}-${{ matrix.ver }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
-        path: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports
+        path: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz
         if-no-files-found: error
 
   #
@@ -698,7 +697,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        include:
         - {os: 'freebsd', ver: '14', guest_dir: 'freebsd-14-amd64', transport: 'pcie'}
         #- {os: 'freebsd', ver: '15', guest_dir: 'freebsd-15-amd64', transport: 'pcie'}
         - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie'}
@@ -736,7 +735,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make guest-env <<< "${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+        make guest-env <<< "${{ matrix.os }}-${{ matrix.ver }}"
 
     - name: CIJOE, check that it is available
       run: |
@@ -747,7 +746,7 @@ jobs:
     # raw images live under $HOME/guests and otherwise fill the root disk
     # mid-test, dropping device writes.
     - name: Stage artifacts on /mnt
-      if: matrix.guest.os == 'debian' || matrix.guest.os == 'freebsd'
+      if: matrix.os == 'debian' || matrix.os == 'freebsd'
       run: |
         mkdir -p /mnt/system_imaging
         ln -s /mnt/system_imaging "$HOME/system_imaging"
@@ -757,14 +756,14 @@ jobs:
     - name: CIJOE, provision and test guest
       run: |
         make verify-guest \
-          TRANSPORT="${{ matrix.guest.transport }}" \
-          CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+          TRANSPORT="${{ matrix.transport }}" \
+          CIJOE_OUTPUT="${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
 
     - name: Collect guest serial console
-      if: always() && (matrix.guest.os == 'debian' || matrix.guest.os == 'freebsd')
+      if: always() && (matrix.os == 'debian' || matrix.os == 'freebsd')
       run: |
-        dst="cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
-        serial="$HOME/guests/${{ matrix.guest.guest_dir }}/serial.output"
+        dst="cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
+        serial="$HOME/guests/${{ matrix.guest_dir }}/serial.output"
         echo "::group::guest serial console (tail)"
         tail -c 20000 "$serial" 2>/dev/null || echo "no guest serial output"
         echo "::endgroup::"
@@ -773,7 +772,7 @@ jobs:
     - name: Collect vfu_kvssd device log
       if: always()
       run: |
-        dst="cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+        dst="cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
         echo "::group::vfu_kvssd device log"
         cat /tmp/vfu_kvssd.log 2>/dev/null || echo "no vfu_kvssd device log"
         echo "::endgroup::"
@@ -787,22 +786,22 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive verify-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
+    - name: CIJOE, archive verify-${{ matrix.os }}-${{ matrix.ver }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-*
+        tar czf ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*
 
-    - name: CIJOE, upload verify-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
+    - name: CIJOE, upload verify-${{ matrix.os }}-${{ matrix.ver }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
-        path: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports
+        path: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz
         if-no-files-found: error
 
   #
@@ -810,14 +809,14 @@ jobs:
   #
   verify-physical:
     needs: [source-archive, source-format-check, build-python]
-    runs-on: ${{ matrix.guest.labels }}
+    runs-on: ${{ matrix.labels }}
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name,
       'maas')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'verify')
 
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        include:
         - {os: 'macos', ver: 'sonoma', hostname: 'verify-phys-macos', labels: [self-hosted, macos, verify]}
 
     container:
@@ -860,28 +859,28 @@ jobs:
     # cd'ing into 'cijoe' to auto-collect the non-packaged github-specific configs and
     # workflows.
     - name: CIJOE, run macvfn-provision.yaml
-      if: matrix.guest.os == 'macos'
+      if: matrix.os == 'macos'
       run: |
         cd cijoe && cijoe "workflows/macvfn-provision.yaml" \
         --monitor \
-        --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --output "${{ github.job }}-${{ matrix.guest.hostname }}-provision-macvfn"
+        --config "configs/${{ matrix.hostname }}.toml" \
+        --output "${{ github.job }}-${{ matrix.hostname }}-provision-macvfn"
 
     - name: CIJOE, run provisioning
       run: |
         cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
         --monitor \
-        --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --output "${{ github.job }}-${{ matrix.guest.hostname }}-provision-xnvme" \
+        --config "configs/${{ matrix.hostname }}.toml" \
+        --output "${{ github.job }}-${{ matrix.hostname }}-provision-xnvme" \
         xnvme_source_sync xnvme_build_prep xnvme_build xnvme_install \
         ldconfig xnvme_bindings_py_install_tgz fio_prep
 
     - name: CIJOE, run tests
       run: |
-        cd cijoe && cijoe "workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.yaml" \
+        cd cijoe && cijoe "workflows/test-${{ matrix.os }}-${{ matrix.ver }}.yaml" \
         --monitor \
-        --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --output "${{ github.job }}-${{ matrix.guest.hostname }}-test-results"
+        --config "configs/${{ matrix.hostname }}.toml" \
+        --output "${{ github.job }}-${{ matrix.hostname }}-test-results"
 
     - name: CIJOE, result-log-dump on error
       if: failure()
@@ -891,22 +890,22 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.guest.hostname }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.hostname }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.hostname }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive verify-${{ matrix.guest.hostname }}-reports
+    - name: CIJOE, archive verify-${{ matrix.hostname }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.guest.hostname }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*
+        tar czf ${{ github.job }}-${{ matrix.hostname }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.hostname }}-*
 
-    - name: CIJOE, upload verify-${{ matrix.guest.hostname }}-reports
+    - name: CIJOE, upload verify-${{ matrix.hostname }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.guest.hostname }}-reports
-        path: ${{ github.job }}-${{ matrix.guest.hostname }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.hostname }}-reports
+        path: ${{ github.job }}-${{ matrix.hostname }}-reports.tar.gz
         if-no-files-found: error
 
   #
@@ -914,14 +913,14 @@ jobs:
   #
   verify-maas:
     needs: [source-archive, source-format-check, build-python]
-    runs-on: ${{ matrix.guest.labels }}
+    runs-on: ${{ matrix.labels }}
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name,
       'maas')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'verify')
 
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        include:
         - {os: 'debian', ver: 'trixie-iommu_enabled', transport: 'pcie', hostname: 'ax42-linux', labels: [self-hosted, linux,
             amd64, maas]}
 
@@ -956,19 +955,19 @@ jobs:
         cd cijoe && cijoe \
         "workflows/provision-maas-using-tgz.yaml" \
         --monitor \
-        --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --config "configs/${{ matrix.guest.hostname }}-testing.toml" \
+        --config "configs/${{ matrix.hostname }}.toml" \
+        --config "configs/${{ matrix.hostname }}-testing.toml" \
         --config "configs/system_imaging.toml" \
-        --output "${{ github.job }}-${{ matrix.guest.hostname }}-provision"
+        --output "${{ github.job }}-${{ matrix.hostname }}-provision"
 
     - name: CIJOE, run tests
       run: |
         cd cijoe && cijoe \
-        workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-${{ matrix.guest.transport }}.yaml \
+        workflows/test-${{ matrix.os }}-${{ matrix.ver }}-${{ matrix.transport }}.yaml \
         --monitor \
-        --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --config "configs/${{ matrix.guest.hostname }}-testing.toml" \
-        --output "${{ github.job }}-${{ matrix.guest.hostname }}-test-results"
+        --config "configs/${{ matrix.hostname }}.toml" \
+        --config "configs/${{ matrix.hostname }}-testing.toml" \
+        --output "${{ github.job }}-${{ matrix.hostname }}-test-results"
 
     - name: CIJOE, result-log-dump on error
       if: failure()
@@ -978,22 +977,22 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.guest.hostname }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.hostname }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.hostname }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive verify-${{ matrix.guest.hostname }}-reports
+    - name: CIJOE, archive verify-${{ matrix.hostname }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.guest.hostname }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*
+        tar czf ${{ github.job }}-${{ matrix.hostname }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.hostname }}-*
 
-    - name: CIJOE, upload verify-${{ matrix.guest.hostname }}-reports
+    - name: CIJOE, upload verify-${{ matrix.hostname }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.guest.hostname }}-reports
-        path: ${{ github.job }}-${{ matrix.guest.hostname }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.hostname }}-reports
+        path: ${{ github.job }}-${{ matrix.hostname }}-reports.tar.gz
         if-no-files-found: error
 
 
@@ -1092,12 +1091,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        include:
         - {os: 'linux', labels: [self-hosted, linux, amd64, maas]}
         - {os: 'freebsd', labels: [self-hosted, linux, amd64, maas]}
         - {os: 'windows', labels: [self-hosted, linux, amd64, maas]}
 
-    runs-on: ${{ matrix.guest.labels }}
+    runs-on: ${{ matrix.labels }}
 
     steps:
     - uses: xnvme/actions/.github/actions/cleanup@main
@@ -1130,45 +1129,45 @@ jobs:
         cd cijoe && cijoe \
         "workflows/provision-maas-using-tgz.yaml" \
         --monitor \
-        --config "configs/ax42-${{ matrix.guest.os }}.toml" \
+        --config "configs/ax42-${{ matrix.os }}.toml" \
         --config "configs/system_imaging.toml" \
-        ${{ matrix.guest.os == 'windows' && 'guest_kill guest_initialize windows_qemu_prep windows_guest_start guest_check packages_extra xnvme_source_sync xnvme_build_prep xnvme_build xnvme_install fio_prep' || '' }} \
-        --output "${{ github.job }}-${{ matrix.guest.os }}-provision-xnvme"
+        ${{ matrix.os == 'windows' && 'guest_kill guest_initialize windows_qemu_prep windows_guest_start guest_check packages_extra xnvme_source_sync xnvme_build_prep xnvme_build xnvme_install fio_prep' || '' }} \
+        --output "${{ github.job }}-${{ matrix.os }}-provision-xnvme"
 
     - name: CIJOE, run latency benchmark
       run: |
-        rm -rf cijoe/latency-${{ matrix.guest.os }}-benchmark
+        rm -rf cijoe/latency-${{ matrix.os }}-benchmark
         cd cijoe && cijoe "workflows/benchmark-latency.yaml" \
         --monitor \
-        --config "configs/ax42-${{ matrix.guest.os }}.toml" \
-        --output "${{ github.job }}-${{ matrix.guest.os }}-benchmark"
+        --config "configs/ax42-${{ matrix.os }}.toml" \
+        --output "${{ github.job }}-${{ matrix.os }}-benchmark"
 
     - name: Capture QEMU guest serial output
       if: always()
       run: |
         toolbox/ci/collect-qemu-serial.sh \
-          "cijoe/${{ github.job }}-${{ matrix.guest.os }}-provision-xnvme"
+          "cijoe/${{ github.job }}-${{ matrix.os }}-provision-xnvme"
 
     - name: CIJOE, upload report.html
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.guest.os }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.guest.os }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.os }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.os }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive latency-${{ matrix.guest.os }}-reports
+    - name: CIJOE, archive latency-${{ matrix.os }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.guest.os }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.guest.os }}-*
+        tar czf ${{ github.job }}-${{ matrix.os }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.os }}-*
 
-    - name: CIJOE, upload latency-${{ matrix.guest.os }}-reports
+    - name: CIJOE, upload latency-${{ matrix.os }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.guest.os }}-reports
-        path: ${{ github.job }}-${{ matrix.guest.os }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.os }}-reports
+        path: ${{ github.job }}-${{ matrix.os }}-reports.tar.gz
         if-no-files-found: error
 
   #
@@ -1204,7 +1203,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        include:
         - {os: 'debian', ver: 'trixie-iommu_enabled'}
 
     container:
@@ -1243,7 +1242,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make guest-env <<< "${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+        make guest-env <<< "${{ matrix.os }}-${{ matrix.ver }}"
 
     - name: CIJOE, check that it is available
       run: |
@@ -1266,12 +1265,12 @@ jobs:
     - name: CIJOE, provision and generate documentation
       run: |
         make docgen-guest \
-          CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+          CIJOE_OUTPUT="${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
 
     - name: Collect vfu_kvssd device log + guest serial console
       if: always()
       run: |
-        dst="cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+        dst="cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
         echo "::group::vfu_kvssd device log"
         cat /tmp/vfu_kvssd.log 2>/dev/null || echo "no vfu_kvssd device log"
         echo "::endgroup::"
@@ -1287,8 +1286,8 @@ jobs:
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
-        path: cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}*
+        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports
+        path: cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}*
         if-no-files-found: error
 
     - name: Checkout site
@@ -1307,7 +1306,7 @@ jobs:
       if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))
       run: |
         find cijoe
-        cp cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-docs/artifacts/docs.tar.gz .
+        cp cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-docs/artifacts/docs.tar.gz .
         tar xzf docs.tar.gz
 
     - name: Update site repository

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -688,29 +688,50 @@ jobs:
   #
   # Build and test xNVMe
   #
-  verify:
+  generate-verify-matrix:
     needs: [source-archive, source-format-check, build-python]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.job == 'verify')
+
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+
+    env:
+      # Each entry is expanded into one entry per 'test_*' step of the cijoe workflow it
+      # runs, so that the test-steps of a workflow are verified as separate jobs.
+      BASE_MATRIX: |
+        - {os: 'freebsd', ver: '14', guest_dir: 'freebsd-14-amd64', transport: 'pcie'}
+        #- {os: 'freebsd', ver: '15', guest_dir: 'freebsd-15-amd64', transport: 'pcie'}
+        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie'}
+        - {os: 'debian', ver: 'trixie-iommu_disabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie'}
+        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'tcp-spdk'}
+        # tcp-linux: enabled in follow-up PR.
+        #- {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'tcp-linux'}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate the job-matrix from the cijoe workflows
+      id: generate
+      run: |
+        pip install --quiet pyyaml
+        python3 toolbox/gha_matrix.py <<< "$BASE_MATRIX" >> "$GITHUB_OUTPUT"
+
+    - name: Show the generated job-matrix
+      run: |
+        echo '${{ steps.generate.outputs.matrix }}' | python3 -m json.tool
+
+  verify:
+    name: verify (${{ matrix.os }}, ${{ matrix.ver }}, ${{ matrix.transport }}, ${{ matrix.test }})
+    needs: [generate-verify-matrix, source-archive, source-format-check, build-python]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' &&
       github.event.inputs.job == 'verify')
 
     strategy:
       fail-fast: false
-      matrix:
-        # empty 'steps' field means run everything in cijoe task
-        include:
-        - {os: 'freebsd', ver: '14', guest_dir: 'freebsd-14-amd64', transport: 'pcie', steps: ''}
-        #- {os: 'freebsd', ver: '15', guest_dir: 'freebsd-15-amd64', transport: 'pcie', steps: ''}
-        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: 'sysinfo
-            enumerate hugepages spdk_probe_diag test_python test_ramdisk'}
-        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: 'sysinfo
-            enumerate hugepages spdk_probe_diag test_os'}
-        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: 'sysinfo
-            enumerate hugepages spdk_probe_diag test_pcie'}
-        - {os: 'debian', ver: 'trixie-iommu_disabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: ''}
-        - {os: 'debian', ver: 'trixie-iommu_enabled-tcp-spdk', guest_dir: 'debian-trixie-amd64', transport: 'tcp-spdk', steps: ''}
-        # tcp-linux: enabled in follow-up PR.
-        #- {os: 'debian', ver: 'trixie-iommu_enabled-tcp-linux', guest_dir: 'debian-trixie-amd64', transport: 'tcp-linux', steps: ''}
+      matrix: ${{ fromJSON(needs.generate-verify-matrix.outputs.matrix) }}
 
     container:
       image: ghcr.io/safl/nosi/ubuntu-2604-docker:latest
@@ -764,12 +785,12 @@ jobs:
         make verify-guest \
           TRANSPORT="${{ matrix.transport }}" \
           TEST_STEPS="${{ matrix.steps }}" \
-          CIJOE_OUTPUT="${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
+          CIJOE_OUTPUT="${{ github.job }}-${{ matrix.id }}"
 
     - name: Collect guest serial console
       if: always() && (matrix.os == 'debian' || matrix.os == 'freebsd')
       run: |
-        dst="cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
+        dst="cijoe/${{ github.job }}-${{ matrix.id }}"
         serial="$HOME/guests/${{ matrix.guest_dir }}/serial.output"
         echo "::group::guest serial console (tail)"
         tail -c 20000 "$serial" 2>/dev/null || echo "no guest serial output"
@@ -779,7 +800,7 @@ jobs:
     - name: Collect vfu_kvssd device log
       if: always()
       run: |
-        dst="cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
+        dst="cijoe/${{ github.job }}-${{ matrix.id }}"
         echo "::group::vfu_kvssd device log"
         cat /tmp/vfu_kvssd.log 2>/dev/null || echo "no vfu_kvssd device log"
         echo "::endgroup::"
@@ -793,22 +814,22 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-report-html
-        path: cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*/report.html
+        name: ${{ github.job }}-${{ matrix.id }}-report-html
+        path: cijoe/${{ github.job }}-${{ matrix.id }}-*/report.html
         if-no-files-found: warn
 
-    - name: CIJOE, archive verify-${{ matrix.os }}-${{ matrix.ver }}-reports
+    - name: CIJOE, archive verify-${{ matrix.id }}-reports
       if: always()
       run: |
-        tar czf ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz \
-          cijoe/${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-*
+        tar czf ${{ github.job }}-${{ matrix.id }}-reports.tar.gz \
+          cijoe/${{ github.job }}-${{ matrix.id }}-*
 
-    - name: CIJOE, upload verify-${{ matrix.os }}-${{ matrix.ver }}-reports
+    - name: CIJOE, upload verify-${{ matrix.id }}-reports
       uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
-        name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports
-        path: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}-reports.tar.gz
+        name: ${{ github.job }}-${{ matrix.id }}-reports
+        path: ${{ github.job }}-${{ matrix.id }}-reports.tar.gz
         if-no-files-found: error
 
   #

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -697,14 +697,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # empty 'steps' field means run everything in cijoe task
         include:
-        - {os: 'freebsd', ver: '14', guest_dir: 'freebsd-14-amd64', transport: 'pcie'}
-        #- {os: 'freebsd', ver: '15', guest_dir: 'freebsd-15-amd64', transport: 'pcie'}
-        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie'}
-        - {os: 'debian', ver: 'trixie-iommu_disabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie'}
-        - {os: 'debian', ver: 'trixie-iommu_enabled-tcp-spdk', guest_dir: 'debian-trixie-amd64', transport: 'tcp-spdk'}
+        - {os: 'freebsd', ver: '14', guest_dir: 'freebsd-14-amd64', transport: 'pcie', steps: ''}
+        #- {os: 'freebsd', ver: '15', guest_dir: 'freebsd-15-amd64', transport: 'pcie', steps: ''}
+        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: 'sysinfo
+            enumerate hugepages spdk_probe_diag test_python test_ramdisk'}
+        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: 'sysinfo
+            enumerate hugepages spdk_probe_diag test_os'}
+        - {os: 'debian', ver: 'trixie-iommu_enabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: 'sysinfo
+            enumerate hugepages spdk_probe_diag test_pcie'}
+        - {os: 'debian', ver: 'trixie-iommu_disabled', guest_dir: 'debian-trixie-amd64', transport: 'pcie', steps: ''}
+        - {os: 'debian', ver: 'trixie-iommu_enabled-tcp-spdk', guest_dir: 'debian-trixie-amd64', transport: 'tcp-spdk', steps: ''}
         # tcp-linux: enabled in follow-up PR.
-        #- {os: 'debian', ver: 'trixie-iommu_enabled-tcp-linux', guest_dir: 'debian-trixie-amd64', transport: 'tcp-linux'}
+        #- {os: 'debian', ver: 'trixie-iommu_enabled-tcp-linux', guest_dir: 'debian-trixie-amd64', transport: 'tcp-linux', steps: ''}
 
     container:
       image: ghcr.io/safl/nosi/ubuntu-2604-docker:latest
@@ -757,6 +763,7 @@ jobs:
       run: |
         make verify-guest \
           TRANSPORT="${{ matrix.transport }}" \
+          TEST_STEPS="${{ matrix.steps }}" \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.os }}-${{ matrix.ver }}"
 
     - name: Collect guest serial console

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,8 @@ guest-test:
 		--config "configs/$(GUEST).toml" \
 		--config "configs/fio.toml" \
 		--config "configs/xnvme.toml" \
-		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-test-results,cijoe-output-guest-test)"
+		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-test-results,cijoe-output-guest-test)" \
+		$(TEST_STEPS)
 	@echo "## xNVMe: guest-test [DONE]"
 
 define guest-stop-help

--- a/toolbox/gha_matrix.py
+++ b/toolbox/gha_matrix.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Expand a GitHub Actions job-matrix into one entry per cijoe test-step
+
+Reads a YAML list of matrix entries on stdin and, for each of them, locates the
+cijoe workflow it would run. The steps of that workflow are split in two: those
+named 'test_*' and the rest, which are treated as preparation. One matrix entry is
+emitted per test-step, with a 'steps' key holding the preparation steps followed by
+that single test-step, such that the test-steps of a workflow run as separate jobs.
+
+Emits 'matrix=<json>' on stdout, for consumption via GITHUB_OUTPUT::
+
+    python3 toolbox/gha_matrix.py <<< "$BASE_MATRIX" >> "$GITHUB_OUTPUT"
+
+The workflow of an entry is 'test-{os}-{ver}-{transport}.yaml', falling back to
+'test-{os}-{ver}.yaml' for the entries whose 'ver' already carries the transport.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS = Path("cijoe/workflows")
+TEST_PREFIX = "test_"
+
+
+def workflow_path(entry):
+    """Returns the path to the cijoe workflow which the given entry runs"""
+
+    stem = f"test-{entry['os']}-{entry['ver']}"
+    candidates = [
+        WORKFLOWS / f"{stem}-{entry['transport']}.yaml",
+        WORKFLOWS / f"{stem}.yaml",
+    ]
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    raise SystemExit(f"no workflow for entry({entry}), tried({candidates})")
+
+
+def expand(entry):
+    """Returns a list of matrix entries, one per test-step of the entry's workflow"""
+
+    workflow = yaml.safe_load(workflow_path(entry).read_text())
+    names = [step["name"] for step in workflow.get("steps", [])]
+
+    tests = [name for name in names if name.startswith(TEST_PREFIX)]
+
+    # Without test-steps there is nothing to split on; run the workflow as it is
+    if not tests:
+        return [entry_with(entry, "", "")]
+
+    # Keep the order the workflow declares, dropping only the other test-steps. Taking
+    # the non-test steps as a prefix instead would move any teardown step ahead of the
+    # test it is meant to run after.
+    return [
+        entry_with(
+            entry,
+            test,
+            " ".join(
+                name
+                for name in names
+                if name == test or not name.startswith(TEST_PREFIX)
+            ),
+        )
+        for test in tests
+    ]
+
+
+def entry_with(entry, test, steps):
+    """Returns the given entry, extended with its 'id', 'test' and 'steps'"""
+
+    # 'id' identifies the entry, both as the job-name and when naming outputs and
+    # artifacts. It has to carry the transport as well: without it two workflows for the
+    # same guest collide whenever they happen to share a test-step name.
+    return {
+        "id": "-".join(
+            part
+            for part in (entry["os"], entry["ver"], entry["transport"], test)
+            if part
+        ),
+        **entry,
+        "test": test,
+        "steps": steps,
+    }
+
+
+def main():
+    entries = yaml.safe_load(sys.stdin)
+
+    expanded = [item for entry in entries for item in expand(entry)]
+
+    print("matrix=" + json.dumps({"include": expanded}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Here, I am splitting up our verification job in smaller chunks to allow us to parallelize the testing.

Essentially, for one test-suite (e.g. test-debian-trixie-iommu_enabled-pcie.yaml), do not run the steps sequentially:
- sysinfo, enumerate, hugepages, spdk_proble_diag, test_python, test_ramdisk, test_os, test_pci

But instead use GHA matrix to create parallel runners:
- sysinfo, enumerate, hugepages, spdk_proble_diag, test_python
- sysinfo, enumerate, hugepages, spdk_proble_diag, test_ramdisk 
- sysinfo, enumerate, hugepages, spdk_proble_diag, test_os
- sysinfo, enumerate, hugepages, spdk_proble_diag, test_pci

This saves us about 10-15 minutes in the runtime of our CI (without maas), but potentially more, when more tests are added in the future.

PS. adopting this will require us to change the required checks from the main branch protection rule, but I think we could just remove the verify step completely, since thsi step will always be run if the verify-maas is run (which is a required check).