### PR TITLE
Multi-process mode for upcie-cuda and upcie-hip

### DIFF
--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -307,7 +307,7 @@ def device(cijoe, request):
             be_opts = callspec.params.get("be_opts") if callspec else None
             if be_opts:
                 if be_opts.get("mproc"):
-                    MprocPrimary.start(cijoe, be_opts["be"])
+                    MprocPrimary.start(cijoe, be_opts["be"], be_opts.get("label"))
                 else:
                     pytest.skip(f"{be_opts.get('be')} does not support multi-process")
         XnvmeDriver.attach(cijoe, request.param)
@@ -353,10 +353,13 @@ class MprocPrimary:
     """
     Manages the lifecycle of a homi primary daemon.
 
-    A single primary holds every 'pcie' device in the configuration, so it can serve
-    whichever device a testcase asks for, as well as testcases enumerating and opening
-    all of them. Tracks which backend the running primary was started with (similar to
-    XnvmeDriver.IS_KERNEL_ATTACHED), so it is only restarted when the backend changes.
+    A single primary holds every device carrying the labels of the backend-configuration
+    under test, so it can serve whichever device a testcase asks for, as well as
+    testcases enumerating and opening all of them. Labels vary per backend; the GPU
+    backends use 'cuda'/'hip' where the host backend uses 'pcie'.
+
+    Tracks the backend and labels the running primary was started with (similar to
+    XnvmeDriver.IS_KERNEL_ATTACHED), so it is only restarted when those change.
     """
 
     RUNNING = None
@@ -385,13 +388,15 @@ class MprocPrimary:
         return not err
 
     @staticmethod
-    def start(cijoe, be):
-        if MprocPrimary.RUNNING == be:
+    def start(cijoe, be, labels=None):
+        labels = labels if labels else ["pcie"]
+
+        if MprocPrimary.RUNNING == (be, tuple(labels)):
             return
 
-        uris = " ".join(d["uri"] for d in cijoe_config_get_all_devices(["pcie"]))
+        uris = " ".join(d["uri"] for d in cijoe_config_get_all_devices(labels))
         if not uris:
-            pytest.skip("Configuration has no device labelled: ['pcie']")
+            pytest.skip(f"Configuration has no device labelled: {labels}")
 
         XnvmeDriver.kernel_detach(cijoe)
 
@@ -423,7 +428,7 @@ class MprocPrimary:
             cijoe.run(f"cat /tmp/mproc_{be}.out")
             pytest.fail(f"homi primary for be({be}) did not become ready")
 
-        MprocPrimary.RUNNING = be
+        MprocPrimary.RUNNING = (be, tuple(labels))
         MprocPrimary.CIJOE = cijoe
 
     @staticmethod

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -154,6 +154,7 @@ def get_backend_configurations():
             "sync": ["upcie-cuda"],
             "admin": ["upcie-cuda"],
             "label": ["cuda"],
