### PR TITLE
feat(be/linux): NVMe FLUSH and FUA support in the io_uring and libaio backends

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_ioworker.py
+++ b/cijoe/tests/logic/test_xnvme_tests_ioworker.py
@@ -195,3 +195,23 @@ def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7 --vec-cnt 4 --direct 1"
     )
     assert not err
+
+
+@xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
+def test_verify_flush(cijoe, device, be_opts, cli_args):
+    # Async-interfaces without an implementation of NVM FLUSH: FreeBSD 'kqueue'
+    # and Windows 'ioring' reject it with -ENOSYS, Windows 'iocp'/'iocp_th'
+    # handle only the FS FLUSH opcode
+    if be_opts["async"] in ["kqueue", "iocp", "iocp_th", "ioring"]:
+        pytest.skip(reason=f"[async={be_opts['async']}] does not implement NVM FLUSH")
+
+    # The FUA-writes make this the first fabrics case sustaining I/O beyond the
+    # keep-alive timeout, and the spdk backend only services the admin-queue --
+    # and thereby keep-alive -- inside admin commands, so the target reaps the
+    # controller mid-run and the queue dies with -ENXIO. A backend concern, not
+    # a FLUSH one; skip until the backend keeps the connection alive
+    if "fabrics" in device["labels"]:
+        pytest.skip(reason="[fabrics] spdk backend sends no keep-alive during I/O")
+
+    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-flush {cli_args}")
+    assert not err

