### PR TITLE
test(cijoe): let the GPU example tests actually run

### DIFF
--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -159,9 +159,13 @@ def xnvme_setup(labels=[], opts=[]):
 
     parametrization = []
 
-    combinations = xnvme_be_opts(
-        opts, ["file"] if "file" in labels else ["bdev", "cdev", "pcie", "fabrics"]
+    # The caller's labels join the defaults rather than being filtered against
+    # them: a backend reached only by its own label, as the GPU ones are, has no
+    # combination generated at all otherwise, and its tests skip everywhere
+    default_labels = (
+        ["file"] if "file" in labels else ["bdev", "cdev", "pcie", "fabrics"]
     )
+    combinations = xnvme_be_opts(opts, sorted(set(default_labels) | set(labels)))
 
     for be_opts in combinations:
         search = labels + be_opts["label"]
@@ -231,9 +235,25 @@ class XnvmeDriver(object):
 
     IS_KERNEL_ATTACHED = None
 
+    # Which userspace driver the current attachment used, so that moving between
+    # a GPU device and a host one rebinds rather than reusing the wrong one
+    USERSPACE_DRIVER = None
+
     @staticmethod
-    def kernel_detach(cijoe):
-        """Detach from kernel"""
+    def userspace_driver(labels):
+        """
+        The userspace driver a device with these labels needs, or None for the default.
+
+        The GPU backends reach a heap the GPU runtime exported, and
+        IOMMU_IOAS_MAP_FILE refuses a dma-buf from one, so a controller behind an
+        IOMMU cannot address it. They need the IOMMU out of the way.
+        """
+
+        return "uio_pci_generic" if {"cuda", "hip"} & set(labels or []) else None
+
+    @staticmethod
+    def kernel_detach(cijoe, driver=None):
+        """Detach from kernel, optionally onto a named userspace driver"""
 
         # Rebinding devices and re-allocating hugepages invalidates a running primary,
         # so tear it down first rather than leaving MprocPrimary with a stale handle.
@@ -241,15 +261,22 @@ class XnvmeDriver(object):
 
         # 64MB contigmem buffers avoid ENOMEM on FreeBSD's fragmented CI heap;
         # see toolbox/xnvme-driver.sh.
-        cmd = "xnvme-driver"
+        env = []
         if get_osname() == "freebsd":
-            cmd = "env CONTIGMEM_BUFSZ=64 " + cmd
+            env.append("CONTIGMEM_BUFSZ=64")
+        if driver:
+            env.append(f"DRIVER_OVERRIDE={driver}")
+
+        cmd = "xnvme-driver"
+        if env:
+            cmd = "env " + " ".join(env) + " " + cmd
 
         err, _ = cijoe.run(cmd)
         if err:
             cijoe.run("dmesg | tail -n20")
 
         XnvmeDriver.IS_KERNEL_ATTACHED = False
+        XnvmeDriver.USERSPACE_DRIVER = driver
 
     @staticmethod
     def kernel_attach(cijoe):
@@ -269,9 +296,13 @@ class XnvmeDriver(object):
 
         needs_kernel = device.get("driver_attachment", "kernel") == "kernel"
         needs_userspace = not needs_kernel
+        driver = XnvmeDriver.userspace_driver(device.get("labels"))
 
-        if needs_userspace and XnvmeDriver.IS_KERNEL_ATTACHED in [True, None]:
-            XnvmeDriver.kernel_detach(cijoe)
+        if needs_userspace and (
+            XnvmeDriver.IS_KERNEL_ATTACHED in [True, None]
+            or XnvmeDriver.USERSPACE_DRIVER != driver
+        ):
+            XnvmeDriver.kernel_detach(cijoe, driver)
             cijoe.run("xnvme enum")
         elif needs_kernel and XnvmeDriver.IS_KERNEL_ATTACHED in [False, None]:
             XnvmeDriver.kernel_attach(cijoe)

--- a/cijoe/tests/examples/test_xnvme_mem_map.py
+++ b/cijoe/tests/examples/test_xnvme_mem_map.py
@@ -3,7 +3,7 @@ import pytest
 from ..conftest import get_shm_id, xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["pcie"], opts=["be"])
+@xnvme_parametrize(labels=["cuda"], opts=["be"])
 def test_cuda_mem_map(cijoe, device, be_opts, cli_args):
     if be_opts["be"] != "upcie-cuda":
         pytest.skip(reason="The example opens the device with --be upcie-cuda")
@@ -14,7 +14,7 @@ def test_cuda_mem_map(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["pcie"], opts=["be"])
+@xnvme_parametrize(labels=["hip"], opts=["be"])
 def test_hip_mem_map(cijoe, device, be_opts, cli_args):
     if be_opts["be"] != "upcie-hip":
         pytest.skip(reason="The example opens the device with --be upcie-hip")

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -156,6 +156,15 @@ def get_backend_configurations():
             "label": ["cuda"],
             "mproc": True,
         },
+        {
+            "be": ["upcie-hip"],
+            "mem": ["upcie-hip"],
+            "async": ["upcie-hip"],
+            "sync": ["upcie-hip"],
+            "admin": ["upcie-hip"],
+            "label": ["hip"],
+            "mproc": True,
+        },
         # Ramdisk
         {
             "be": ["ramdisk_emu"],


### PR DESCRIPTION
`test_cuda_mem_map` and `test_hip_mem_map` skipped everywhere, on every host,
including the two with GPUs in them. Running `workflows/test-gpu.yaml` against
an RTX A6000 selected nothing at all: 15 skipped, 2118 deselected. They looked
like coverage and were not.

Three separate things kept them from running, and a fourth kept them from
passing once they did. The tests asked for a device labelled `pcie` while the
GPU backends label theirs `cuda` and `hip`; the backend combinations were
filtered to `bdev`, `cdev`, `pcie` and `fabrics`, so no `upcie-cuda`
combination existed whatever a test asked for; there was no `upcie-hip`
combination at all; and the harness binds vfio-pci, which a GPU heap cannot be
reached through, since `IOMMU_IOAS_MAP_FILE` refuses a dma-buf exported by a
GPU runtime.

## Worth a careful look

- `XnvmeDriver` is shared by every backend's tests. It now picks
  `uio_pci_generic` for a GPU-labelled device and tracks which userspace driver
  the current attachment used, so that moving between a GPU device and a host
  one rebinds instead of reusing the wrong binding.
- The caller's labels now join the default label set rather than being filtered
  against it. A backend reachable only by its own label has no combination
  generated otherwise.

## Verification

Both tests now run and pass on hardware, each starting from a vfio-pci binding
so the harness has to do the rebinding itself: `test_cuda_mem_map` on an RTX
A6000 and `test_hip_mem_map` on a Radeon under ROCm, both ending with the
device on `uio_pci_generic`.

For regression, `-k "(upcie or spdk) and not fabrics"` was run on an
11-controller QEMU guest against `main` with the stock harness and again with
this change: 107 failed and 106 passed both times, with identical failure sets.
The only difference is four more skips, which are the new `upcie-hip`
combinations skipping on a guest that has no HIP device. Those 107 failures are
that guest's own: it has no vIOMMU, so `be=spdk` cannot open a device there.