+            "mproc": True,
         },
         # Ramdisk
         {

--- a/docs/background/backends/upcie/mproc.md
+++ b/docs/background/backends/upcie/mproc.md
@@ -76,6 +76,18 @@ secondary's mapping by the constant offset between the secondary's import base
 and the primary's published base. PRP entries for a secondary's own commands are
 translated against its private heap, whose physical pages it resolves itself.
 
+### GPU backends
+
+The `upcie-cuda` and `upcie-hip` backends share everything described above: they
+reuse the host backend's controller and queue-pair init/term, and they keep all
+NVMe control structures on the host hugepage heap. Only data buffers live in GPU
+memory, which is allocated from a per-process heap and therefore requires no
+coordination between processes.
+
+The CUDA backend also exposes GPU-resident queue pairs through
+`xnvme_cuda_queue_create()`/`xnvme_cuda_queue_destroy()`. These run under the
+same mutex and shared queue-id bitmap as ordinary queue-pair creation.
+
 (sec-backends-upcie-mproc-startup)=
 ## Startup handshake
 
@@ -191,18 +203,14 @@ startup. Because uPCIe also needs hugepages for its DMA memory, the two cannot
 be expected to share a system, and running uPCIe and SPDK in multi-process
 mode side by side cannot be not guaranteed to work.
 
-### CUDA backend
+### GPU backend doorbell registration
 
-Multi-process mode is **not supported** with the `upcie-cuda` backend. The
-backend does not advertise the multi-process capability, so opening an
-`upcie-cuda` device with a non-zero `shm_id` fails with `-ENOTSUP`.
+`upcie-cuda` registers the I/O queue doorbells of its GPU-resident queue pairs
+with `cuMemHostRegister(..., CU_MEMHOSTREGISTER_IOMEMORY)`. Each process maps
+BAR0 independently, so each registers its own mapping of the doorbell page; this
+has not been exercised across many concurrent processes on the same controller.
 
-The memory model is not the obstacle: `upcie-cuda` keeps all NVMe control
-structures — the admin queue, the I/O submission/completion rings, PRP lists
-and request pools — on the same host hugepage heap that multi-process mode
-shares, and places only data buffers in per-process GPU memory, which is never
-shared between processes. What is missing is serialization: the `upcie-cuda`
-admin path submits to the shared admin queue without taking the per-controller
-admin mutex, so concurrent processes would race on the admin submission ring.
-Enabling multi-process mode for `upcie-cuda` would require serializing its admin
-path under the same mutex used by the host backend.
+Note also that `upcie-cuda` and `upcie-hip` require the device to be bound to
+`uio_pci_generic`. The `vfio-pci` path that the host backend supports is
+rejected before the controller is opened, so it is unavailable in multi-process
+mode with these backends as well.

--- a/docs/tools/homi/index.rst
+++ b/docs/tools/homi/index.rst
@@ -13,8 +13,9 @@ Running **homi** puts that responsibility in a process of its own, so the
 processes actually doing I/O can come and go freely as secondaries.
 
 :ref:`sec-backends-upcie-mproc` is only available for the
-:ref:`sec-backends-upcie` and :ref:`sec-backends-spdk` backends. **homi** is
-therefore useful where one of those is built: ``upcie`` on Linux, and ``spdk`` on
+:ref:`sec-backends-upcie` backend and its GPU variants, and for the
+:ref:`sec-backends-spdk` backend. **homi** is therefore useful where one of those
+is built: ``upcie``, ``upcie-cuda`` and ``upcie-hip`` on Linux, and ``spdk`` on
 Linux and FreeBSD. On Windows it exits with ``-ENOTSUP``, since no
 multi-process capable backend is available there. On other platforms it runs, but
 opening a device with a non-zero ``shm_id`` fails with ``-ENOTSUP``.
@@ -67,9 +68,16 @@ Backends
 ========
 
 **homi** works with any backend that advertises the multi-process capability,
-which is ``spdk`` and ``upcie``::
+which is ``spdk``, ``upcie``, ``upcie-cuda`` and ``upcie-hip``::
 
    homi start 0000:03:00.0 --be spdk --shm_id 1
+
+With ``upcie-cuda`` and ``upcie-hip``, **homi** additionally caps the GPU device
+heap at 2 MiB rather than the backend default of 1 GiB. It never allocates data
+buffers, which is all the device heap is used for, so claiming the default would
+take VRAM away from the secondaries::
+
+   homi start 0000:03:00.0 --be upcie-cuda --shm_id 1
 
 .. seealso::
 

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -121,6 +121,7 @@ struct xnvme_cli_args {
 
 	uint64_t shm_id;
 	uint64_t host_heap_size;
+	uint64_t device_heap_size;
 	uint32_t main_core;
 	const char *core_mask;
 	const char *iova_mode;
@@ -369,9 +370,10 @@ enum xnvme_cli_opt {
 
 	XNVME_CLI_OPT_CPULIST = 132, ///< XNVME_CLI_OPT_CPULIST
 
-	XNVME_CLI_OPT_HOST_HEAP_SIZE = 133, ///< XNVME_CLI_OPT_HOST_HEAP_SIZE
+	XNVME_CLI_OPT_HOST_HEAP_SIZE   = 133, ///< XNVME_CLI_OPT_HOST_HEAP_SIZE
+	XNVME_CLI_OPT_DEVICE_HEAP_SIZE = 134, ///< XNVME_CLI_OPT_DEVICE_HEAP_SIZE
 
-	XNVME_CLI_OPT_END = 134, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_END = 135, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -157,6 +157,11 @@ void
 xnvme_be_upcie_mproc_free_all_queues(struct xnvme_be_upcie_ctrlr *ctrlr);
 
 int
+xnvme_be_upcie_mproc_qids_lock(struct xnvme_be_upcie_ctrlr *ctrlr);
+void
+xnvme_be_upcie_mproc_qids_unlock(struct xnvme_be_upcie_ctrlr *ctrlr);
+
+int
 xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrlr,
 					       struct nvme_qpair *qpair, uint16_t depth,
 					       bool create);

--- a/lib/upcie/xnvme_be_upcie_cuda.c
+++ b/lib/upcie/xnvme_be_upcie_cuda.c
@@ -18,7 +18,7 @@ const struct xnvme_be_config g_xnvme_be_upcie_cuda = {
 		{
 			.name = "upcie-cuda",
 			.descr = "CUDA-based uPCIe userspace NVMe driver",
-			.caps = XNVME_BE_CAP_NVME_PCIE,
+			.caps = XNVME_BE_CAP_NVME_PCIE | XNVME_BE_CAP_MPROC,
 		},
 };
 

--- a/lib/upcie/xnvme_be_upcie_cuda_admin.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_admin.c
@@ -14,6 +14,7 @@ xnvme_be_upcie_cuda_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t
 				   void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
 {
 	struct xnvme_be_upcie_state *state = (void *)ctx->dev->be.state;
+	struct xnvme_be_upcie_ctrlr *be_ctrlr = state->ctrlr;
 	struct nvme_controller *ctrlr = state->ctrlr->ctrl;
 	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
 	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
@@ -32,6 +33,16 @@ xnvme_be_upcie_cuda_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t
 	if (dbuf) {
 		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
 							   dbuf_nbytes, cmd);
+	}
+
+	// The admin queue is shared in multi-process mode, and the request pool it draws
+	// command identifiers from is not. Holding the mutex from submission all the way
+	// through reaping keeps a single command in flight, so identifiers cannot collide.
+	err = xnvme_be_upcie_ctrlr_mutex_lock(be_ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		nvme_request_free(ctrlr->aq.rpool, req->cid);
+		return err;
 	}
 
 	err = nvme_qpair_enqueue(&ctrlr->aq, cmd);
@@ -55,6 +66,7 @@ xnvme_be_upcie_cuda_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t
 	}
 
 exit:
+	xnvme_be_upcie_ctrlr_mutex_unlock(be_ctrlr);
 	nvme_request_free(ctrlr->aq.rpool, req->cid);
 	return err;
 }

