### PR TITLE
fix(upcie/mproc): follow-ups from #696 and #732

### DIFF
--- a/docs/background/backends/upcie/mproc.md
+++ b/docs/background/backends/upcie/mproc.md
@@ -63,7 +63,7 @@ fresh one.
 
 ### Hugepage sharing
 
-Every process allocates it own private DMA heap from its own hugepages. This
+Every process allocates its own private DMA heap from its own hugepages. This
 means that I/O queue pairs and buffers are allocated from a private heap. The
 admin PRP pools are also allocated on the private heap, but the admin queue itself
 is allocated only once on the heap of the primary process. The primary
@@ -201,7 +201,7 @@ out with `-ENOENT`. The timeout is fixed and not currently configurable.
 SPDK's own multi-process mode claims **all** free hugepages on the system at
 startup. Because uPCIe also needs hugepages for its DMA memory, the two cannot
 be expected to share a system, and running uPCIe and SPDK in multi-process
-mode side by side cannot be not guaranteed to work.
+mode side by side is not guaranteed to work.
 
 ### GPU backend doorbell registration
 

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -319,11 +319,16 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 
 	is_owner = !g_upcie_rte.mproc || g_upcie_rte.mproc->is_primary;
 
-	err = _pci_enable_bus_master(dev->ident.uri);
-	if (err) {
-		XNVME_DEBUG("FAILED: _pci_enable_bus_master(%s)", dev->ident.uri);
-		errno = -err;
-		goto failed;
+	/* Only the owner writes the PCI Command register; the primary flipped Bus Master
+	 * Enable at open time and a secondary has neither the need nor, in general, the
+	 * privilege to touch it. */
+	if (is_owner) {
+		err = _pci_enable_bus_master(dev->ident.uri);
+		if (err) {
+			XNVME_DEBUG("FAILED: _pci_enable_bus_master(%s)", dev->ident.uri);
+			errno = -err;
+			goto failed;
+		}
 	}
 
 	ctrlr = calloc(1, sizeof(*ctrlr));

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -101,7 +101,7 @@ _rte_init(struct xnvme_opts *opts)
 	err = hostmem_heap_init(&g_upcie_rte.heap, heap_size, &g_upcie_rte.config);
 	if (err) {
 		XNVME_DEBUG("FAILED: hostmem_heap_init(); err(%d)", err);
-		return err;
+		goto fail_mproc;
 	}
 
 	if (g_upcie_rte.mproc) {
@@ -130,7 +130,8 @@ _rte_init(struct xnvme_opts *opts)
 				XNVME_DEBUG("FAILED: Timed out while waiting for primary process "
 					    "hugepage "
 					    "information");
-				return -ENOENT;
+				err = -ENOENT;
+				goto fail_heap;
 			}
 
 			err = xnvme_be_upcie_mproc_import_admin_hugepage();
@@ -139,7 +140,7 @@ _rte_init(struct xnvme_opts *opts)
 					"FAILED: xnvme_be_upcie_mproc_import_admin_hugepage(); "
 					"err(%d)",
 					err);
-				return err;
+				goto fail_heap;
 			}
 		}
 	}
@@ -147,6 +148,14 @@ _rte_init(struct xnvme_opts *opts)
 	g_upcie_rte.is_initialized = 1;
 
 	return 0;