--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -34,6 +34,20 @@ xnvme_nvm_read(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, uint16_t
 /**
  * Submit a NVMe Write command
  *
+ * NOTE: fields which are not arguments here, such as 'ctx->cmd.nvm.fua', are
+ * left untouched; set them on the context before calling this. Neither this
+ * function nor ::xnvme_queue_get_cmd_ctx clears them, so a context which is
+ * reused for another command carries them over. Reset it with
+ * ::xnvme_cmd_ctx_clear when that is not intended.
+ *
+ * NOTE: whether 'ctx->cmd.nvm.fua' is honoured is backend-dependent, and it
+ * applies to NVM writes only. Backends passing the command through to an NVMe
+ * device (ioctl, io_uring_cmd, spdk, libvfn, upcie) carry the bit in the
+ * command itself. The Linux io_uring and libaio backends translate it to
+ * RWF_DSYNC, which on a raw block device makes the kernel issue the write
+ * with REQ_FUA. The remaining backends (psync, POSIX-aio, ramdisk, FreeBSD,
+ * Windows, macOS) ignore it.
+ *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier
  * @param slba The LBA to start the write at
@@ -80,6 +94,10 @@ xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, 
  *
  * This populates the command fields in the given context, it does not submit
  * the command. Submit it with e.g. ::xnvme_cmd_pass.
+ *
+ * NOTE: only the fields given as arguments are populated; the remaining ones,
+ * such as 'ctx->cmd.nvm.fua', are left as they were. Reset a reused context
+ * with ::xnvme_cmd_ctx_clear when carrying them over is not intended.
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param opcode Opcode for the NVMe command

--- a/lib/xnvme_be_linux_async_libaio.c
+++ b/lib/xnvme_be_linux_async_libaio.c
@@ -11,6 +11,7 @@
 #ifdef XNVME_BE_LINUX_LIBAIO_ENABLED
 #include <errno.h>
 #include <libaio.h>
+#include <linux/fs.h>
 #include <stdatomic.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
@@ -199,6 +200,13 @@ _linux_libaio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, 
 		return -ENOSYS;
 	}
 
+	// Honour the FUA bit of an NVM write; on a raw block device RWF_DSYNC
+	// makes the kernel issue the write with REQ_FUA. Only for the NVM opcode:
+	// 'fua' is an NVMe command-field, it does not exist for the FS opcodes
+	if (ctx->cmd.nvm.fua && ctx->cmd.common.opcode == XNVME_SPEC_NVM_OPC_WRITE) {
+		iocb.aio_rw_flags = RWF_DSYNC;
+	}
+
 	iocb.data = (unsigned long *)ctx;
 
 	if (queue->efd != -1) {
@@ -265,6 +273,13 @@ _linux_libaio_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec
 	default:
 		XNVME_DEBUG("FAILED: unsupported opcode: %d", ctx->cmd.common.opcode);
 		return -ENOSYS;
+	}
+
+	// Honour the FUA bit of an NVM write; on a raw block device RWF_DSYNC
+	// makes the kernel issue the write with REQ_FUA. Only for the NVM opcode:
+	// 'fua' is an NVMe command-field, it does not exist for the FS opcodes
+	if (ctx->cmd.nvm.fua && ctx->cmd.common.opcode == XNVME_SPEC_NVM_OPC_WRITE) {
+		iocb.aio_rw_flags = RWF_DSYNC;
 	}
 
 	if (queue->efd != -1) {

--- a/lib/xnvme_be_linux_async_libaio.c
+++ b/lib/xnvme_be_linux_async_libaio.c
@@ -188,7 +188,11 @@ _linux_libaio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, 
 		io_prep_pread(&iocb, state->fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
 		break;
 
-		// TODO: determine how to handle fsync
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		// NOTE: full fsync, matching the psync backend
+		io_prep_fsync(&iocb, state->fd);
+		break;
 
 	default:
 		XNVME_DEBUG("FAILED: unsupported opcode: %d", ctx->cmd.common.opcode);
@@ -252,7 +256,11 @@ _linux_libaio_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec
 		io_prep_preadv(&iocb, state->fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
 		break;
 
-		// TODO: determine how to handle fsync
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		// NOTE: full fsync, matching the psync backend
+		io_prep_fsync(&iocb, state->fd);
+		break;
 
 	default:
 		XNVME_DEBUG("FAILED: unsupported opcode: %d", ctx->cmd.common.opcode);

--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <liburing.h>
+#include <linux/fs.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
 #include <xnvme_queue.h>
@@ -338,7 +339,12 @@ xnvme_be_linux_liburing_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbu
 	// NOTE: we only ever register a single file, the raw device, so the
 	// provided index will always be 0
 	sqe->fd = queue->poll_sq ? 0 : state->fd;
-	sqe->rw_flags = 0;
+	// Honour the FUA bit of an NVM write; on a raw block device RWF_DSYNC
+	// makes the kernel issue the write with REQ_FUA. Only for the NVM opcode:
+	// 'fua' is an NVMe command-field, it does not exist for the FS opcodes
+	sqe->rw_flags = (ctx->cmd.common.opcode == XNVME_SPEC_NVM_OPC_WRITE && ctx->cmd.nvm.fua)
+				? RWF_DSYNC
+				: 0;
 	sqe->user_data = (unsigned long)ctx;
 	// sqe->__pad2[0] = sqe->__pad2[1] = sqe->__pad2[2] = 0;
 
@@ -409,6 +415,13 @@ xnvme_be_linux_liburing_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, s
 	/* fall through */
 	case XNVME_SPEC_FS_OPC_WRITE:
 		io_uring_prep_writev(sqe, fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
+		if (ctx->cmd.common.opcode == XNVME_SPEC_NVM_OPC_WRITE && ctx->cmd.nvm.fua) {
+			// Honour the FUA bit of an NVM write; on a raw block device
+			// RWF_DSYNC makes the kernel issue the write with REQ_FUA.
+			// Only for the NVM opcode: 'fua' is an NVMe command-field, it
+			// does not exist for the FS opcodes
+			sqe->rw_flags = RWF_DSYNC;
+		}
 		break;
 
 	case XNVME_SPEC_NVM_OPC_READ:

--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -294,6 +294,19 @@ xnvme_be_linux_liburing_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbu
 		opcode = IORING_OP_READ;
 		break;
 
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		// NOTE: IORING_OP_FSYNC has no iopoll-handler; on a ring set up with
+		// IORING_SETUP_IOPOLL it would be accepted here and only fail with
+		// -EINVAL at completion-time. Reject it at submission-time instead
+		if (queue->poll_io) {
+			XNVME_DEBUG("FAILED: FLUSH is not supported on an IOPOLL queue");
+			return -ENOSYS;
+		}
+		// NOTE: full fsync, matching the psync backend
+		opcode = IORING_OP_FSYNC;
+		break;
+
 	default:
 		XNVME_DEBUG("FAILED: unsupported opcode: %d for async", ctx->cmd.common.opcode);
 		return -ENOSYS;
@@ -302,6 +315,18 @@ xnvme_be_linux_liburing_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbu
 	sqe = io_uring_get_sqe(&queue->ring);
 	if (!sqe) {
 		return -EAGAIN;
+	}
+
+	if (opcode == IORING_OP_FSYNC) {
+		// NOTE: the prep-helper zeroes 'addr', 'off', 'len' and 'fsync_flags'.
+		// io_fsync_prep() rejects a non-zero 'addr'; 'off'/'len' would select a
+		// range for vfs_fsync_range(), zero/zero means the entire file
+		io_uring_prep_fsync(sqe, queue->poll_sq ? 0 : state->fd, 0);
+		// NOTE: set after the prep-helper; io_uring_prep_rw() zeroes 'flags'
+		sqe->flags = queue->poll_sq ? IOSQE_FIXED_FILE : 0;
+		sqe->user_data = (unsigned long)ctx;
+
+		goto submit;
 	}
 
 	sqe->opcode = opcode;
@@ -316,6 +341,8 @@ xnvme_be_linux_liburing_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbu
 	sqe->rw_flags = 0;
 	sqe->user_data = (unsigned long)ctx;
 	// sqe->__pad2[0] = sqe->__pad2[1] = sqe->__pad2[2] = 0;
+
+submit:
 
 	if (queue->batching) {
 		goto exit;
@@ -355,6 +382,16 @@ xnvme_be_linux_liburing_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, s
 		return -ENOTSUP;
 	}
 
+	// NOTE: IORING_OP_FSYNC has no iopoll-handler; on a ring set up with
+	// IORING_SETUP_IOPOLL it would be accepted at submission-time and only fail
+	// with -EINVAL at completion-time. Reject it up-front instead, and do so
+	// before acquiring an sqe, such that none is left dangling in the ring
+	if (queue->poll_io && (ctx->cmd.common.opcode == XNVME_SPEC_NVM_OPC_FLUSH ||
+			       ctx->cmd.common.opcode == XNVME_SPEC_FS_OPC_FLUSH)) {
+		XNVME_DEBUG("FAILED: FLUSH is not supported on an IOPOLL queue");
+		return -ENOSYS;
+	}
+
 	sqe = io_uring_get_sqe(&queue->ring);
 	if (!sqe) {
 		return -EAGAIN;
@@ -379,6 +416,17 @@ xnvme_be_linux_liburing_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, s
 	/* fall through */
 	case XNVME_SPEC_FS_OPC_READ:
 		io_uring_prep_readv(sqe, fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
+		break;
+
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		// NOTE: full fsync, matching the psync backend
+		io_uring_prep_fsync(sqe, fd, 0);
+		// NOTE: re-assign after the prep-helper; on liburing versions where
+		// io_uring_prep_rw() zeroes 'flags', the assignment above would be
+		// dropped and an SQPOLL queue would fsync the actual file descriptor
+		// 0 instead of the registered file. Matches the single-buffer path
+		sqe->flags = queue->poll_sq ? IOSQE_FIXED_FILE : 0;
 		break;
 
 	default:

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <libxnvme.h>
+#include <string.h>
 
 #define QDEPTH_MAX 16
 #define QDEPTH_DEF 4
@@ -68,6 +69,7 @@ struct iowork {
 
 	int vectored; ///< Whether or not the vectored I/O path is used
 	int vec_cnt;
+	int fua; ///< Set the FUA bit on writes
 
 	uint64_t nio; ///< Number of I/Os to complete (count-from-1)
 
@@ -239,6 +241,7 @@ on_completion(struct xnvme_cmd_ctx *ctx, void *cb_arg)
 	ctx->cmd.common.opcode = work->opc;
 	ctx->cmd.nvm.nlb = work->io.naddr - 1;
 	ctx->cmd.nvm.slba += work->nworkers * work->io.naddr;
+	ctx->cmd.nvm.fua = work->fua && (work->opc == XNVME_SPEC_NVM_OPC_WRITE);
 
 	_submit(work, worker, ctx);
 
@@ -388,6 +391,7 @@ start_workers(struct iowork *work)
 		ctx->cmd.common.opcode = work->opc;
 		ctx->cmd.nvm.nlb = work->io.naddr - 1;
 		ctx->cmd.nvm.slba = work->range.slba + i * work->io.naddr;
+		ctx->cmd.nvm.fua = work->fua && (work->opc == XNVME_SPEC_NVM_OPC_WRITE);
 		ctx->async.cb_arg = worker;
 		err = _submit(work, worker, ctx);
 		if (err) {
@@ -395,6 +399,87 @@ start_workers(struct iowork *work)
 		}
 	}
 	return 0;
+}
+
+struct flush_state {
+	struct iowork *work;
+	int done;
+	int err;
+};
+
+static void
+on_flush_completion(struct xnvme_cmd_ctx *ctx, void *cb_arg)
+{
+	struct flush_state *state = cb_arg;
+
+	state->err = xnvme_cmd_ctx_cpl_status(ctx) ? -EIO : 0;
+
+	// Restore the queue-wide callback; xnvme_queue_set_cb() stamps it onto
+	// every pooled context only once, so a per-context override would
+	// otherwise survive the put and hijack a later data-I/O
+	xnvme_cmd_ctx_set_cb(ctx, on_completion, state->work);
+	xnvme_queue_put_cmd_ctx(ctx->async.queue, ctx);
+
+	state->done = 1;
+}
+
+static int
+iowork_flush(struct iowork *work)
+{
+	struct flush_state state = {.work = work, .done = 0, .err = 0};
+	struct xnvme_cmd_ctx *ctx;
+	int err;
+
+	ctx = xnvme_queue_get_cmd_ctx(work->queue);
+	if (!ctx) {
+		return -errno;
+	}
+
+	memset(&ctx->cmd, 0x0, sizeof(ctx->cmd));
+	ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_FLUSH;
+	ctx->cmd.common.nsid = work->nsid;
+	xnvme_cmd_ctx_set_cb(ctx, on_flush_completion, &state);
+
+retry:
+	// Submit through the vectored path when the data-phases do; the FLUSH
+	// dispatch differs between cmd_io and cmd_iov, so both need exercising
+	if (work->vectored) {
+		err = xnvme_cmd_pass_iov(ctx, NULL, 0, 0, NULL, 0);
+	} else {
+		err = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
+	}
+	switch (err) {
+	case 0:
+		break;
+
+	case -EBUSY:
+	case -EAGAIN:
+		err = xnvme_queue_poke(work->queue, 0);
+		if (err < 0) {
+			goto failed;
+		}
+		goto retry;
+
+	default:
+		goto failed;
+	}
+
+	while (!state.done) {
+		err = xnvme_queue_poke(work->queue, 0);
+		if (err < 0) {
+			// The command was submitted; the context is in flight and
+			// cannot be returned to the pool
+			return err;
+		}
+	}
+
+	return state.err;
+
+failed:
+	// Not submitted; restore the queue-wide callback and return the context
+	xnvme_cmd_ctx_set_cb(ctx, on_completion, work);
+	xnvme_queue_put_cmd_ctx(work->queue, ctx);
+	return err;
 }
 
 static int
@@ -421,7 +506,7 @@ final(struct iowork work, int err)
 }
 
 static int
-test_verify(struct xnvme_cli *cli)
+_verify(struct xnvme_cli *cli, bool flush)
 {
 	struct iowork work;
 	int err;
@@ -431,6 +516,10 @@ test_verify(struct xnvme_cli *cli)
 		XNVME_DEBUG("FAILED: iowork_from_cli(), err: %d", err);
 		return err;
 	}
+
+	// The flush-variant also sets the FUA bit on its writes; both are
+	// durability paths, and neither has coverage elsewhere
+	work.fua = flush;
 
 	iowork_pp(&work);
 	xnvme_dev_pr(work.dev, XNVME_PR_DEF);
@@ -466,9 +555,30 @@ test_verify(struct xnvme_cli *cli)
 			err = EIO;
 			return final(work, err);
 		}
+
+		// Flush between the write phase and the read phase
+		if (flush && (i == 0)) {
+			err = iowork_flush(&work);
+			if (err) {
+				xnvme_cli_perr("iowork_flush()", err);
+				return final(work, err);
+			}
+		}
 	}
 
 	return final(work, err);