--- a/lib/upcie/xnvme_be_upcie_cuda_gpu.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_gpu.c
@@ -21,12 +21,22 @@ xnvme_cuda_queue_create(struct xnvme_dev *dev, uint16_t depth, struct xnvme_cuda
 		return -ENOMEM;
 	}
 
+	err = xnvme_be_upcie_mproc_qids_lock(state->ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_mproc_qids_lock(); err(%d)", err);
+		cuMemFree((CUdeviceptr)qpair);
+		return err;
+	}
+
 	// The spec says that for systems where memory ordering is not guaranteed, then one should
 	// leave room in the queue to avoid races. Thus, we do so here, by allocating one more than
 	// what is needed.
 	err = nvme_controller_cuda_create_io_qpair(state->ctrlr->ctrl,
 						   (struct nvme_qpair_cuda *)qpair, depth + 1,
 						   &g_upcie_cuda_rte.cuda_heap);
+
+	xnvme_be_upcie_mproc_qids_unlock(state->ctrlr);
+
 	if (err) {
 		XNVME_DEBUG("FAILED: nvme_controller_cuda_create_io_qpair(); err(%d)", err);
 		cuMemFree((CUdeviceptr)qpair);
@@ -41,9 +51,34 @@ void
 xnvme_cuda_queue_destroy(struct xnvme_dev *dev, struct xnvme_cuda_queue *queue)
 {
 	struct xnvme_be_upcie_state *state = (void *)dev->be.state;
+	struct nvme_qpair_cuda qpair = {0};
+	int cu_err, err;
+
+	err = xnvme_be_upcie_mproc_qids_lock(state->ctrlr);
+	if (err) {
+		// Without the admin queue the device-side queues cannot be deleted, and
+		// releasing the GPU memory they still reference would be worse than leaking it.
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_mproc_qids_lock(); err(%d)", err);
+		return;
+	}
+
+	// nvme_controller_cuda_delete_io_qpair() does not return the queue identifier to the
+	// pool, unlike its host counterpart. Read it off the device-side queue-pair and release
+	// it here, so a create/destroy cycle does not drain the identifier space.
+	cu_err = cuMemcpyDtoH(&qpair, (CUdeviceptr)queue, sizeof(qpair));
+	if (cu_err) {
+		XNVME_DEBUG("FAILED: cuMemcpyDtoH(device QP -> host QP); CUresult(%d)", cu_err);
+	}
 
 	nvme_controller_cuda_delete_io_qpair(state->ctrlr->ctrl, (struct nvme_qpair_cuda *)queue,
 					     &g_upcie_cuda_rte.cuda_heap);
+
+	if (!cu_err) {
+		nvme_qid_free(state->ctrlr->ctrl->qids, qpair.qid);
+	}
+
+	xnvme_be_upcie_mproc_qids_unlock(state->ctrlr);
+
 	cuMemFree((CUdeviceptr)queue);
 }
 

--- a/lib/upcie/xnvme_be_upcie_hip.c
+++ b/lib/upcie/xnvme_be_upcie_hip.c
@@ -18,7 +18,7 @@ const struct xnvme_be_config g_xnvme_be_upcie_hip = {
 		{
 			.name = "upcie-hip",
 			.descr = "HIP-based uPCIe userspace NVMe driver",
-			.caps = XNVME_BE_CAP_NVME_PCIE,
+			.caps = XNVME_BE_CAP_NVME_PCIE | XNVME_BE_CAP_MPROC,
 		},
 };
 

--- a/lib/upcie/xnvme_be_upcie_hip_admin.c
+++ b/lib/upcie/xnvme_be_upcie_hip_admin.c
@@ -14,6 +14,7 @@ xnvme_be_upcie_hip_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t 
 				  void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
 {
 	struct xnvme_be_upcie_state *state = (void *)ctx->dev->be.state;
+	struct xnvme_be_upcie_ctrlr *be_ctrlr = state->ctrlr;
 	struct nvme_controller *ctrlr = state->ctrlr->ctrl;
 	struct nvme_command *cmd = (struct nvme_command *)&ctx->cmd;
 	struct nvme_completion *cpl = (struct nvme_completion *)&ctx->cpl;
@@ -32,6 +33,16 @@ xnvme_be_upcie_hip_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t 
 	if (dbuf) {
 		nvme_request_prep_command_prps_contig_hip(req, &g_upcie_hip_rte.hip_heap, dbuf,
 							  dbuf_nbytes, cmd);
+	}
+
+	// The admin queue is shared in multi-process mode, and the request pool it draws
+	// command identifiers from is not. Holding the mutex from submission all the way
+	// through reaping keeps a single command in flight, so identifiers cannot collide.
+	err = xnvme_be_upcie_ctrlr_mutex_lock(be_ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		nvme_request_free(ctrlr->aq.rpool, req->cid);
+		return err;
 	}
 
 	err = nvme_qpair_enqueue(&ctrlr->aq, cmd);
@@ -55,6 +66,7 @@ xnvme_be_upcie_hip_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t 
 	}
 
 exit:
+	xnvme_be_upcie_ctrlr_mutex_unlock(be_ctrlr);
 	nvme_request_free(ctrlr->aq.rpool, req->cid);
 	return err;
 }

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -676,6 +676,52 @@ failed:
 }
 
 /**
+ * Take the admin-queue mutex and import the shared I/O queue-id bitmap
+ *
+ * Wraps xnvme_be_upcie_ctrlr_mutex_lock() for callers that allocate or release
+ * I/O queue identifiers. In a secondary process ctrlr->ctrl is a process-local
+ * copy of the controller, so the bitmap has to be pulled in from shared memory
+ * before it is consulted. In a primary process, and when not in multi-process
+ * mode, this is a no-op beyond the locking itself.
+ *
+ * @param ctrlr The backend controller
+ *
+ * @return On success, 0 is returned. On error, a non-zero value is returned.
+ */
+int
+xnvme_be_upcie_mproc_qids_lock(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	int err;
+
+	err = xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		return err;
+	}
+
+	if (ctrlr->shm) {
+		memcpy(ctrlr->ctrl->qids, ctrlr->shm->ctrl.qids, sizeof(ctrlr->ctrl->qids));
+	}
+
+	return 0;
+}
+
+/**
+ * Publish the I/O queue-id bitmap and release the admin-queue mutex
+ *
+ * @param ctrlr The backend controller
+ */
+void
+xnvme_be_upcie_mproc_qids_unlock(struct xnvme_be_upcie_ctrlr *ctrlr)
+{
+	if (ctrlr->shm) {
+		memcpy(ctrlr->shm->ctrl.qids, ctrlr->ctrl->qids, sizeof(ctrlr->shm->ctrl.qids));
+	}
+
+	xnvme_be_upcie_ctrlr_mutex_unlock(ctrlr);
+}
+
+/**
  * Create or delete a queue pair in multi process mode
  *
  * Helper function for locking the shared controller mutex, updating the
@@ -691,16 +737,13 @@ xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrl
 					       struct nvme_qpair *qpair, uint16_t depth,
 					       bool create)
 {
-	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
 	int err;
 
-	err = xnvme_be_upcie_ctrlr_mutex_lock(ctrlr);
+	err = xnvme_be_upcie_mproc_qids_lock(ctrlr);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_mutex_lock(); err(%d)", err);
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_mproc_qids_lock(); err(%d)", err);
 		return err;
 	}
-
-	memcpy(ctrlr->ctrl->qids, shm->ctrl.qids, sizeof(ctrlr->ctrl->qids));
 
 	if (create) {
 		err = nvme_controller_create_io_qpair(ctrlr->ctrl, qpair, depth);
@@ -708,8 +751,7 @@ xnvme_be_upcie_mproc_create_or_delete_io_qpair(struct xnvme_be_upcie_ctrlr *ctrl
 		err = nvme_controller_delete_io_qpair(ctrlr->ctrl, qpair);
 	}
 
-	memcpy(shm->ctrl.qids, ctrlr->ctrl->qids, sizeof(shm->ctrl.qids));
-	xnvme_be_upcie_ctrlr_mutex_unlock(ctrlr);
+	xnvme_be_upcie_mproc_qids_unlock(ctrlr);
 
 	return err;
 }

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -623,6 +623,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "For be=upcie, host DMA heap size in bytes",
 	},
 	{
+		.opt = XNVME_CLI_OPT_DEVICE_HEAP_SIZE,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "device_heap_size",
+		.descr = "For be={upcie-cuda,upcie-hip}, GPU device heap size in bytes",
+	},
+	{
 		.opt = XNVME_CLI_OPT_MAIN_CORE,
 		.vtype = XNVME_CLI_OPT_VTYPE_HEX,
 		.name = "main_core",
@@ -1621,6 +1627,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 	case XNVME_CLI_OPT_HOST_HEAP_SIZE:
 		args->host_heap_size = num;
 		break;
+	case XNVME_CLI_OPT_DEVICE_HEAP_SIZE:
+		args->device_heap_size = num;
+		break;
 	case XNVME_CLI_OPT_MAIN_CORE:
 		args->main_core = arg ? num : 0;
 		break;
@@ -2248,6 +2257,9 @@ xnvme_cli_to_opts(const struct xnvme_cli *cli, struct xnvme_opts *opts)
 	opts->shm_id = cli->given[XNVME_CLI_OPT_SHM_ID] ? cli->args.shm_id : opts->shm_id;
 	opts->host_heap_size = cli->given[XNVME_CLI_OPT_HOST_HEAP_SIZE] ? cli->args.host_heap_size
 									: opts->host_heap_size;
+	opts->device_heap_size = cli->given[XNVME_CLI_OPT_DEVICE_HEAP_SIZE]
+					 ? cli->args.device_heap_size
+					 : opts->device_heap_size;
 	opts->main_core =
 		cli->given[XNVME_CLI_OPT_MAIN_CORE] ? cli->args.main_core : opts->main_core;
 	opts->core_mask =

--- a/tools/homi.c
+++ b/tools/homi.c
@@ -15,6 +15,12 @@
 // per device that costs.
 #define HOMI_HEAP_SIZE_PER_DEV (16ULL * 1024 * 1024)
 
+// The GPU backends allocate a device heap for data buffers, which HOMI never allocates
+// from; only the control structures it does need live on the host heap. Claiming the
+// backend default would take a GiB of VRAM away from the secondaries. 2MiB is the dma-buf
+// granularity that AMD requires, so it is the smallest heap both GPU backends accept.
+#define HOMI_DEVICE_HEAP_SIZE (2ULL * 1024 * 1024)
+
 #ifndef XNVME_PLATFORM_WINDOWS_ENABLED
 
 static volatile sig_atomic_t stop = 0;
@@ -119,6 +125,8 @@ sub_start(struct xnvme_cli *cli)
 	// the secondaries HOMI exists to serve.
 	opts.host_heap_size = cli->args.host_heap_size ? cli->args.host_heap_size
 						       : HOMI_HEAP_SIZE_PER_DEV * ndevs;
+	opts.device_heap_size =
+		cli->args.device_heap_size ? cli->args.device_heap_size : HOMI_DEVICE_HEAP_SIZE;
 
 	err = _xnvme_dev_open_all(dev_uris, ndevs, &opts, &devs);
 	if (err) {
@@ -159,9 +167,10 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_URI, XNVME_CLI_POSN},
 			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LREQ},
-			{XNVME_CLI_OPT_HOST_HEAP_SIZE, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_HOST_HEAP_SIZE, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_DEVICE_HEAP_SIZE, XNVME_CLI_LOPT},
 		},
 	},
 };


### PR DESCRIPTION
This branch is built on top of #696 and has all of its commits. I cannot create stacked PRs from forked repositories.

This PR enables multiprocess mode for upcie-cuda and upcie-hip. Since these backends use a lot of the infrastructure from the upcie backend, the only "real" change is to use the admin queue lock on the admin paths. `--device_heap_size` is added to the CLI of xNVMe and to the homi tool.

Closes #728 