+
+fail_heap:
+	hostmem_heap_term(&g_upcie_rte.heap);
+fail_mproc:
+	if (g_upcie_rte.mproc) {
+		xnvme_be_upcie_mproc_rte_term();
+	}
+	return err;
 }
 
 /**

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -676,9 +676,10 @@ failed:
  *
  * Wraps xnvme_be_upcie_ctrlr_mutex_lock() for callers that allocate or release
  * I/O queue identifiers. In a secondary process ctrlr->ctrl is a process-local
- * copy of the controller, so the bitmap has to be pulled in from shared memory
- * before it is consulted. In a primary process, and when not in multi-process
- * mode, this is a no-op beyond the locking itself.
+ * copy of the controller and has to see the current bitmap before it is
+ * consulted; in a primary process ctrlr->ctrl points into the shared segment
+ * itself so no import is needed, and outside multi-process mode ctrlr->shm is
+ * NULL, so this is a no-op beyond the locking itself.
  *
  * @param ctrlr The backend controller
  *
@@ -695,7 +696,7 @@ xnvme_be_upcie_mproc_qids_lock(struct xnvme_be_upcie_ctrlr *ctrlr)
 		return err;
 	}
 
-	if (ctrlr->shm) {
+	if (ctrlr->shm && ctrlr->ctrl != &ctrlr->shm->ctrl) {
 		memcpy(ctrlr->ctrl->qids, ctrlr->shm->ctrl.qids, sizeof(ctrlr->ctrl->qids));
 	}
 
@@ -710,7 +711,7 @@ xnvme_be_upcie_mproc_qids_lock(struct xnvme_be_upcie_ctrlr *ctrlr)
 void
 xnvme_be_upcie_mproc_qids_unlock(struct xnvme_be_upcie_ctrlr *ctrlr)
 {
-	if (ctrlr->shm) {
+	if (ctrlr->shm && ctrlr->ctrl != &ctrlr->shm->ctrl) {
 		memcpy(ctrlr->shm->ctrl.qids, ctrlr->ctrl->qids, sizeof(ctrlr->shm->ctrl.qids));
 	}
 

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -220,29 +220,22 @@ _recover_aq(struct xnvme_be_upcie_ctrlr *ctrlr)
 {
 	struct xnvme_be_upcie_ctrlr_shm *shm = ctrlr->shm;
 	struct nvme_qpair *aq = &ctrlr->ctrl->aq;
-	struct nvme_completion *cq = aq->cq;
-	struct nvme_completion *cqe;
-	uint16_t head = shm->ctrl.aq.head;
-	uint8_t phase = shm->ctrl.aq.phase;
+	struct nvme_completion cpl = {0};
 	int drained = 0;
 
-	cqe = &cq[head];
+	// Point the local queue-pair at the shared head/phase; the caller re-syncs it from
+	// shared memory once the mutex is marked consistent, so this is safe to clobber.
+	aq->head = shm->ctrl.aq.head;
+	aq->phase = shm->ctrl.aq.phase;
 
-	while ((cqe->cid < 0xFFFF) && ((cqe->status & 0x1) == phase)) {
-		head++;
-		if (head == aq->depth) {
-			head = 0;
-			phase ^= 1;
-		}
-
-		mmio_write32(aq->cqdb, 0, head);
+	// timeout_ms(1): one poll of the current slot; the drain stops at the first slot the
+	// device has not written, it does not wait for completions still in flight
+	while (!nvme_qpair_reap_cpl(aq, 1, &cpl)) {
 		drained++;
-
-		cqe = &cq[head];
 	}
 
-	shm->ctrl.aq.head = head;
-	shm->ctrl.aq.phase = phase;
+	shm->ctrl.aq.head = aq->head;
+	shm->ctrl.aq.phase = aq->phase;
 
 	if (drained) {
 		XNVME_DEBUG("INFO: recovered admin CQ after owner death; drained(%d)", drained);

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -397,7 +397,8 @@ xnvme_be_upcie_mproc_ctrlr_shm_init(struct xnvme_dev *dev, struct xnvme_be_upcie
 	xnvme_be_upcie_shm_bdf_name(dev->ident.uri, shm_name, sizeof(shm_name));
 
 	/* Use flock to determine whether another primary process has claimed device */
-	snprintf(ctrlr->lock_name, sizeof(ctrlr->lock_name), "/tmp%s-lock", dev->ident.uri);
+	snprintf(ctrlr->lock_name, sizeof(ctrlr->lock_name), "/tmp/xnvme-upcie-%s-lock",
+		 dev->ident.uri);
 	ctrlr->lock_fd = -1;
 
 	lock_fd = open(ctrlr->lock_name, O_CREAT | O_RDWR, 0600);

--- a/lib/upcie/xnvme_be_upcie_mproc.c
+++ b/lib/upcie/xnvme_be_upcie_mproc.c
@@ -54,6 +54,7 @@ xnvme_be_upcie_mproc_rte_term()
 	}
 
 	free(mproc);
+	g_upcie_rte.mproc = NULL;
 }
 
 int
@@ -195,6 +196,7 @@ xnvme_be_upcie_mproc_import_admin_hugepage()
 	if (err) {
 		XNVME_DEBUG("FAILED: hostmem_hugepage_import(); err(%d)", err);
 		free(g_upcie_rte.mproc->primary_hugepage);
+		g_upcie_rte.mproc->primary_hugepage = NULL;
 		return err;
 	}
 