+}
+
+static int
+test_verify(struct xnvme_cli *cli)
+{
+	return _verify(cli, false);
+}
+
+static int
+test_verify_flush(struct xnvme_cli *cli)
+{
+	return _verify(cli, true);
 }
 
 static int
@@ -520,6 +630,22 @@ static struct xnvme_cli_sub g_subs[] = {
 		"Write, then read and compare",
 		"Write, then read and compare",
 		test_verify,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_VEC_CNT, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_NLB, XNVME_CLI_LOPT},
+
+			XNVME_CLI_ASYNC_OPTS,
+		},
+	},
+	{
+		"verify-flush",
+		"Write, flush, then read and compare",
+		"Write, flush, then read and compare",
+		test_verify_flush,
 		{
 			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -39,6 +39,9 @@ tests = {
   ],
   'ioworker.c': [
     ['verify', ['verify', '1GB']],
+    ['verify_flush', ['verify-flush', '1GB']],
+    ['verify_flush emu', ['verify-flush', '1GB', '--async', 'emu']],
+    ['verify_flush emu vec-cnt=4', ['verify-flush', '1GB', '--async', 'emu', '--vec-cnt', '4']],
     ['verify_sync', ['verify-sync', '1GB']],
     ['verify vec-cnt=4', ['verify', '1GB', '--vec-cnt', '4']],
     ['verify_sync vec-cnt=4', ['verify-sync', '1GB', '--vec-cnt', '4']],


### PR DESCRIPTION
The opcode dispatch in the io_uring and libaio async backends handled only READ and WRITE; FLUSH fell through to the default case and was rejected with -ENOSYS. This breaks any consumer whose device reports a volatile write cache, e.g. serving a namespace through ublk makes the kernel issue FLUSH, and mkfs on top of it fails with EIO. Similarly, the FUA bit set on a write command was silently ignored.

Scoped down per review to the FLUSH/FUA work and its tests; the SQPOLL fix with its regression test, the sqe-leak fix in cmd_iov, the poll_sq/poll_io options and the qdepth fix move to a follow-up PR. Four commits:

1. **feat(be/linux): support NVMe FLUSH in the io_uring and libaio backends** — FLUSH → `IORING_OP_FSYNC` / `IO_CMD_FSYNC` in the single-buffer and vectored paths; full fsync, matching psync. On an IOPOLL ring FLUSH is rejected at submission-time with -ENOSYS (IORING_OP_FSYNC has no iopoll-handler), matching the pre-change behaviour, and before acquiring an sqe.
2. **feat(be/linux): honour the FUA bit in io_uring and libaio writes** — `ctx->cmd.nvm.fua` on an NVM write → `RWF_DSYNC`; on a raw block device the kernel then issues the write with REQ_FUA. NVM write opcode only: 'fua' is an NVMe command-field, the FS opcodes define no such field and the file-API has no way of setting it. The header documents that honouring 'fua' is backend-dependent and that unset fields survive context reuse.
3. **tests(ioworker): add a verify-flush subcommand** — FUA-write, FLUSH through the queue, read-compare; the FLUSH goes through the vectored submission-path when `--vec-cnt` is given, so both `cmd_io` and `cmd_iov` dispatches are exercised. Meson entries with `--async emu` walk a real opcode dispatch (the plain `1GB` entry resolves to the nil backend, which ignores the opcode).
4. **tests(cijoe): cover NVM FLUSH through the async backends in ioworker** — verify-flush across the backend matrix, skipping the async-interfaces without an NVM FLUSH implementation (posix, kqueue, iocp, iocp_th).

## Verification

On Ubuntu 24.04, kernel 6.8.12, against a file-backed target, the ramdisk backend, and a Samsung SSD 970 EVO 1TB (as root):

- `meson test` — pass/fail set identical to `main` on the same machine.
- Every commit in the series builds.
- Queue-level smoke driving write, FUA-write and FLUSH through io_uring and libaio (single-buffer and vectored): all complete without error.
- `xnvme_tests_ioworker verify-flush 1GB --async emu|thrpool`, with `--vec-cnt 4`: pass.
- Real-NVMe: `verify-flush` over io_uring, libaio and io_uring_cmd, plus vectored variants: pass (detail in the comments below).

Known gap, deferred: vectored READ/WRITE on an SQPOLL queue still loses `IOSQE_FIXED_FILE` through the prep-helpers — that is the pre-existing bug whose fix moved to the follow-up PR; the FLUSH branch added here re-assigns `sqe->flags` after its prep-helper and is unaffected.