@@ -392,7 +394,7 @@ xnvme_be_upcie_mproc_ctrlr_shm_init(struct xnvme_dev *dev, struct xnvme_be_upcie
 	struct xnvme_be_upcie_ctrlr_shm *shm;
 	char shm_name[64];
 	size_t shm_size = sizeof(*shm);
-	int shm_fd, lock_fd, err;
+	int shm_fd = -1, lock_fd = -1, err;
 
 	xnvme_be_upcie_shm_bdf_name(dev->ident.uri, shm_name, sizeof(shm_name));
 


### PR DESCRIPTION
#732 is now on `main`, so this PR is rebased onto it and stands alone: four fixes, a refactor and a docs cleanup.

## What is in it

Four fixes, a refactor and a docs cleanup from local review of #696 (merged as `b8a1964d`) and #732, `+45 -34` across 3 files:

- `fix(upcie/mproc): put per-BDF lock file under /tmp/`
  - `+2 -1` in 1 file
  - The `/tmp%s-lock` snprintf missed a slash; the lock resolved under `/` instead of `/tmp/`.
- `fix(upcie/mproc): clean up on _rte_init and ctrlr_shm_init error paths`
  - `+15 -4` across 2 files
  - Mproc state leaked when `_rte_init` failed after `mproc_rte_init` succeeded; `shm_fd`/`lock_fd` were also read uninitialised in ctrlr_shm_init's failed label.
- `refactor(upcie/mproc): replace custom completion-handling with helper`
  - `+10 -17` in 1 file
  - `_recover_aq` kept its own copy of the CQ walk; it now drives the shared helper, as suggested in review.
- `fix(upcie/mproc): only the owner enables PCI bus master`
  - `+10 -5` in 1 file
  - Secondaries called `_pci_enable_bus_master` too, without the need or the config-space write permission.
- `fix(upcie/mproc): skip qids self-copy in the primary`
  - `+6 -5` in 1 file
  - Same-address memcpy (UB per C99) because `ctrl == &shm->ctrl` in the primary.
- `docs(upcie/mproc): fix "allocates it own" and a double negative`
  - `+2 -2` in 1 file
  - Prose fixes in `docs/background/backends/upcie/mproc.md`.

## What is not

- The stale-shm foot-gun: a fresh homi occasionally came up as "Lock file already claimed" against a free `shm_id`. Not root-caused, needs a live repro.
- Freeing the qid inside uPCIe's `nvme_controller_cuda_delete_io_qpair()` rather than in the backend, from review of #732; tracked at #735.
- `_recover_aq` resyncs `head` and `phase` but not `tail`, so an owner that died between submitting and unlocking may leave the shared SQ cursor behind the device. Read from the code, not reproduced, and it predates this PR.
- Trailer discipline on `856536fa` (`992df891` before #732 was rebase-merged), now on `main` and not retroactively fixable.
- Wiring `--device_heap_size` beyond `homi start`. Review of #732 questioned whether the option is needed at all, so this may end as a removal instead; tracked at #736.

## Verified

Built and smoke-tested on warp (RTX A6000) and wave (RX 7800 XT). `homi --be upcie --shm_id 1` + one xnvmeperf secondary matched the pre-fixup baseline (1.64 M / 1.80 M IOPS); two concurrent secondaries fanned out cleanly (853 k+852 k / 898 k+898 k). `/dev/shm/xnvme-upcie-*` and `/tmp/xnvme-upcie-*` clean after primary exit on both boxes.

Those runs predate two later changes to the branch, neither of which alters what was measured. The `nvme_qpair_reap_cpl` refactor is build-and-format-checked only, and `_recover_aq` runs on owner death, a path the smoke test does not reach. The rebase onto the merged #732 dropped the seven shared commits by patch-id and left a byte-identical tree, verified with `git diff` against the pre-rebase head.

## GPU HW verification

Not on this branch. GPU HW verification requires uPCIe v0.6.0 and the DKMS `dmabuf-import` module; this PR's base sits on `main`'s pre-#727 uPCIe snapshot which uses the in-tree udmabuf path and cannot use `dmabuf-import`. All six commits here are host-mproc code paths and touch no GPU or dmabuf code, so this is orthogonal to what's under review. GPU HW verification for the mproc surface happens at #734.


