### PR TITLE
tools: add qublk, a ublk server backed by xNVMe

### DIFF
--- a/cijoe/tests/tools/qublk_session.py
+++ b/cijoe/tests/tools/qublk_session.py
@@ -1,0 +1,130 @@
+"""
+qublk session-helper
+====================
+
+qublk is a blocking daemon; it serves a ublk block-device until signalled. Exercising it
+therefore cannot be done by running a command and inspecting its status, the way the
+one-shot command-line tools are tested. Instead, each test-case runs a single shell
+session which launches qublk in the background, waits for the block-device to appear,
+runs a payload against it, and tears it down with SIGINT.
+
+* qublk_session(cijoe, uri, be, payload, ...): run 'payload' against a served device
+
+* qublk_teardown(cijoe, mountpoint): remove leftovers from a failed test-case
+
+Three things the session-script must get right, each of which has bitten before:
+
+* The lines are joined by newline, not by ';'. The background launch already ends in
+  '&', and a ';' following it is a shell syntax error.
+
+* The qublk log goes to a mktemp path. A fixed path in /tmp breaks the next run as soon
+  as one is left behind by another user.
+
+* The payload runs in a subshell with 'set -e', so the first failing line decides the
+  status. Without it a multi-line payload would report only its last line, and e.g. a
+  failed mkfs followed by a successful mount would pass. The subshell keeps 'set -e'
+  away from the teardown, which must run regardless.
+"""
+
+import pytest
+
+UBLK_NODE = "/dev/ublkb0"
+UBLK_CONTROL = "/dev/ublk-control"
+
+DEFAULT_TIMEOUT_TICKS = 50  # 0.2s each, so 10s for the block-device to appear
+
+
+def require_ublk(cijoe):
+    """
+    Skip unless ublk can actually be used
+
+    qublk needs root and the 'ublk_drv' module. Neither is available in the unprivileged
+    containers running the ramdisk test-suite, and those select on the 'ramdisk' keyword,
+    which matches the ramdisk-backend parametrization of these very test-cases. Without
+    this guard they would be collected there and fail for reasons having nothing to do
+    with qublk.
+    """
+
+    err, _ = cijoe.run("test $(id -u) -eq 0")
+    if err:
+        pytest.skip("qublk requires root")
+
+    cijoe.run("modprobe ublk_drv 2>/dev/null || true")
+
+    err, _ = cijoe.run(f"test -c {UBLK_CONTROL}")
+    if err:
+        pytest.skip(f"qublk requires the ublk_drv module ({UBLK_CONTROL} is absent)")
+
+
+def require_mkfs_xfs(cijoe):
+    """Skip unless mkfs.xfs is available; the fs-level cases format with XFS"""
+
+    err, _ = cijoe.run("command -v mkfs.xfs")
+    if err:
+        pytest.skip("the filesystem-level cases require mkfs.xfs (xfsprogs)")
+
+
+def qublk_script(uri, be, args, payload, node=UBLK_NODE, mountpoint=None):
+    """
+    Produce the shell session serving 'node' from the given device
+
+    'payload' is a list of shell lines run while the block-device is served; its exit status
+    becomes the exit status of the session. When 'mountpoint' is given it is unmounted during
+    teardown regardless of what the payload did.
+    """
+
+    umount = [
+        f"umount {mountpoint} 2>/dev/null || umount -l {mountpoint} 2>/dev/null || true"
+    ]
+
+    return "\n".join(
+        [
+            "set -u",
+            "id -un",
+            "modprobe ublk_drv || echo MODPROBE-FAILED",
+            # A leftover device from a crashed run would satisfy the readiness
+            # wait while the qublk under test got another id; refuse to start
+            f"if [ -b {node} ]; then echo PREEXISTING-DEVICE; exit 1; fi",
+            "log=$(mktemp)",
+            f"qublk run {uri} --be {be} --dev-id 0 {args} > $log 2>&1 &".replace(
+                "  >", " >"
+            ),
+            "pid=$!",
+            f"for i in $(seq 1 {DEFAULT_TIMEOUT_TICKS}); "
+            f"do [ -b {node} ] && break; sleep 0.2; done",
+            f"if [ ! -b {node} ]; then echo MISSING-DEVICE; cat $log; "
+            "kill -INT $pid 2>/dev/null; exit 1; fi",
+            "(",
+            "set -e",
+            *payload,
+            ")",
+            "rc=$?",
+            *(umount if mountpoint else []),
+            "kill -INT $pid 2>/dev/null",
+            "wait $pid",
+            f"if [ -b {node} ]; then echo LEFTOVER-DEVICE; rc=1; fi",
+            "cat $log",
+            "rm -f $log",
+            "exit $rc",
+        ]
+    )
+
+
+def qublk_session(cijoe, uri, be, payload, args="", node=UBLK_NODE, mountpoint=None):
+    """Run 'payload' against the ublk block-device served by qublk"""
+
+    script = qublk_script(uri, be, args, payload, node=node, mountpoint=mountpoint)
+
+    return cijoe.run(f"bash -c '{script}'")
+
+
+def qublk_teardown(cijoe, mountpoint=None, node=UBLK_NODE):
+    """Ensure a failed test-case does not leave a mount or a ublk device behind"""
+
+    if mountpoint:
+        cijoe.run(
+            f"umount {mountpoint} 2>/dev/null || umount -l {mountpoint} 2>/dev/null || true"
+        )
+
+    cijoe.run("pkill -INT qublk || true")
+    cijoe.run(f"for i in $(seq 1 25); do [ -b {node} ] || break; sleep 0.2; done")

--- a/cijoe/tests/tools/test_qublk.py
+++ b/cijoe/tests/tools/test_qublk.py
@@ -1,0 +1,62 @@
+"""
+qublk exposes an xNVMe device as a Linux ublk block-device.
+
+Unlike the other command-line tools, qublk is a blocking daemon; it requires root and
+the 'ublk_drv' module, and it runs until signalled. It therefore cannot be exercised by
+a single command returning a status; see qublk_session.py for how a test-case drives it.
+
+The cases here exercise the raw block-device; filesystem-level coverage is in
+test_qublk_fs.py.
+"""
+
+import pytest
+
+from ..conftest import xnvme_parametrize
+from .qublk_session import UBLK_NODE, qublk_session, qublk_teardown, require_ublk
+
+
+@pytest.fixture(autouse=True)
+def qublk_cleanup(cijoe):
+    """Skip when ublk is unusable; leave no daemon or ublk device behind"""
+
+    require_ublk(cijoe)
+
+    yield
+
+    qublk_teardown(cijoe)
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_run_dd(cijoe, device, be_opts, cli_args):
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [f"dd if={UBLK_NODE} of=/dev/null bs=1M count=32 iflag=direct"],
+        args="--qdepth 64",
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_run_multi_queue(cijoe, device, be_opts, cli_args):
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [f"dd if={UBLK_NODE} of=/dev/null bs=1M count=32 iflag=direct"],
+        args="--qdepth 64 --nqueues 4",
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_run_max_io_bytes(cijoe, device, be_opts, cli_args):
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [f"dd if={UBLK_NODE} of=/dev/null bs=128k count=64 iflag=direct"],
+        args="--qdepth 64 --max-io-bytes 131072",
+    )
+    assert not err

--- a/cijoe/tests/tools/test_qublk_fs.py
+++ b/cijoe/tests/tools/test_qublk_fs.py
@@ -1,0 +1,188 @@
+"""
+Filesystem-level coverage for qublk.
+
+qublk serves an xNVMe device as a Linux ublk block-device; these cases put an XFS
+filesystem on it and exercise what a block-device is actually used for: formatting,
+mounting, file operations, and remounting.
+
+'test_persistence_across_restart' is the case that matters most. Mounting and writing can
+succeed while the data never reaches the device; only stopping qublk, starting it again and
+comparing the content proves otherwise. It is also what drives qublk's FLUSH and FUA paths.
+"""
+
+import pytest
+
+from ..conftest import xnvme_parametrize
+from .qublk_session import (
+    UBLK_NODE,
+    qublk_session,
+    qublk_teardown,
+    require_mkfs_xfs,
+    require_ublk,
+)
+
+MNT = "/mnt/qublk-test"
+PAYLOAD_FILE = f"{MNT}/payload.bin"
+PAYLOAD_MIB = 8
+
+MKFS = f"mkfs.xfs -f -q {UBLK_NODE}"
+MOUNT = f"mount {UBLK_NODE} {MNT}"
+UMOUNT = f"umount {MNT}"
+
+# Write a reproducible payload and record its digest next to it.
+# No single-quotes in payload lines: the session is wrapped in bash -c '...'
+WRITE_PAYLOAD = [
+    f"dd if=/dev/urandom of={PAYLOAD_FILE} bs=1M count={PAYLOAD_MIB} status=none",
+    f'sha256sum {PAYLOAD_FILE} | cut -d" " -f1 > {MNT}/payload.sha256',
+    "sync",
+]
+
+# Compare against the recorded digest; size alone would not catch corrupted content
+VERIFY_PAYLOAD = [
+    f"test -f {PAYLOAD_FILE}",
+    f"test $(stat -c %s {PAYLOAD_FILE}) -eq $(({PAYLOAD_MIB} * 1024 * 1024))",
+    f'echo "$(cat {MNT}/payload.sha256)  {PAYLOAD_FILE}" | sha256sum -c -',
+]
+
+
+@pytest.fixture(autouse=True)
+def qublk_fs_cleanup(cijoe):
+    """Skip when ublk is unusable; leave no mount, daemon or ublk device behind"""
+
+    require_ublk(cijoe)
+    require_mkfs_xfs(cijoe)
+
+    cijoe.run(f"mkdir -p {MNT}")
+
+    yield
+
+    qublk_teardown(cijoe, mountpoint=MNT)
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_format_mount_umount(cijoe, device, be_opts, cli_args):
+    """Format the served device, mount it, confirm the mount, unmount it"""
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [
+            MKFS,
+            MOUNT,
+            f"findmnt --source {UBLK_NODE} --target {MNT}",
+            f"test $(stat -f -c %T {MNT}) = xfs",
+            UMOUNT,
+        ],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_existing_filesystem(cijoe, device, be_opts, cli_args):
+    """Mount a filesystem which is already there, without formatting again"""
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [MKFS, MOUNT, UMOUNT, MOUNT, f"test $(stat -f -c %T {MNT}) = xfs", UMOUNT],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_remount(cijoe, device, be_opts, cli_args):
+    """Mount, unmount and mount again within the same qublk session"""
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [
+            MKFS,
+            MOUNT,
+            f"touch {MNT}/before-remount",
+            UMOUNT,
+            MOUNT,
+            f"test -f {MNT}/before-remount",
+            UMOUNT,
+        ],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_file_write_read(cijoe, device, be_opts, cli_args):
+    """Write a file, read it back and compare the content"""
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [MKFS, MOUNT] + WRITE_PAYLOAD + VERIFY_PAYLOAD + [UMOUNT],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_file_delete(cijoe, device, be_opts, cli_args):
+    """Create files and directories, delete them, confirm they are gone"""
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [
+            MKFS,
+            MOUNT,
+            f"mkdir -p {MNT}/dir/sub",
+            f"echo content > {MNT}/dir/sub/file",
+            f"test -f {MNT}/dir/sub/file",
+            f"rm -r {MNT}/dir",
+            f"test ! -e {MNT}/dir",
+            UMOUNT,
+        ],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_persistence_across_restart(cijoe, device, be_opts, cli_args):
+    """Data written in one qublk session must be readable in the next"""
+
+    # The ramdisk backend keeps the device in the memory of the serving process, so its
+    # content is gone once qublk stops. That is a property of the backing store, not
+    # something qublk could preserve, so the case only applies to persistent devices.
+    if "ramdisk" in device["labels"]:
+        pytest.skip("ramdisk backing does not persist across a qublk restart")
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [MKFS, MOUNT] + WRITE_PAYLOAD + [UMOUNT],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err, "failed while writing the payload"
+
+    err, _ = qublk_session(
+        cijoe,
+        device["uri"],
+        be_opts["be"],
+        [MOUNT] + VERIFY_PAYLOAD + [UMOUNT],
+        args="--qdepth 64",
+        mountpoint=MNT,
+    )
+    assert not err, "payload did not survive the restart"

--- a/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
@@ -32,6 +32,6 @@ steps:
 - name: test_mproc
   uses: core.testrunner
   with:
-    # Excluded from multi-process mode: kvs and dual_be (has no --shm_id)
-    args: '-k "(upcie or spdk) and not (fabrics or kvs or dual_be)" tests --shm_id 1'
+    # Excluded from multi-process mode: kvs, dual_be and qublk (have no --shm_id)
+    args: '-k "(upcie or spdk) and not (fabrics or kvs or dual_be or qublk)" tests --shm_id 1'
     random_order: false

--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
@@ -51,6 +51,6 @@ steps:
 - name: test_mproc
   uses: core.testrunner
   with:
-    # Excluded from multi-process mode: kvs and dual_be (has no --shm_id)
-    args: '-k "pcie and not (upcie or fabrics or kvs or dual_be)" tests --shm_id 1'
+    # Excluded from multi-process mode: kvs, dual_be and qublk (have no --shm_id)
+    args: '-k "pcie and not (upcie or fabrics or kvs or dual_be or qublk)" tests --shm_id 1'
     random_order: false

--- a/docs/tools/index.rst
+++ b/docs/tools/index.rst
@@ -8,7 +8,8 @@ Navigate the menu on the left for descriptions and usage examples of the
 different command-line tools provided with **xNVMe**.
 
 In addition to the cli tools, performance tools are provided in the form of
-:ref:`sec-tools-fio` and :ref:`sec-tools-xnvmeperf`.
+:ref:`sec-tools-fio` and :ref:`sec-tools-xnvmeperf`, and :ref:`sec-tools-qublk`
+exposes an **xNVMe** device as an ordinary Linux block device.
 
 .. toctree::
    :hidden:
@@ -21,3 +22,4 @@ In addition to the cli tools, performance tools are provided in the form of
    homi/index
    fio/index
    xnvmeperf/index
+   qublk/index

--- a/docs/tools/qublk/index.rst
+++ b/docs/tools/qublk/index.rst
@@ -1,0 +1,54 @@
+.. _sec-tools-qublk:
+
+qublk
+#####
+
+**qublk** is a ublk server backed by **xNVMe**. It creates a ``/dev/ublkbN``
+block device, receives ``READ`` / ``WRITE`` / ``FLUSH`` requests from the Linux
+``ublk_drv`` over ``io_uring``, and services them through the **xNVMe**
+asynchronous command interface. Thus, any **xNVMe** backend, such as
+:ref:`sec-backends-upcie` or **io_uring**, becomes usable as an ordinary block
+device.
+
+``REQ_FUA`` and ``REQ_PREFLUSH`` are supported, as are multiple ublk hardware
+queues via ``--nqueues``.
+
+.. literalinclude:: qublk_usage.out
+   :language: bash
+
+Requirements
+============
+
+**qublk** is Linux-only and is built only when ``liburing`` and
+``<linux/ublk_cmd.h>`` are available. At runtime it requires:
+
+* ``root`` privileges
+
+* the ublk driver, loaded with ``modprobe ublk_drv``
+
+* for user space backends such as **uPCIe**, a device bound to
+  ``uio_pci_generic`` and hugepages configured; see :ref:`sec-backends-upcie`
+
+``run`` — Serve a block-device
+==============================
+
+Opens the given device URI, adds a ublk device, and serves it until
+``SIGINT`` / ``SIGTERM``, upon which it performs a clean teardown
+(``STOP_DEV`` followed by ``DEL_DEV``).
+
+When ``--dev-id`` is not given, the kernel assigns the device identifier.
+When ``--max-io-bytes`` is not given, the per-IO buffer size defaults to the
+smaller of 1MiB and the controller ``MDTS``.
+
+.. literalinclude:: qublk_run_usage.out
+   :language: bash
+
+Example — NVMe block device via io_uring::
+
+   qublk run /dev/nvme0n1 --be io_uring --qdepth 64
+
+Example — user space NVMe via uPCIe, with multiple hardware queues::
+
+   qublk run 0000:01:00.0 --be upcie --qdepth 64 --nqueues 4
+
+While **qublk** is running, ``/dev/ublkb0`` is the resulting block device.

--- a/docs/tools/qublk/qublk_run_usage.cmd
+++ b/docs/tools/qublk/qublk_run_usage.cmd
@@ -1,0 +1,1 @@
+qublk run --help

--- a/docs/tools/qublk/qublk_run_usage.out
+++ b/docs/tools/qublk/qublk_run_usage.out
@@ -1,0 +1,23 @@
+Usage: qublk run <uri> [<args>]
+
+Serve a ublk block-device backed by the given xNVMe device
+  
+Positional arguments:
+
+  uri                           ; Device URI e.g. '/dev/nvme0n1', '0000:01:00.1', '10.9.8.1:8888', '\\.\PhysicalDrive1'
+  
+Where <args> include:
+
+  [ --qdepth NUM ]              ; Use given 'NUM' as queue max capacity
+  [ --nqueues NUM ]             ; Number of queues per device
+  [ --dev-id NUM ]              ; Use given 'NUM' as device identifier
+  [ --max-io-bytes NUM ]        ; Use given 'NUM' as per-IO buffer size in bytes
+  
+With <args> for backend:
+
+  [ --be STRING ]               ; xNVMe backend, e.g. 'spdk', 'libvfn', 'upcie'
+  [ --help ]                    ; Show usage / help
+
+See 'qublk --help' for other commands
+
+qublk - ublk server backed by xNVMe -- ver: {major: 0, minor: 7, patch: 5}

--- a/docs/tools/qublk/qublk_usage.cmd
+++ b/docs/tools/qublk/qublk_usage.cmd
@@ -1,0 +1,1 @@
+qublk --help

--- a/docs/tools/qublk/qublk_usage.out
+++ b/docs/tools/qublk/qublk_usage.out
@@ -1,0 +1,9 @@
+Usage: qublk <command> [<args>]
+
+Where <command> is one of:
+
+  run              | Serve a ublk block-device backed by the given xNVMe device
+
+See 'qublk <command> --help' for the description of [<args>]
+
+qublk - ublk server backed by xNVMe -- ver: {major: 0, minor: 7, patch: 5}

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -96,6 +96,8 @@ struct xnvme_cli_args {
 	uint32_t seed;
 	uint32_t iosize;
 	uint32_t qdepth;
+	uint32_t dev_id;
+	uint32_t max_io_bytes;
 	bool direct;
 	uint32_t limit;
 
@@ -373,7 +375,11 @@ enum xnvme_cli_opt {
 	XNVME_CLI_OPT_HOST_HEAP_SIZE   = 133, ///< XNVME_CLI_OPT_HOST_HEAP_SIZE
 	XNVME_CLI_OPT_DEVICE_HEAP_SIZE = 134, ///< XNVME_CLI_OPT_DEVICE_HEAP_SIZE
 
-	XNVME_CLI_OPT_END = 135, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_DEV_ID = 135, ///< XNVME_CLI_OPT_DEV_ID
+
+	XNVME_CLI_OPT_MAX_IO_BYTES = 136, ///< XNVME_CLI_OPT_MAX_IO_BYTES
+
+	XNVME_CLI_OPT_END = 137, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -919,6 +919,18 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "Number of queues per device",
 	},
 	{
+		.opt = XNVME_CLI_OPT_DEV_ID,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "dev-id",
+		.descr = "Use given 'NUM' as device identifier",
+	},
+	{
+		.opt = XNVME_CLI_OPT_MAX_IO_BYTES,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "max-io-bytes",
+		.descr = "Use given 'NUM' as per-IO buffer size in bytes",
+	},
+	{
 		.opt = XNVME_CLI_OPT_ALT_BE,
 		.vtype = XNVME_CLI_OPT_VTYPE_STR,
 		.name = "alt-be",
@@ -1564,6 +1576,12 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 		break;
 	case XNVME_CLI_OPT_QDEPTH:
 		args->qdepth = num;
+		break;
+	case XNVME_CLI_OPT_DEV_ID:
+		args->dev_id = num;
+		break;
+	case XNVME_CLI_OPT_MAX_IO_BYTES:
+		args->max_io_bytes = num;
 		break;
 	case XNVME_CLI_OPT_DIRECT:
 		args->direct = true;

--- a/tests/cli.c
+++ b/tests/cli.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <errno.h>
+#include <inttypes.h>
 #include <libxnvme.h>
 
 static int
@@ -37,6 +38,53 @@ sub_cpuids(struct xnvme_cli *cli)
 	return err;
 }
 
+/**
+ * Expected values for the 'numeric' sub-command; these must match the arguments given by the
+ * test-cases registered in 'tests/meson.build'
+ */
+#define EXPECTED_NQUEUES 4
+#define EXPECTED_DEV_ID 7
+#define EXPECTED_MAX_IO_BYTES 131072
+
+static int
+check_num(const char *name, int given, uint64_t val, uint64_t expected)
+{
+	if (!given) {
+		if (val) {
+			xnvme_cli_pinf("FAILED: %s not given, yet val: %" PRIu64, name, val);
+			return -EINVAL;
+		}
+		return 0;
+	}
+
+	if (val != expected) {
+		xnvme_cli_pinf("FAILED: %s val: %" PRIu64 ", expected: %" PRIu64, name, val,
+			       expected);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * Verify that numeric options make it all the way into 'xnvme_cli_args'; an option missing its
+ * assignment in the option-to-args switch parses fine but silently drops the value
+ */
+static int
+sub_numeric(struct xnvme_cli *cli)
+{
+	int err = 0;
+
+	err |= check_num("nqueues", cli->given[XNVME_CLI_OPT_NQUEUES], cli->args.nqueues,
+			 EXPECTED_NQUEUES);
+	err |= check_num("dev-id", cli->given[XNVME_CLI_OPT_DEV_ID], cli->args.dev_id,
+			 EXPECTED_DEV_ID);
+	err |= check_num("max-io-bytes", cli->given[XNVME_CLI_OPT_MAX_IO_BYTES],
+			 cli->args.max_io_bytes, EXPECTED_MAX_IO_BYTES);
+
+	return err;
+}
+
 static struct xnvme_cli_sub g_subs[] = {
 	{
 		"optional",
@@ -55,6 +103,17 @@ static struct xnvme_cli_sub g_subs[] = {
 		{
 			{XNVME_CLI_OPT_CPUMASK, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_CPULIST, XNVME_CLI_LOPT},
+		},
+	},
+	{
+		"numeric",
+		"Numeric command-line arguments",
+		"Numeric command-line arguments",
+		sub_numeric,
+		{
+			{XNVME_CLI_OPT_NQUEUES, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_DEV_ID, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_MAX_IO_BYTES, XNVME_CLI_LOPT},
 		},
 	},
 };

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,6 +19,8 @@ tests = {
   ],
   'cli.c': [
     ['optional', ['optional']],
+    ['numeric', ['numeric', '--nqueues', '4', '--dev-id', '7', '--max-io-bytes', '131072']],
+    ['numeric, not given', ['numeric']],
   ],
   'compare.c': [
     ['no args', ['compare', '1GB']],

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -62,3 +62,4 @@ foreach source, tests : tools
 endforeach
 
 subdir('xnvmeperf')
+subdir('qublk')

--- a/tools/qublk/ctrl.c
+++ b/tools/qublk/ctrl.c
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define _GNU_SOURCE
+#include "ctrl.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <liburing.h>
+
+#define CTRL_DEV "/dev/ublk-control"
+
+static int
+ctrl_uring_cmd(int ctrl_fd, uint32_t cmd_op, const struct ublksrv_ctrl_cmd *cmd)
+{
+	struct io_uring ring;
+	struct io_uring_params p = {
+		.flags = IORING_SETUP_SQE128 | IORING_SETUP_CQE32,
+	};
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	int rc, res;
+
+	rc = io_uring_queue_init_params(2, &ring, &p);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_queue_init_params(ctrl): %s\n", strerror(-rc));
+		return rc;
+	}
+
+	sqe = io_uring_get_sqe(&ring);
+	if (!sqe) {
+		io_uring_queue_exit(&ring);
+		return -ENOMEM;
+	}
+
+	io_uring_prep_rw(IORING_OP_URING_CMD, sqe, ctrl_fd, NULL, 0, 0);
+	sqe->cmd_op = cmd_op;
+	memset(sqe->cmd, 0, 80);
+	memcpy(sqe->cmd, cmd, sizeof(*cmd));
+
+	rc = io_uring_submit_and_wait(&ring, 1);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_submit_and_wait(ctrl 0x%x): %s\n", cmd_op,
+			strerror(-rc));
+		io_uring_queue_exit(&ring);
+		return rc;
+	}
+
+	rc = io_uring_peek_cqe(&ring, &cqe);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_peek_cqe(ctrl 0x%x): %s\n", cmd_op, strerror(-rc));
+		io_uring_queue_exit(&ring);
+		return rc;
+	}
+
+	res = cqe->res;
+	io_uring_cqe_seen(&ring, cqe);
+	io_uring_queue_exit(&ring);
+
+	if (res < 0) {
+		fprintf(stderr, "ublk ctrl cmd 0x%x failed: %s\n", cmd_op, strerror(-res));
+		return res;
+	}
+	return 0;
+}
+
+int
+qublk_ctrl_open(struct qublk_dev *dev)
+{
+	dev->ctrl_fd = open(CTRL_DEV, O_RDWR | O_CLOEXEC);
+	if (dev->ctrl_fd < 0) {
+		fprintf(stderr, "open(%s): %s\n", CTRL_DEV, strerror(errno));
+		return -errno;
+	}
+	return 0;
+}
+
+void
+qublk_ctrl_close(struct qublk_dev *dev)
+{
+	if (dev->ctrl_fd >= 0) {
+		close(dev->ctrl_fd);
+		dev->ctrl_fd = -1;
+	}
+}
+
+int
+qublk_ctrl_get_features(struct qublk_dev *dev, uint64_t *features)
+{
+	uint64_t buf[UBLK_FEATURES_LEN / sizeof(uint64_t)] = {0};
+	struct ublksrv_ctrl_cmd cmd = {
+		.dev_id = (uint32_t)-1,
+		.queue_id = (uint16_t)-1,
+		.addr = (uint64_t)(uintptr_t)buf,
+		.len = sizeof(buf),
+	};
+	int rc;
+
+	rc = ctrl_uring_cmd(dev->ctrl_fd, UBLK_U_CMD_GET_FEATURES, &cmd);
+	if (rc < 0) {
+		return rc;
+	}
+	*features = buf[0];
+	return 0;
+}
+
+int
+qublk_ctrl_add_dev(struct qublk_dev *dev)
+{
+	struct ublksrv_ctrl_dev_info info = {
+		.nr_hw_queues = dev->nr_queues,
+		.queue_depth = dev->depth,
+		.max_io_buf_bytes = dev->max_io_buf,
+		.dev_id = (uint32_t)dev->dev_id,
+		.flags = dev->flags,
+	};
+	struct ublksrv_ctrl_cmd cmd = {
+		.dev_id = (uint32_t)dev->dev_id,
+		.queue_id = (uint16_t)-1,
+		.addr = (uint64_t)(uintptr_t)&info,
+		.len = sizeof(info),
+	};
+	int rc;
+
+	rc = ctrl_uring_cmd(dev->ctrl_fd, UBLK_U_CMD_ADD_DEV, &cmd);
+	if (rc < 0) {
+		return rc;
+	}
+	dev->dev_id = (int)info.dev_id;
+	return 0;
+}
+
+int
+qublk_ctrl_set_params(struct qublk_dev *dev)
+{
+	const struct xnvme_geo *geo = dev->geo;
+	uint8_t lba_shift = dev->lba_shift;
+	uint64_t dev_sectors_512 = geo->tbytes >> 9;
+	struct ublk_params params = {
+		.len = sizeof(params),
+		.types = UBLK_PARAM_TYPE_BASIC,
+		.basic =
+			{
+				.attrs = dev->has_vwc ? (UBLK_ATTR_VOLATILE_CACHE | UBLK_ATTR_FUA)
+						      : 0,
+				.logical_bs_shift = lba_shift,
+				.physical_bs_shift = lba_shift,
+				.io_opt_shift = lba_shift,
+				.io_min_shift = lba_shift,
+				.max_sectors = dev->max_io_buf >> 9,
+				.dev_sectors = dev_sectors_512,
+			},
+	};
+	struct ublksrv_ctrl_cmd cmd = {
+		.dev_id = (uint32_t)dev->dev_id,
+		.queue_id = (uint16_t)-1,
+		.addr = (uint64_t)(uintptr_t)&params,
+		.len = sizeof(params),
+	};
+
+	return ctrl_uring_cmd(dev->ctrl_fd, UBLK_U_CMD_SET_PARAMS, &cmd);
+}
+
+int
+qublk_ctrl_start_dev(struct qublk_dev *dev)
+{
+	struct ublksrv_ctrl_cmd cmd = {
+		.dev_id = (uint32_t)dev->dev_id,
+		.queue_id = (uint16_t)-1,
+		.data[0] = (uint64_t)getpid(),
+	};
+	return ctrl_uring_cmd(dev->ctrl_fd, UBLK_U_CMD_START_DEV, &cmd);
+}
+
+int
+qublk_ctrl_stop_dev(struct qublk_dev *dev)
+{
+	struct ublksrv_ctrl_cmd cmd = {
+		.dev_id = (uint32_t)dev->dev_id,
+		.queue_id = (uint16_t)-1,
+	};
+	return ctrl_uring_cmd(dev->ctrl_fd, UBLK_U_CMD_STOP_DEV, &cmd);
+}
+
+int
+qublk_ctrl_del_dev(struct qublk_dev *dev)
+{
+	struct ublksrv_ctrl_cmd cmd = {
+		.dev_id = (uint32_t)dev->dev_id,
+		.queue_id = (uint16_t)-1,
+	};
+	return ctrl_uring_cmd(dev->ctrl_fd, UBLK_U_CMD_DEL_DEV, &cmd);
+}

--- a/tools/qublk/ctrl.c
+++ b/tools/qublk/ctrl.c
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include "ctrl.h"
 
 #include <errno.h>

--- a/tools/qublk/ctrl.c
+++ b/tools/qublk/ctrl.c
@@ -113,8 +113,8 @@ int
 qublk_ctrl_add_dev(struct qublk_dev *dev)
 {
 	struct ublksrv_ctrl_dev_info info = {
-		.nr_hw_queues = dev->nr_queues,
-		.queue_depth = dev->depth,
+		.nr_hw_queues = dev->nqueues,
+		.queue_depth = dev->qdepth,
 		.max_io_buf_bytes = dev->max_io_buf,
 		.dev_id = (uint32_t)dev->dev_id,
 		.flags = dev->flags,

--- a/tools/qublk/ctrl.h
+++ b/tools/qublk/ctrl.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef QUBLK_CTRL_H
+#define QUBLK_CTRL_H
+
+#include "qublk.h"
+
+int
+qublk_ctrl_open(struct qublk_dev *dev);
+void
+qublk_ctrl_close(struct qublk_dev *dev);
+
+int
+qublk_ctrl_get_features(struct qublk_dev *dev, uint64_t *features);
+int
+qublk_ctrl_add_dev(struct qublk_dev *dev);
+int
+qublk_ctrl_set_params(struct qublk_dev *dev);
+int
+qublk_ctrl_start_dev(struct qublk_dev *dev);
+int
+qublk_ctrl_stop_dev(struct qublk_dev *dev);
+int
+qublk_ctrl_del_dev(struct qublk_dev *dev);
+
+#endif

--- a/tools/qublk/io.c
+++ b/tools/qublk/io.c
@@ -1,0 +1,880 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define _GNU_SOURCE
+#include "io.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <liburing.h>
+#include <libxnvme.h>
+
+#ifndef IORING_SETUP_SINGLE_ISSUER
+#define IORING_SETUP_SINGLE_ISSUER (1U << 12)
+#endif
+#ifndef IORING_SETUP_DEFER_TASKRUN
+#define IORING_SETUP_DEFER_TASKRUN (1U << 13)
+#endif
+
+/*
+ * io_uring CQE user_data convention:
+ *   bit 63 clear -> ublk tag CQE; user_data is the tag (< depth)
+ *   bit 63 set   -> cross-queue MSG_RING; encoded as:
+ *                   bits 62-60: type (QUBLK_MSG_*)
+ *                   bits 31-16: originating q_id
+ *                   bits 15-0 : originating tag
+ * The MSG_RING payload uses sqe->off (delivered as target cqe->user_data) for
+ * the encoded id and sqe->len (delivered as target cqe->res) for status.
+ */
+#define QUBLK_UD_MSG_BIT (1ULL << 63)
+#define QUBLK_MSG_TYPE_SHIFT 60
+#define QUBLK_MSG_TYPE_MASK 0x7ULL
+#define QUBLK_MSG_QID_SHIFT 16
+#define QUBLK_MSG_QID_MASK 0xFFFFULL
+#define QUBLK_MSG_TAG_MASK 0xFFFFULL
+
+enum {
+	QUBLK_MSG_SOURCE = 0,     /* source-side CQE for our outgoing MSG_RING */
+	QUBLK_MSG_DO_FLUSH = 1,   /* recipient: issue NVMe FLUSH for (orig_q, orig_tag) */
+	QUBLK_MSG_FLUSH_DONE = 2, /* originator: a remote FLUSH completed (res = status) */
+};
+
+static inline uint64_t
+ud_msg(unsigned type, uint16_t qid, uint16_t tag)
+{
+	return QUBLK_UD_MSG_BIT | ((uint64_t)type << QUBLK_MSG_TYPE_SHIFT) |
+	       ((uint64_t)qid << QUBLK_MSG_QID_SHIFT) | (uint64_t)tag;
+}
+
+static size_t
+page_round_up(size_t v)
+{
+	size_t pg = (size_t)sysconf(_SC_PAGESIZE);
+	return (v + pg - 1) & ~(pg - 1);
+}
+
+/*
+ * ublk_drv maps each queue's iod array at a fixed stride of
+ * round_up(UBLK_MAX_QUEUE_DEPTH * sizeof(ublksrv_io_desc), PAGE_SIZE) from
+ * UBLKSRV_CMD_BUF_OFFSET. The stride is the kernel max, not our queue depth.
+ */
+static size_t
+iod_stride(void)
+{
+	return page_round_up((size_t)UBLK_MAX_QUEUE_DEPTH * sizeof(struct ublksrv_io_desc));
+}
+
+/*
+ * Per iteration of io_loop we may queue, between submits: one
+ * COMMIT_AND_FETCH per local tag, (nr_queues-1) outgoing MSG_RINGs per local
+ * barrier op, and (nr_queues-1) FLUSH_DONE replies per remote-served flush.
+ * Worst case is depth * (2 * nr_queues - 1) SQEs.
+ */
+static unsigned
+ring_entries_for(const struct qublk_queue *q)
+{
+	unsigned nq = q->dev->nr_queues;
+	unsigned entries = (unsigned)q->depth * (2 * nq - 1);
+
+	if (entries < (unsigned)q->depth) {
+		entries = q->depth;
+	}
+	return entries;
+}
+
+static int
+init_ring(struct qublk_queue *q)
+{
+	struct io_uring_params p = {0};
+	unsigned entries = ring_entries_for(q);
+	int rc;
+
+	p.flags = IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN;
+	rc = io_uring_queue_init_params(entries, &q->ring, &p);
+	if (rc == -EINVAL) {
+		memset(&p, 0, sizeof(p));
+		rc = io_uring_queue_init_params(entries, &q->ring, &p);
+	}
+	return rc;
+}
+
+static int
+rflush_pool_init(struct qublk_dev *dev, struct qublk_queue *q)
+{
+	uint32_t n;
+
+	if (dev->nr_queues <= 1) {
+		return 0;
+	}
+	n = (uint32_t)(dev->nr_queues - 1) * q->depth;
+	q->rflush_pool = calloc(n, sizeof(*q->rflush_pool));
+	if (!q->rflush_pool) {
+		return -ENOMEM;
+	}
+	q->rflush_nr = n;
+	for (uint32_t i = 0; i < n; i++) {
+		q->rflush_pool[i].remote_q = q;
+		q->rflush_pool[i].next = q->rflush_free;
+		q->rflush_free = &q->rflush_pool[i];
+	}
+	return 0;
+}
+
+static void
+rflush_pool_fini(struct qublk_queue *q)
+{
+	free(q->rflush_pool);
+	q->rflush_pool = NULL;
+	q->rflush_free = NULL;
+	q->rflush_nr = 0;
+}
+
+static struct qublk_remote_flush *
+rflush_alloc(struct qublk_queue *q)
+{
+	struct qublk_remote_flush *rf = q->rflush_free;
+
+	if (rf) {
+		q->rflush_free = rf->next;
+		rf->next = NULL;
+	}
+	return rf;
+}
+
+static void
+rflush_release(struct qublk_queue *q, struct qublk_remote_flush *rf)
+{
+	rf->next = q->rflush_free;
+	q->rflush_free = rf;
+}
+
+static void
+prep_io_uring_cmd(struct io_uring_sqe *sqe, uint32_t cmd_op, const struct ublksrv_io_cmd *cmd,
+		  uint64_t user_data)
+{
+	io_uring_prep_rw(IORING_OP_URING_CMD, sqe, 0, NULL, 0, 0);
+	sqe->flags = IOSQE_FIXED_FILE;
+	sqe->cmd_op = cmd_op;
+	memcpy(sqe->cmd, cmd, sizeof(*cmd));
+	sqe->user_data = user_data;
+}
+
+static int
+submit_fetch(struct qublk_queue *q, struct qublk_io *io)
+{
+	struct io_uring_sqe *sqe;
+	struct ublksrv_io_cmd cmd = {
+		.q_id = q->q_id,
+		.tag = io->tag,
+		.result = -1,
+		.addr = (uint64_t)(uintptr_t)io->buf,
+	};
+
+	sqe = io_uring_get_sqe(&q->ring);
+	if (!sqe) {
+		return -EAGAIN;
+	}
+	prep_io_uring_cmd(sqe, UBLK_U_IO_FETCH_REQ, &cmd, io->tag);
+	return 0;
+}
+
+static int
+submit_commit_and_fetch(struct qublk_queue *q, struct qublk_io *io, int result)
+{
+	struct io_uring_sqe *sqe;
+	struct ublksrv_io_cmd cmd = {
+		.q_id = q->q_id,
+		.tag = io->tag,
+		.result = result,
+		.addr = (uint64_t)(uintptr_t)io->buf,
+	};
+
+	sqe = io_uring_get_sqe(&q->ring);
+	if (!sqe) {
+		return -EAGAIN;
+	}
+	prep_io_uring_cmd(sqe, UBLK_U_IO_COMMIT_AND_FETCH_REQ, &cmd, io->tag);
+	return 0;
+}
+
+static void
+on_xnvme_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
+{
+	struct qublk_io *io = opaque;
+	struct qublk_queue *q = io->q;
+	uint8_t op;
+	int result;
+
+	if (xnvme_cmd_ctx_cpl_status(ctx)) {
+		result = -EIO;
+	} else {
+		op = ublksrv_get_op(io->iod);
+		if (op == UBLK_IO_OP_READ || op == UBLK_IO_OP_WRITE) {
+			result = (int)(io->iod->nr_sectors << 9);
+		} else {
+			result = 0;
+		}
+	}
+
+	xnvme_queue_put_cmd_ctx(q->xq, ctx);
+	submit_commit_and_fetch(q, io, result);
+}
+
+static void
+barrier_complete_iod(struct qublk_queue *q, struct qublk_io *io)
+{
+	int result;
+
+	if (io->barrier_err) {
+		result = io->barrier_err;
+	} else if (ublksrv_get_op(io->iod) == UBLK_IO_OP_WRITE) {
+		result = (int)(io->iod->nr_sectors << 9);
+	} else {
+		result = 0;
+	}
+	submit_commit_and_fetch(q, io, result);
+}
+
+static void
+on_local_barrier_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
+{
+	struct qublk_io *io = opaque;
+	struct qublk_queue *q = io->q;
+	int status = xnvme_cmd_ctx_cpl_status(ctx) ? -EIO : 0;
+
+	xnvme_queue_put_cmd_ctx(q->xq, ctx);
+	if (status && io->barrier_err == 0) {
+		io->barrier_err = status;
+	}
+	if (--io->barrier_outstanding == 0) {
+		barrier_complete_iod(q, io);
+	}
+}
+
+static void
+msg_post_flush_done(struct qublk_queue *q, uint16_t orig_qid, uint16_t orig_tag, int status)
+{
+	struct qublk_queue *orig = &q->dev->queues[orig_qid];
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(&q->ring);
+	if (!sqe) {
+		fprintf(stderr, "qublk: q%d no SQE for FLUSH_DONE reply\n", q->q_id);
+		q->dev->stop = 1;
+		return;
+	}
+	io_uring_prep_msg_ring(sqe, orig->ring.ring_fd, status,
+			       ud_msg(QUBLK_MSG_FLUSH_DONE, 0, orig_tag), 0);
+	sqe->user_data = ud_msg(QUBLK_MSG_SOURCE, 0, 0);
+}
+
+static void
+on_remote_flush_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
+{
+	struct qublk_remote_flush *rf = opaque;
+	struct qublk_queue *q = rf->remote_q;
+	uint16_t orig_qid = rf->orig_q_id;
+	uint16_t orig_tag = rf->orig_tag;
+	int status = xnvme_cmd_ctx_cpl_status(ctx) ? -EIO : 0;
+
+	xnvme_queue_put_cmd_ctx(q->xq, ctx);
+	rflush_release(q, rf);
+	msg_post_flush_done(q, orig_qid, orig_tag, status);
+}
+
+static void
+handle_msg_do_flush(struct qublk_queue *q, uint16_t orig_qid, uint16_t orig_tag)
+{
+	struct qublk_dev *dev = q->dev;
+	uint32_t nsid = xnvme_dev_get_nsid(dev->xdev);
+	struct qublk_remote_flush *rf;
+	struct xnvme_cmd_ctx *ctx;
+	int rc;
+
+	rf = rflush_alloc(q);
+	if (!rf) {
+		fprintf(stderr, "qublk: q%d remote-flush pool exhausted\n", q->q_id);
+		msg_post_flush_done(q, orig_qid, orig_tag, -ENOMEM);
+		return;
+	}
+	rf->orig_q_id = orig_qid;
+	rf->orig_tag = orig_tag;
+
+	for (;;) {
+		ctx = xnvme_queue_get_cmd_ctx(q->xq);
+		if (ctx) {
+			break;
+		}
+		xnvme_queue_poke(q->xq, 0);
+	}
+	memset(&ctx->cmd, 0, sizeof(ctx->cmd));
+	xnvme_cmd_ctx_set_cb(ctx, on_remote_flush_complete, rf);
+	xnvme_prep_nvm(ctx, XNVME_SPEC_NVM_OPC_FLUSH, nsid, 0, 0);
+	rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
+	while (rc == -EBUSY || rc == -EAGAIN) {
+		xnvme_queue_poke(q->xq, 0);
+		rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
+	}
+	if (rc < 0) {
+		xnvme_queue_put_cmd_ctx(q->xq, ctx);
+		rflush_release(q, rf);
+		msg_post_flush_done(q, orig_qid, orig_tag, rc);
+	}
+}
+
+static void
+handle_msg_flush_done(struct qublk_queue *q, uint16_t orig_tag, int status)
+{
+	struct qublk_io *io;
+
+	if (orig_tag >= q->depth) {
+		fprintf(stderr, "qublk: q%d FLUSH_DONE: bogus tag %u\n", q->q_id, orig_tag);
+		return;
+	}
+	io = &q->ios[orig_tag];
+	if (status && io->barrier_err == 0) {
+		io->barrier_err = status;
+	}
+	if (--io->barrier_outstanding == 0) {
+		barrier_complete_iod(q, io);
+	}
+}
+
+static int
+dispatch_barrier(struct qublk_queue *q, struct qublk_io *io, uint8_t op)
+{
+	struct qublk_dev *dev = q->dev;
+	const struct ublksrv_io_desc *iod = io->iod;
+	uint32_t nsid = xnvme_dev_get_nsid(dev->xdev);
+	uint8_t lba_shift = dev->lba_shift;
+	struct xnvme_cmd_ctx *ctx;
+	int rc;
+
+	ctx = xnvme_queue_get_cmd_ctx(q->xq);
+	if (!ctx) {
+		return -EBUSY;
+	}
+	memset(&ctx->cmd, 0, sizeof(ctx->cmd));
+	xnvme_cmd_ctx_set_cb(ctx, on_local_barrier_complete, io);
+
+	if (op == UBLK_IO_OP_FLUSH) {
+		xnvme_prep_nvm(ctx, XNVME_SPEC_NVM_OPC_FLUSH, nsid, 0, 0);
+		rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
+	} else {
+		uint64_t slba = iod->start_sector >> (lba_shift - 9);
+		uint16_t nlb = (uint16_t)(((iod->nr_sectors << 9) >> lba_shift) - 1);
+		ctx->cmd.nvm.fua = 1;
+		rc = xnvme_nvm_write(ctx, nsid, slba, nlb, io->buf, NULL);
+	}
+	if (rc == -EBUSY || rc == -EAGAIN) {
+		xnvme_queue_put_cmd_ctx(q->xq, ctx);
+		return rc;
+	}
+	if (rc < 0) {
+		xnvme_queue_put_cmd_ctx(q->xq, ctx);
+		return submit_commit_and_fetch(q, io, rc);
+	}
+
+	io->barrier_outstanding = 1;
+	io->barrier_err = 0;
+
+	for (uint16_t r = 0; r < dev->nr_queues; r++) {
+		struct qublk_queue *rq;
+		struct io_uring_sqe *sqe;
+
+		if (r == q->q_id) {
+			continue;
+		}
+		rq = &dev->queues[r];
+		sqe = io_uring_get_sqe(&q->ring);
+		if (!sqe) {
+			fprintf(stderr, "qublk: q%d no SQE for MSG_RING fan-out\n", q->q_id);
+			dev->stop = 1;
+			return -ENOSPC;
+		}
+		io_uring_prep_msg_ring(sqe, rq->ring.ring_fd, 0,
+				       ud_msg(QUBLK_MSG_DO_FLUSH, q->q_id, io->tag), 0);
+		sqe->user_data = ud_msg(QUBLK_MSG_SOURCE, 0, 0);
+		io->barrier_outstanding++;
+	}
+	return 0;
+}
+
+static int
+dispatch(struct qublk_queue *q, struct qublk_io *io)
+{
+	struct qublk_dev *dev = q->dev;
+	const struct ublksrv_io_desc *iod = io->iod;
+	struct xnvme_cmd_ctx *ctx;
+	uint64_t bytes, slba;
+	uint32_t nsid = xnvme_dev_get_nsid(dev->xdev);
+	uint16_t nlb;
+	uint8_t op = ublksrv_get_op(iod);
+	uint8_t lba_shift = dev->lba_shift;
+	int rc;
+
+	if (op != UBLK_IO_OP_FLUSH) {
+		bytes = (uint64_t)iod->nr_sectors << 9;
+		if (bytes > dev->max_io_buf) {
+			fprintf(stderr, "qublk: tag %u: I/O %lu B exceeds max_io_buf %u\n",
+				io->tag, (unsigned long)bytes, dev->max_io_buf);
+			return submit_commit_and_fetch(q, io, -EINVAL);
+		}
+		// A zero-length or sub-LBA-sized transfer would underflow the
+		// zero-based 'nlb' computed below
+		if (!bytes || (bytes & ((1u << lba_shift) - 1))) {
+			fprintf(stderr,
+				"qublk: tag %u: I/O %lu B is not a multiple of the LBA size\n",
+				io->tag, (unsigned long)bytes);
+			return submit_commit_and_fetch(q, io, -EINVAL);
+		}
+	}
+
+	if (op == UBLK_IO_OP_FLUSH ||
+	    (op == UBLK_IO_OP_WRITE && (iod->op_flags & UBLK_IO_F_FUA))) {
+		return dispatch_barrier(q, io, op);
+	}
+
+	ctx = xnvme_queue_get_cmd_ctx(q->xq);
+	if (!ctx) {
+		return -EBUSY;
+	}
+	/*
+	 * The ctx is pooled per xnvme queue and reused across commands.
+	 * xnvme_nvm_{read,write} only writes opcode/nsid/slba/nlb, so other
+	 * fields in cdw12 (fua, lr, prinfo, ...) carry over from the prior
+	 * command. Zero the NVMe command header before each submit.
+	 */
+	memset(&ctx->cmd, 0, sizeof(ctx->cmd));
+	xnvme_cmd_ctx_set_cb(ctx, on_xnvme_complete, io);
+
+	switch (op) {
+	case UBLK_IO_OP_READ:
+		slba = iod->start_sector >> (lba_shift - 9);
+		nlb = (uint16_t)(((iod->nr_sectors << 9) >> lba_shift) - 1);
+		rc = xnvme_nvm_read(ctx, nsid, slba, nlb, io->buf, NULL);
+		break;
+	case UBLK_IO_OP_WRITE:
+		slba = iod->start_sector >> (lba_shift - 9);
+		nlb = (uint16_t)(((iod->nr_sectors << 9) >> lba_shift) - 1);
+		rc = xnvme_nvm_write(ctx, nsid, slba, nlb, io->buf, NULL);
+		break;
+	default:
+		xnvme_queue_put_cmd_ctx(q->xq, ctx);
+		return submit_commit_and_fetch(q, io, -EOPNOTSUPP);
+	}
+
+	if (rc == -EBUSY || rc == -EAGAIN) {
+		xnvme_queue_put_cmd_ctx(q->xq, ctx);
+		return rc;
+	}
+	if (rc < 0) {
+		xnvme_queue_put_cmd_ctx(q->xq, ctx);
+		return submit_commit_and_fetch(q, io, rc);
+	}
+	return 0;
+}
+
+static int
+handle_ublk_cqe(struct qublk_queue *q, struct io_uring_cqe *cqe)
+{
+	struct qublk_io *io;
+	uint16_t tag = (uint16_t)cqe->user_data;
+	int rc;
+
+	if (tag >= q->depth) {
+		fprintf(stderr, "qublk: bogus tag %u in cqe\n", tag);
+		return -EINVAL;
+	}
+	io = &q->ios[tag];
+
+	if (cqe->res == UBLK_IO_RES_OK) {
+		rc = dispatch(q, io);
+		while (rc == -EBUSY || rc == -EAGAIN) {
+			xnvme_queue_poke(q->xq, 0);
+			rc = dispatch(q, io);
+		}
+		return rc;
+	}
+	if (cqe->res == UBLK_IO_RES_ABORT || cqe->res == -ENODEV) {
+		q->dev->stop = 1;
+		return 0;
+	}
+	fprintf(stderr, "qublk: tag %u unexpected fetch res %d\n", tag, cqe->res);
+	q->dev->stop = 1;
+	return 0;
+}
+
+static void
+handle_msg_cqe(struct qublk_queue *q, uint64_t ud, int res)
+{
+	unsigned type = (unsigned)((ud >> QUBLK_MSG_TYPE_SHIFT) & QUBLK_MSG_TYPE_MASK);
+	uint16_t qid = (uint16_t)((ud >> QUBLK_MSG_QID_SHIFT) & QUBLK_MSG_QID_MASK);
+	uint16_t tag = (uint16_t)(ud & QUBLK_MSG_TAG_MASK);
+
+	switch (type) {
+	case QUBLK_MSG_SOURCE:
+		if (res < 0) {
+			fprintf(stderr, "qublk: q%d MSG_RING source CQE err=%d\n", q->q_id, res);
+			q->dev->stop = 1;
+		}
+		break;
+	case QUBLK_MSG_DO_FLUSH:
+		handle_msg_do_flush(q, qid, tag);
+		break;
+	case QUBLK_MSG_FLUSH_DONE:
+		handle_msg_flush_done(q, tag, res);
+		break;
+	default:
+		fprintf(stderr, "qublk: q%d unknown msg type %u\n", q->q_id, type);
+		break;
+	}
+}
+
+static void
+handle_cqe(struct qublk_queue *q, struct io_uring_cqe *cqe)
+{
+	if (cqe->user_data & QUBLK_UD_MSG_BIT) {
+		handle_msg_cqe(q, cqe->user_data, cqe->res);
+	} else {
+		handle_ublk_cqe(q, cqe);
+	}
+}
+
+static int
+queue_init(struct qublk_dev *dev, struct qublk_queue *q, int q_id, int ublkc_fd)
+{
+	size_t stride = iod_stride();
+	off_t map_off;
+	int rc;
+
+	q->dev = dev;
+	q->q_id = q_id;
+	q->depth = dev->depth;
+	q->ublkc_fd = ublkc_fd;
+	q->ios = NULL;
+	q->iod_arr = NULL;
+	q->xq = NULL;
+	q->tid = 0;
+	q->init_rc = 0;
+
+	q->iod_arr_bytes = page_round_up((size_t)q->depth * sizeof(struct ublksrv_io_desc));
+	map_off = (off_t)UBLKSRV_CMD_BUF_OFFSET + (off_t)q_id * (off_t)stride;
+	q->iod_arr = mmap(NULL, q->iod_arr_bytes, PROT_READ, MAP_SHARED, ublkc_fd, map_off);
+	if (q->iod_arr == MAP_FAILED) {
+		fprintf(stderr, "mmap(iod q%d): %s\n", q_id, strerror(errno));
+		q->iod_arr = NULL;
+		return -errno;
+	}
+
+	q->ios = calloc(q->depth, sizeof(*q->ios));
+	if (!q->ios) {
+		return -ENOMEM;
+	}
+	for (uint16_t t = 0; t < q->depth; t++) {
+		q->ios[t].tag = t;
+		q->ios[t].q = q;
+		q->ios[t].iod = &q->iod_arr[t];
+		q->ios[t].buf = xnvme_buf_alloc(dev->xdev, dev->max_io_buf);
+		if (!q->ios[t].buf) {
+			fprintf(stderr, "xnvme_buf_alloc(%u): %s\n", dev->max_io_buf,
+				strerror(errno));
+			return -ENOMEM;
+		}
+	}
+
+	rc = xnvme_queue_init(dev->xdev, q->depth, 0, &q->xq);
+	if (rc < 0) {
+		fprintf(stderr, "xnvme_queue_init(q%d, %u): %s\n", q_id, q->depth, strerror(-rc));
+		return rc;
+	}
+
+	rc = rflush_pool_init(dev, q);
+	if (rc < 0) {
+		fprintf(stderr, "rflush_pool_init(q%d): %s\n", q_id, strerror(-rc));
+		return rc;
+	}
+
+	return 0;
+}
+
+static void
+queue_fini(struct qublk_dev *dev, struct qublk_queue *q)
+{
+	if (q->xq) {
+		xnvme_queue_drain(q->xq);
+		xnvme_queue_term(q->xq);
+		q->xq = NULL;
+	}
+	rflush_pool_fini(q);
+	if (q->ios) {
+		for (uint16_t t = 0; t < q->depth; t++) {
+			if (q->ios[t].buf) {
+				xnvme_buf_free(dev->xdev, q->ios[t].buf);
+			}
+		}
+		free(q->ios);
+		q->ios = NULL;
+	}
+	if (q->iod_arr) {
+		munmap(q->iod_arr, q->iod_arr_bytes);
+		q->iod_arr = NULL;
+	}
+}
+
+int
+qublk_io_init(struct qublk_dev *dev)
+{
+	char path[64];
+	int ublkc_fd, rc;
+
+	dev->queues = calloc(dev->nr_queues, sizeof(*dev->queues));
+	if (!dev->queues) {
+		return -ENOMEM;
+	}
+
+	snprintf(path, sizeof(path), "/dev/ublkc%d", dev->dev_id);
+	ublkc_fd = open(path, O_RDWR | O_CLOEXEC);
+	if (ublkc_fd < 0) {
+		fprintf(stderr, "open(%s): %s\n", path, strerror(errno));
+		rc = -errno;
+		goto err;
+	}
+
+	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+		dev->queues[i].ublkc_fd = -1;
+	}
+	dev->queues[0].ublkc_fd = ublkc_fd;
+
+	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+		rc = queue_init(dev, &dev->queues[i], i, ublkc_fd);
+		if (rc < 0) {
+			goto err;
+		}
+	}
+
+	return 0;
+
+err:
+	qublk_io_fini(dev);
+	return rc;
+}
+
+void
+qublk_io_fini(struct qublk_dev *dev)
+{
+	int ublkc_fd = -1;
+
+	if (!dev->queues) {
+		return;
+	}
+	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+		if (dev->queues[i].ublkc_fd >= 0) {
+			ublkc_fd = dev->queues[i].ublkc_fd;
+		}
+		queue_fini(dev, &dev->queues[i]);
+	}
+	if (ublkc_fd >= 0) {
+		close(ublkc_fd);
+	}
+	free(dev->queues);
+	dev->queues = NULL;
+}
+
+/*
+ * Submit initial FETCH_REQs from the I/O thread so that ublk_drv records the
+ * I/O thread as the queue's ubq_daemon. Subsequent COMMIT_AND_FETCH commands
+ * (also from this thread) then pass the daemon == current check.
+ */
+static int
+submit_initial_fetches(struct qublk_queue *q)
+{
+	int rc;
+
+	for (uint16_t t = 0; t < q->depth; t++) {
+		rc = submit_fetch(q, &q->ios[t]);
+		if (rc < 0) {
+			fprintf(stderr, "submit_fetch(q%d t%u): %s\n", q->q_id, t, strerror(-rc));
+			return rc;
+		}
+	}
+	rc = io_uring_submit(&q->ring);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_submit(initial FETCHs q%d): %s\n", q->q_id,
+			strerror(-rc));
+		return rc;
+	}
+	return 0;
+}
+
+static void
+io_loop(struct qublk_queue *q)
+{
+	struct qublk_dev *dev = q->dev;
+	struct __kernel_timespec idle_ts = {.tv_nsec = 100 * 1000 * 1000};
+	struct io_uring_cqe *cqe;
+	unsigned head, count;
+	int xp;
+
+	while (!dev->stop) {
+		/*
+		 * NVMe completions can only arrive while commands are in flight,
+		 * and the upcie backend has no completion fd to wait on -- so we
+		 * must busy-poll the xnvme queue whenever it has outstanding work.
+		 * When it is empty, the only events that can wake us are a new
+		 * ublk request (FETCH) or a peer queue's barrier MSG_RING, both of
+		 * which post to this ring's fd; block on it instead of spinning so
+		 * an idle queue does not pin a core away from the application. The
+		 * wait is bounded so the loop re-checks dev->stop -- shutdown sets
+		 * the flag from another thread without posting a CQE here.
+		 */
+		if (xnvme_queue_get_outstanding(q->xq) == 0) {
+			io_uring_submit_and_wait_timeout(&q->ring, &cqe, 1, &idle_ts, NULL);
+		} else {
+			io_uring_submit_and_get_events(&q->ring);
+		}
+
+		count = 0;
+		io_uring_for_each_cqe(&q->ring, head, cqe)
+		{
+			handle_cqe(q, cqe);
+			count++;
+		}
+		if (count) {
+			io_uring_cq_advance(&q->ring, count);
+		}
+
+		if (xnvme_queue_get_outstanding(q->xq)) {
+			xnvme_queue_poke(q->xq, 0);
+		}
+	}
+
+	/* Drain: keep pumping until xnvme queue empty and no more ublk CQEs. */
+	for (int idle = 0; idle < 1024;) {
+		io_uring_submit_and_get_events(&q->ring);
+		count = 0;
+		io_uring_for_each_cqe(&q->ring, head, cqe)
+		{
+			(void)cqe;
+			count++;
+		}
+		if (count) {
+			io_uring_cq_advance(&q->ring, count);
+		}
+
+		xp = xnvme_queue_poke(q->xq, 0);
+		if (xnvme_queue_get_outstanding(q->xq) == 0 && count == 0 && xp == 0) {
+			idle++;
+		} else {
+			idle = 0;
+		}
+	}
+}
+
+static void *
+io_thread_main(void *arg)
+{
+	struct qublk_queue *q = arg;
+	struct qublk_dev *dev = q->dev;
+	int rc;
+
+	rc = init_ring(q);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_queue_init(q%d): %s\n", q->q_id, strerror(-rc));
+		q->init_rc = rc;
+		sem_post(&dev->io_ready);
+		return NULL;
+	}
+
+	rc = io_uring_register_files(&q->ring, &q->ublkc_fd, 1);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_register_files(q%d): %s\n", q->q_id, strerror(-rc));
+		q->init_rc = rc;
+		sem_post(&dev->io_ready);
+		io_uring_queue_exit(&q->ring);
+		return NULL;
+	}
+
+	rc = io_uring_register_ring_fd(&q->ring);
+	if (rc < 0) {
+		fprintf(stderr, "io_uring_register_ring_fd(q%d): %s\n", q->q_id, strerror(-rc));
+		q->init_rc = rc;
+		sem_post(&dev->io_ready);
+		io_uring_queue_exit(&q->ring);
+		return NULL;
+	}
+
+	q->init_rc = submit_initial_fetches(q);
+	sem_post(&dev->io_ready);
+	if (q->init_rc == 0) {
+		io_loop(q);
+	}
+	io_uring_queue_exit(&q->ring);
+	return NULL;
+}
+
+int
+qublk_io_thread_start(struct qublk_dev *dev)
+{
+	uint16_t started = 0;
+	int rc, err = 0;
+
+	if (sem_init(&dev->io_ready, 0, 0) < 0) {
+		fprintf(stderr, "sem_init: %s\n", strerror(errno));
+		return -errno;
+	}
+
+	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+		dev->queues[i].init_rc = 0;
+		rc = pthread_create(&dev->queues[i].tid, NULL, io_thread_main, &dev->queues[i]);
+		if (rc) {
+			fprintf(stderr, "pthread_create(q%u): %s\n", i, strerror(rc));
+			dev->queues[i].tid = 0;
+			err = -rc;
+			break;
+		}
+		started++;
+	}
+
+	for (uint16_t i = 0; i < started; i++) {
+		sem_wait(&dev->io_ready);
+	}
+	sem_destroy(&dev->io_ready);
+
+	if (err == 0) {
+		for (uint16_t i = 0; i < dev->nr_queues; i++) {
+			if (dev->queues[i].init_rc < 0) {
+				err = dev->queues[i].init_rc;
+				break;
+			}
+		}
+	}
+
+	if (err < 0) {
+		dev->stop = 1;
+		qublk_io_thread_join(dev);
+		return err;
+	}
+	return 0;
+}
+
+void
+qublk_io_thread_join(struct qublk_dev *dev)
+{
+	if (!dev->queues) {
+		return;
+	}
+	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+		if (dev->queues[i].tid) {
+			pthread_join(dev->queues[i].tid, NULL);
+			dev->queues[i].tid = 0;
+		}
+	}
+}

--- a/tools/qublk/io.c
+++ b/tools/qublk/io.c
@@ -80,7 +80,7 @@ iod_stride(void)
 static unsigned
 ring_entries_for(const struct qublk_queue *q)
 {
-	unsigned nq = q->dev->nr_queues;
+	unsigned nq = q->dev->nqueues;
 	unsigned entries = (unsigned)q->depth * (2 * nq - 1);
 
 	if (entries < (unsigned)q->depth) {
@@ -110,10 +110,10 @@ rflush_pool_init(struct qublk_dev *dev, struct qublk_queue *q)
 {
 	uint32_t n;
 
-	if (dev->nr_queues <= 1) {
+	if (dev->nqueues <= 1) {
 		return 0;
 	}
-	n = (uint32_t)(dev->nr_queues - 1) * q->depth;
+	n = (uint32_t)(dev->nqueues - 1) * q->depth;
 	q->rflush_pool = calloc(n, sizeof(*q->rflush_pool));
 	if (!q->rflush_pool) {
 		return -ENOMEM;
@@ -385,7 +385,7 @@ dispatch_barrier(struct qublk_queue *q, struct qublk_io *io, uint8_t op)
 	io->barrier_outstanding = 1;
 	io->barrier_err = 0;
 
-	for (uint16_t r = 0; r < dev->nr_queues; r++) {
+	for (uint16_t r = 0; r < dev->nqueues; r++) {
 		struct qublk_queue *rq;
 		struct io_uring_sqe *sqe;
 
@@ -557,7 +557,7 @@ queue_init(struct qublk_dev *dev, struct qublk_queue *q, int q_id, int ublkc_fd)
 
 	q->dev = dev;
 	q->q_id = q_id;
-	q->depth = dev->depth;
+	q->depth = dev->qdepth;
 	q->ublkc_fd = ublkc_fd;
 	q->ios = NULL;
 	q->iod_arr = NULL;
@@ -635,7 +635,7 @@ qublk_io_init(struct qublk_dev *dev)
 	char path[64];
 	int ublkc_fd, rc;
 
-	dev->queues = calloc(dev->nr_queues, sizeof(*dev->queues));
+	dev->queues = calloc(dev->nqueues, sizeof(*dev->queues));
 	if (!dev->queues) {
 		return -ENOMEM;
 	}
@@ -648,12 +648,12 @@ qublk_io_init(struct qublk_dev *dev)
 		goto err;
 	}
 
-	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+	for (uint16_t i = 0; i < dev->nqueues; i++) {
 		dev->queues[i].ublkc_fd = -1;
 	}
 	dev->queues[0].ublkc_fd = ublkc_fd;
 
-	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+	for (uint16_t i = 0; i < dev->nqueues; i++) {
 		rc = queue_init(dev, &dev->queues[i], i, ublkc_fd);
 		if (rc < 0) {
 			goto err;
@@ -675,7 +675,7 @@ qublk_io_fini(struct qublk_dev *dev)
 	if (!dev->queues) {
 		return;
 	}
-	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+	for (uint16_t i = 0; i < dev->nqueues; i++) {
 		if (dev->queues[i].ublkc_fd >= 0) {
 			ublkc_fd = dev->queues[i].ublkc_fd;
 		}
@@ -831,7 +831,7 @@ qublk_io_thread_start(struct qublk_dev *dev)
 		return -errno;
 	}
 
-	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+	for (uint16_t i = 0; i < dev->nqueues; i++) {
 		dev->queues[i].init_rc = 0;
 		rc = pthread_create(&dev->queues[i].tid, NULL, io_thread_main, &dev->queues[i]);
 		if (rc) {
@@ -849,7 +849,7 @@ qublk_io_thread_start(struct qublk_dev *dev)
 	sem_destroy(&dev->io_ready);
 
 	if (err == 0) {
-		for (uint16_t i = 0; i < dev->nr_queues; i++) {
+		for (uint16_t i = 0; i < dev->nqueues; i++) {
 			if (dev->queues[i].init_rc < 0) {
 				err = dev->queues[i].init_rc;
 				break;
@@ -871,7 +871,7 @@ qublk_io_thread_join(struct qublk_dev *dev)
 	if (!dev->queues) {
 		return;
 	}
-	for (uint16_t i = 0; i < dev->nr_queues; i++) {
+	for (uint16_t i = 0; i < dev->nqueues; i++) {
 		if (dev->queues[i].tid) {
 			pthread_join(dev->queues[i].tid, NULL);
 			dev->queues[i].tid = 0;

--- a/tools/qublk/io.c
+++ b/tools/qublk/io.c
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include "io.h"
 
 #include <errno.h>
@@ -312,6 +314,11 @@ handle_msg_do_flush(struct qublk_queue *q, uint16_t orig_qid, uint16_t orig_tag)
 		if (ctx) {
 			break;
 		}
+		if (dev->stop) {
+			rflush_release(q, rf);
+			msg_post_flush_done(q, orig_qid, orig_tag, -ENODEV);
+			return;
+		}
 		xnvme_queue_poke(q->xq, 0);
 	}
 	memset(&ctx->cmd, 0, sizeof(ctx->cmd));
@@ -498,7 +505,10 @@ handle_ublk_cqe(struct qublk_queue *q, struct io_uring_cqe *cqe)
 	if (cqe->res == UBLK_IO_RES_OK) {
 		rc = dispatch(q, io);
 		while (rc == -EBUSY || rc == -EAGAIN) {
+			// -EBUSY is a full xnvme queue, cured by poking it; -EAGAIN
+			// is an exhausted io_uring SQ, cured only by submitting it
 			xnvme_queue_poke(q->xq, 0);
+			io_uring_submit(&q->ring);
 			rc = dispatch(q, io);
 		}
 		return rc;
@@ -762,7 +772,10 @@ io_loop(struct qublk_queue *q)
 		count = 0;
 		io_uring_for_each_cqe(&q->ring, head, cqe)
 		{
-			(void)cqe;
+			// Dispatch rather than discard; STOP_DEV waits on requests
+			// in flight, and one delivered after 'stop' was set would
+			// otherwise never be committed
+			handle_cqe(q, cqe);
 			count++;
 		}
 		if (count) {

--- a/tools/qublk/io.h
+++ b/tools/qublk/io.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef QUBLK_IO_H
+#define QUBLK_IO_H
+
+#include "qublk.h"
+
+int
+qublk_io_init(struct qublk_dev *dev);
+void
+qublk_io_fini(struct qublk_dev *dev);
+
+int
+qublk_io_thread_start(struct qublk_dev *dev);
+void
+qublk_io_thread_join(struct qublk_dev *dev);
+
+#endif

--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <getopt.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libxnvme.h>
+
+#include "ctrl.h"
+#include "io.h"
+#include "qublk.h"
+
+static bool
+is_pow2(uint32_t v)
+{
+	return v && (v & (v - 1)) == 0;
+}
+
+static uint8_t
+lba_shift_of(uint32_t lba_nbytes)
+{
+	for (uint8_t s = 0; s < 32; s++) {
+		if ((1u << s) == lba_nbytes) {
+			return s;
+		}
+	}
+	return 0;
+}
+
+static const struct option qublk_opts[] = {
+	{"be", required_argument, NULL, 'b'},
+	{"depth", required_argument, NULL, 'd'},
+	{"dev-id", required_argument, NULL, 'i'},
+	{"max-io-bytes", required_argument, NULL, 'm'},
+	{"nr-queues", required_argument, NULL, 'q'},
+	{"help", no_argument, NULL, 'h'},
+	{0},
+};
+
+static void
+usage(const char *prog)
+{
+	fprintf(stderr,
+		"usage: %s URI [--be BE] [--depth N] [--dev-id N] [--max-io-bytes N] "
+		"[--nr-queues N]\n"
+		"  URI            xNVMe device URI (e.g. /dev/nvme0n1, 0000:01:00.0)\n"
+		"  --be BE        xNVMe backend (upcie, io_uring, io_uring_cmd, libaio, ...)\n"
+		"  --depth N      per-queue depth, power of 2 (default: 64)\n"
+		"  --dev-id N     requested ublk dev id (default: -1 / auto)\n"
+		"  --max-io-bytes N  per-IO buffer size (default: min(1MiB, MDTS))\n"
+		"  --nr-queues N  number of ublk hardware queues (default: 1)\n",
+		prog);
+}
+
+int
+main(int argc, char **argv)
+{
+	struct qublk_dev dev = {
+		.ctrl_fd = -1,
+		.dev_id = -1,
+		.nr_queues = 1,
+		.depth = 64,
+		.flags = UBLK_F_CMD_IOCTL_ENCODE,
+	};
+	struct xnvme_opts xopts;
+	const char *uri = NULL, *be = NULL;
+	sigset_t blk;
+	uint64_t feat = 0;
+	uint32_t want_max_io = 0, cap_max;
+	int c, sig;
+
+	while ((c = getopt_long(argc, argv, "b:d:i:m:q:h", qublk_opts, NULL)) != -1) {
+		switch (c) {
+		case 'b':
+			be = optarg;
+			break;
+		case 'd':
+			dev.depth = (uint16_t)atoi(optarg);
+			break;
+		case 'i':
+			dev.dev_id = atoi(optarg);
+			break;
+		case 'm':
+			want_max_io = (uint32_t)strtoul(optarg, NULL, 0);
+			break;
+		case 'q':
+			dev.nr_queues = (uint16_t)atoi(optarg);
+			break;
+		case 'h':
+			usage(argv[0]);
+			return 0;
+		default:
+			usage(argv[0]);
+			return 2;
+		}
+	}
+	if (optind >= argc) {
+		usage(argv[0]);
+		return 2;
+	}
+	uri = argv[optind];
+	if (!is_pow2(dev.depth) || dev.depth > QUBLK_MAX_QUEUE_DEPTH) {
+		fprintf(stderr, "qublk: --depth must be power of 2, <= %u\n",
+			QUBLK_MAX_QUEUE_DEPTH);
+		return 2;
+	}
+	if (dev.nr_queues < 1 || dev.nr_queues > UBLK_MAX_NR_QUEUES) {
+		fprintf(stderr, "qublk: --nr-queues must be in [1, %u]\n", UBLK_MAX_NR_QUEUES);
+		return 2;
+	}
+
+	xopts = xnvme_opts_default();
+	xopts.rdwr = 1;
+	if (be) {
+		xopts.be = be;
+	}
+
+	dev.xdev = xnvme_dev_open(uri, &xopts);
+	if (!dev.xdev) {
+		fprintf(stderr, "xnvme_dev_open(%s): %s\n", uri, strerror(errno));
+		return 1;
+	}
+	dev.geo = xnvme_dev_get_geo(dev.xdev);
+	dev.lba_shift = lba_shift_of(dev.geo->lba_nbytes);
+	if (dev.lba_shift < 9) {
+		fprintf(stderr, "qublk: unsupported LBA size %u\n", dev.geo->lba_nbytes);
+		goto err_xdev;
+	}
+
+	{
+		const struct xnvme_spec_idfy_ctrlr *ctrlr = xnvme_dev_get_ctrlr(dev.xdev);
+		dev.has_vwc = ctrlr ? (uint8_t)ctrlr->vwc.present : 1;
+	}
+
+	cap_max = dev.geo->mdts_nbytes ? dev.geo->mdts_nbytes : (1u << 20);
+	dev.max_io_buf = want_max_io ? want_max_io : (cap_max < (1u << 20) ? cap_max : (1u << 20));
+	if (dev.max_io_buf > cap_max) {
+		dev.max_io_buf = cap_max;
+	}
+	dev.max_io_buf &= ~(uint32_t)(sysconf(_SC_PAGESIZE) - 1);
+
+	setvbuf(stderr, NULL, _IOLBF, 0);
+
+	sigemptyset(&blk);
+	sigaddset(&blk, SIGINT);
+	sigaddset(&blk, SIGTERM);
+	pthread_sigmask(SIG_BLOCK, &blk, NULL);
+
+	if (qublk_ctrl_open(&dev) < 0) {
+		goto err_xdev;
+	}
+	if (qublk_ctrl_get_features(&dev, &feat) < 0) {
+		goto err_ctrl;
+	}
+	if (!(feat & UBLK_F_CMD_IOCTL_ENCODE)) {
+		fprintf(stderr, "qublk: kernel lacks UBLK_F_CMD_IOCTL_ENCODE\n");
+		goto err_ctrl;
+	}
+
+	if (qublk_ctrl_add_dev(&dev) < 0) {
+		goto err_ctrl;
+	}
+	fprintf(stderr,
+		"qublk: added ublk dev id=%d nr_queues=%u depth=%u max_io=%u backend=%s uri=%s\n",
+		dev.dev_id, dev.nr_queues, dev.depth, dev.max_io_buf, be ? be : "(auto)", uri);
+
+	if (qublk_ctrl_set_params(&dev) < 0) {
+		goto err_added;
+	}
+	if (qublk_io_init(&dev) < 0) {
+		goto err_added;
+	}
+	if (qublk_io_thread_start(&dev) < 0) {
+		goto err_io;
+	}
+	if (qublk_ctrl_start_dev(&dev) < 0) {
+		dev.stop = 1;
+		qublk_io_thread_join(&dev);
+		goto err_io;
+	}
+
+	fprintf(stderr, "qublk: /dev/ublkb%d ready (Ctrl-C to stop)\n", dev.dev_id);
+
+	sigwait(&blk, &sig);
+	fprintf(stderr, "qublk: stopping (signal %d)\n", sig);
+	dev.stop = 1;
+
+	qublk_io_thread_join(&dev);
+	qublk_ctrl_stop_dev(&dev);
+	qublk_io_fini(&dev);
+	qublk_ctrl_del_dev(&dev);
+	qublk_ctrl_close(&dev);
+	xnvme_dev_close(dev.xdev);
+	return 0;
+
+err_io:
+	qublk_io_fini(&dev);
+err_added:
+	qublk_ctrl_del_dev(&dev);
+err_ctrl:
+	qublk_ctrl_close(&dev);
+err_xdev:
+	xnvme_dev_close(dev.xdev);
+	return 1;
+}

--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -67,8 +67,8 @@ main(int argc, char **argv)
 	struct qublk_dev dev = {
 		.ctrl_fd = -1,
 		.dev_id = -1,
-		.nr_queues = 1,
-		.depth = 64,
+		.nqueues = 1,
+		.qdepth = 64,
 		.flags = UBLK_F_CMD_IOCTL_ENCODE,
 	};
 	struct xnvme_opts xopts;
@@ -84,7 +84,7 @@ main(int argc, char **argv)
 			be = optarg;
 			break;
 		case 'd':
-			dev.depth = (uint16_t)atoi(optarg);
+			dev.qdepth = (uint32_t)atoi(optarg);
 			break;
 		case 'i':
 			dev.dev_id = atoi(optarg);
@@ -93,7 +93,7 @@ main(int argc, char **argv)
 			want_max_io = (uint32_t)strtoul(optarg, NULL, 0);
 			break;
 		case 'q':
-			dev.nr_queues = (uint16_t)atoi(optarg);
+			dev.nqueues = (uint32_t)atoi(optarg);
 			break;
 		case 'h':
 			usage(argv[0]);
@@ -108,12 +108,12 @@ main(int argc, char **argv)
 		return 2;
 	}
 	uri = argv[optind];
-	if (!is_pow2(dev.depth) || dev.depth > QUBLK_MAX_QUEUE_DEPTH) {
+	if (!is_pow2(dev.qdepth) || dev.qdepth > QUBLK_MAX_QUEUE_DEPTH) {
 		fprintf(stderr, "qublk: --depth must be power of 2, <= %u\n",
 			QUBLK_MAX_QUEUE_DEPTH);
 		return 2;
 	}
-	if (dev.nr_queues < 1 || dev.nr_queues > UBLK_MAX_NR_QUEUES) {
+	if (dev.nqueues < 1 || dev.nqueues > UBLK_MAX_NR_QUEUES) {
 		fprintf(stderr, "qublk: --nr-queues must be in [1, %u]\n", UBLK_MAX_NR_QUEUES);
 		return 2;
 	}
@@ -171,7 +171,7 @@ main(int argc, char **argv)
 	}
 	fprintf(stderr,
 		"qublk: added ublk dev id=%d nr_queues=%u depth=%u max_io=%u backend=%s uri=%s\n",
-		dev.dev_id, dev.nr_queues, dev.depth, dev.max_io_buf, be ? be : "(auto)", uri);
+		dev.dev_id, dev.nqueues, dev.qdepth, dev.max_io_buf, be ? be : "(auto)", uri);
 
 	if (qublk_ctrl_set_params(&dev) < 0) {
 		goto err_added;

--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -6,7 +6,6 @@
 #define _GNU_SOURCE
 #endif
 #include <errno.h>
-#include <getopt.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -21,11 +20,10 @@
 #include "io.h"
 #include "qublk.h"
 
-static bool
-is_pow2(uint32_t v)
-{
-	return v && (v & (v - 1)) == 0;
-}
+#define QUBLK_DEFAULT_QDEPTH 64
+#define QUBLK_DEFAULT_NQUEUES 1
+#define QUBLK_DEFAULT_DEV_ID (-1) ///< Let the kernel assign the ublk device identifier
+#define QUBLK_DEFAULT_MAX_IO_CAP (1u << 20)
 
 static uint8_t
 lba_shift_of(uint32_t lba_nbytes)
@@ -38,103 +36,75 @@ lba_shift_of(uint32_t lba_nbytes)
 	return 0;
 }
 
-static const struct option qublk_opts[] = {
-	{"be", required_argument, NULL, 'b'},
-	{"depth", required_argument, NULL, 'd'},
-	{"dev-id", required_argument, NULL, 'i'},
-	{"max-io-bytes", required_argument, NULL, 'm'},
-	{"nr-queues", required_argument, NULL, 'q'},
-	{"help", no_argument, NULL, 'h'},
-	{0},
-};
-
-static void
-usage(const char *prog)
-{
-	fprintf(stderr,
-		"usage: %s URI [--be BE] [--depth N] [--dev-id N] [--max-io-bytes N] "
-		"[--nr-queues N]\n"
-		"  URI            xNVMe device URI (e.g. /dev/nvme0n1, 0000:01:00.0)\n"
-		"  --be BE        xNVMe backend (upcie, io_uring, io_uring_cmd, libaio, ...)\n"
-		"  --depth N      per-queue depth, power of 2 (default: 64)\n"
-		"  --dev-id N     requested ublk dev id (default: -1 / auto)\n"
-		"  --max-io-bytes N  per-IO buffer size (default: min(1MiB, MDTS))\n"
-		"  --nr-queues N  number of ublk hardware queues (default: 1)\n",
-		prog);
-}
-
-int
-main(int argc, char **argv)
+static int
+sub_run(struct xnvme_cli *cli)
 {
 	struct qublk_dev dev = {
 		.ctrl_fd = -1,
-		.dev_id = -1,
-		.nqueues = 1,
-		.qdepth = 64,
+		.dev_id = QUBLK_DEFAULT_DEV_ID,
+		.nqueues = QUBLK_DEFAULT_NQUEUES,
+		.qdepth = QUBLK_DEFAULT_QDEPTH,
 		.flags = UBLK_F_CMD_IOCTL_ENCODE,
 	};
-	struct xnvme_opts xopts;
-	const char *uri = NULL, *be = NULL;
+	struct xnvme_opts xopts = xnvme_opts_default();
+	const char *uri = cli->args.uri;
+	const char *be = cli->args.be;
 	sigset_t blk;
 	uint64_t feat = 0;
 	uint32_t want_max_io = 0, cap_max;
-	int c, sig;
+	int sig;
 
-	while ((c = getopt_long(argc, argv, "b:d:i:m:q:h", qublk_opts, NULL)) != -1) {
-		switch (c) {
-		case 'b':
-			be = optarg;
-			break;
-		case 'd':
-			dev.qdepth = (uint32_t)atoi(optarg);
-			break;
-		case 'i':
-			dev.dev_id = atoi(optarg);
-			break;
-		case 'm':
-			want_max_io = (uint32_t)strtoul(optarg, NULL, 0);
-			break;
-		case 'q':
-			dev.nqueues = (uint32_t)atoi(optarg);
-			break;
-		case 'h':
-			usage(argv[0]);
-			return 0;
-		default:
-			usage(argv[0]);
-			return 2;
-		}
+	// Options are optional; only override the defaults for the ones actually given
+	if (cli->given[XNVME_CLI_OPT_QDEPTH]) {
+		dev.qdepth = cli->args.qdepth;
 	}
-	if (optind >= argc) {
-		usage(argv[0]);
-		return 2;
+	if (cli->given[XNVME_CLI_OPT_NQUEUES]) {
+		dev.nqueues = cli->args.nqueues;
 	}
-	uri = argv[optind];
-	if (!is_pow2(dev.qdepth) || dev.qdepth > QUBLK_MAX_QUEUE_DEPTH) {
-		fprintf(stderr, "qublk: --depth must be power of 2, <= %u\n",
-			QUBLK_MAX_QUEUE_DEPTH);
-		return 2;
+	if (cli->given[XNVME_CLI_OPT_DEV_ID]) {
+		dev.dev_id = (int)cli->args.dev_id;
 	}
-	if (dev.nqueues < 1 || dev.nqueues > UBLK_MAX_NR_QUEUES) {
-		fprintf(stderr, "qublk: --nr-queues must be in [1, %u]\n", UBLK_MAX_NR_QUEUES);
-		return 2;
+	if (cli->given[XNVME_CLI_OPT_MAX_IO_BYTES]) {
+		want_max_io = cli->args.max_io_bytes;
 	}
 
-	xopts = xnvme_opts_default();
+	// Half of QUBLK_MAX_QUEUE_DEPTH: xnvme_queue_init() requires a capacity
+	// strictly below 4096, so a qdepth of 4096 would fail only after ADD_DEV
+	if (!xnvme_is_pow2(dev.qdepth) || dev.qdepth > (QUBLK_MAX_QUEUE_DEPTH / 2)) {
+		xnvme_cli_perr("Error: --qdepth must be a power of 2 and within limits", -EINVAL);
+		return -EINVAL;
+	}
+	if (dev.nqueues > UBLK_MAX_NR_QUEUES) {
+		xnvme_cli_perr("Error: --nqueues is out of range", -EINVAL);
+		return -EINVAL;
+	}
+	// The identifier becomes the ublk minor; cap it accordingly (MINORBITS)
+	if (cli->given[XNVME_CLI_OPT_DEV_ID] && cli->args.dev_id >= (1u << 20)) {
+		xnvme_cli_perr("Error: --dev-id is out of range", -EINVAL);
+		return -EINVAL;
+	}
+	// max_io_buf is rounded down to a page multiple below; anything smaller
+	// than a page would round to zero
+	if (cli->given[XNVME_CLI_OPT_MAX_IO_BYTES] &&
+	    want_max_io < (uint32_t)sysconf(_SC_PAGESIZE)) {
+		xnvme_cli_perr("Error: --max-io-bytes must be at least the page size", -EINVAL);
+		return -EINVAL;
+	}
+
+	xnvme_cli_to_opts(cli, &xopts);
 	xopts.rdwr = 1;
-	if (be) {
-		xopts.be = be;
-	}
 
 	dev.xdev = xnvme_dev_open(uri, &xopts);
 	if (!dev.xdev) {
-		fprintf(stderr, "xnvme_dev_open(%s): %s\n", uri, strerror(errno));
-		return 1;
+		int err = errno ? -errno : -EIO;
+
+		xnvme_cli_perr("Failed: xnvme_dev_open()", err);
+		return err;
 	}
 	dev.geo = xnvme_dev_get_geo(dev.xdev);
 	dev.lba_shift = lba_shift_of(dev.geo->lba_nbytes);
 	if (dev.lba_shift < 9) {
-		fprintf(stderr, "qublk: unsupported LBA size %u\n", dev.geo->lba_nbytes);
+		xnvme_cli_perr("Failed: unsupported LBA size", -EINVAL);
 		goto err_xdev;
 	}
 
@@ -143,8 +113,11 @@ main(int argc, char **argv)
 		dev.has_vwc = ctrlr ? (uint8_t)ctrlr->vwc.present : 1;
 	}
 
-	cap_max = dev.geo->mdts_nbytes ? dev.geo->mdts_nbytes : (1u << 20);
-	dev.max_io_buf = want_max_io ? want_max_io : (cap_max < (1u << 20) ? cap_max : (1u << 20));
+	cap_max = dev.geo->mdts_nbytes ? dev.geo->mdts_nbytes : QUBLK_DEFAULT_MAX_IO_CAP;
+	dev.max_io_buf = want_max_io
+				 ? want_max_io
+				 : (cap_max < QUBLK_DEFAULT_MAX_IO_CAP ? cap_max
+								       : QUBLK_DEFAULT_MAX_IO_CAP);
 	if (dev.max_io_buf > cap_max) {
 		dev.max_io_buf = cap_max;
 	}
@@ -164,7 +137,7 @@ main(int argc, char **argv)
 		goto err_ctrl;
 	}
 	if (!(feat & UBLK_F_CMD_IOCTL_ENCODE)) {
-		fprintf(stderr, "qublk: kernel lacks UBLK_F_CMD_IOCTL_ENCODE\n");
+		xnvme_cli_perr("Failed: kernel lacks UBLK_F_CMD_IOCTL_ENCODE", -ENOSYS);
 		goto err_ctrl;
 	}
 
@@ -172,7 +145,7 @@ main(int argc, char **argv)
 		goto err_ctrl;
 	}
 	fprintf(stderr,
-		"qublk: added ublk dev id=%d nr_queues=%u depth=%u max_io=%u backend=%s uri=%s\n",
+		"qublk: added ublk dev id=%d nqueues=%u qdepth=%u max_io=%u backend=%s uri=%s\n",
 		dev.dev_id, dev.nqueues, dev.qdepth, dev.max_io_buf, be ? be : "(auto)", uri);
 
 	if (qublk_ctrl_set_params(&dev) < 0) {
@@ -215,5 +188,39 @@ err_ctrl:
 	qublk_ctrl_close(&dev);
 err_xdev:
 	xnvme_dev_close(dev.xdev);
-	return 1;
+	return -EIO;
+}
+
+static struct xnvme_cli_sub g_subs[] = {
+	{
+		"run",
+		"Serve a ublk block-device backed by the given xNVMe device",
+		"Serve a ublk block-device backed by the given xNVMe device",
+		sub_run,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_NQUEUES, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_DEV_ID, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_MAX_IO_BYTES, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+		},
+	},
+};
+
+static struct xnvme_cli g_cli = {
+	.title = "qublk - ublk server backed by xNVMe",
+	.descr_short = "Expose an xNVMe device as a ublk block-device",
+	.descr_long = "",
+	.subs = g_subs,
+	.nsubs = sizeof g_subs / sizeof(*g_subs),
+};
+
+int
+main(int argc, char **argv)
+{
+	return xnvme_cli_run(&g_cli, argc, argv, XNVME_CLI_INIT_NONE);
 }

--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <errno.h>
 #include <getopt.h>
 #include <signal.h>
@@ -192,10 +194,13 @@ main(int argc, char **argv)
 
 	sigwait(&blk, &sig);
 	fprintf(stderr, "qublk: stopping (signal %d)\n", sig);
+	// STOP_DEV first, as ubdsrv does: del_gendisk() waits on requests in
+	// flight, so the queue threads must still be servicing; the kernel then
+	// aborts the pending FETCHes, which is what makes the threads exit
+	qublk_ctrl_stop_dev(&dev);
 	dev.stop = 1;
 
 	qublk_io_thread_join(&dev);
-	qublk_ctrl_stop_dev(&dev);
 	qublk_io_fini(&dev);
 	qublk_ctrl_del_dev(&dev);
 	qublk_ctrl_close(&dev);

--- a/tools/qublk/meson.build
+++ b/tools/qublk/meson.build
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+qublk_source = [
+  'main.c',
+  'ctrl.c',
+  'io.c',
+]
+
+if not is_linux
+  warning('No support for ublk on this platform, skipping qublk')
+elif not uring_dep.found()
+  warning('No liburing, skipping qublk')
+elif not cc.has_header('linux/ublk_cmd.h')
+  warning('No linux/ublk_cmd.h, skipping qublk')
+else
+  executable(
+    'qublk',
+    qublk_source,
+    include_directories: [conf_inc, xnvme_inc],
+    link_args: link_args_hardening,
+    link_with: xnvmelib,
+    install_rpath: xnvmelib_rpath,
+    dependencies: [uring_dep, thread_dep],
+    install: true,
+  )
+endif

--- a/tools/qublk/meson.build
+++ b/tools/qublk/meson.build
@@ -14,6 +14,8 @@ elif not uring_dep.found()
   warning('No liburing, skipping qublk')
 elif not cc.has_header('linux/ublk_cmd.h')
   warning('No linux/ublk_cmd.h, skipping qublk')
+elif not cc.has_header_symbol('linux/ublk_cmd.h', 'UBLK_U_CMD_GET_FEATURES')
+  warning('linux/ublk_cmd.h lacks the ioctl-encoded ublk commands (kernel headers < 6.3), skipping qublk')
 else
   executable(
     'qublk',

--- a/tools/qublk/qublk.h
+++ b/tools/qublk/qublk.h
@@ -43,7 +43,7 @@ struct qublk_remote_flush {
 
 struct qublk_queue {
 	int q_id;
-	uint16_t depth;
+	uint32_t depth;
 	int ublkc_fd;
 	struct io_uring ring;
 	struct ublksrv_io_desc *iod_arr;
@@ -61,8 +61,8 @@ struct qublk_queue {
 struct qublk_dev {
 	int ctrl_fd;
 	int dev_id;
-	uint16_t nr_queues;
-	uint16_t depth;
+	uint32_t nqueues;
+	uint32_t qdepth;
 	uint32_t max_io_buf;
 	uint64_t flags;
 	struct xnvme_dev *xdev;

--- a/tools/qublk/qublk.h
+++ b/tools/qublk/qublk.h
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef QUBLK_H
+#define QUBLK_H
+
+#include <pthread.h>
+#include <semaphore.h>
+#include <signal.h>
+#include <stdint.h>
+
+#include <linux/ublk_cmd.h>
+#include <liburing.h>
+#include <libxnvme.h>
+
+#define QUBLK_MAX_QUEUE_DEPTH UBLK_MAX_QUEUE_DEPTH
+
+struct qublk_dev;
+struct qublk_queue;
+
+struct qublk_io {
+	uint16_t tag;
+	void *buf;
+	const struct ublksrv_io_desc *iod;
+	struct qublk_queue *q;
+	/*
+	 * NVMe orders FLUSH/FUA only within a single submission queue, so
+	 * FLUSH and FUA writes fan a per-namespace FLUSH out to every xnvme
+	 * queue and the ublk IOD is committed only after all sub-ops have
+	 * landed. Touched only by the originating queue's I/O thread.
+	 */
+	int barrier_outstanding;
+	int barrier_err;
+};
+
+struct qublk_remote_flush {
+	struct qublk_queue *remote_q;
+	uint16_t orig_q_id;
+	uint16_t orig_tag;
+	struct qublk_remote_flush *next;
+};
+
+struct qublk_queue {
+	int q_id;
+	uint16_t depth;
+	int ublkc_fd;
+	struct io_uring ring;
+	struct ublksrv_io_desc *iod_arr;
+	size_t iod_arr_bytes;
+	struct xnvme_queue *xq;
+	struct qublk_io *ios;
+	struct qublk_dev *dev;
+	struct qublk_remote_flush *rflush_pool;
+	struct qublk_remote_flush *rflush_free;
+	uint32_t rflush_nr;
+	pthread_t tid;
+	int init_rc;
+};
+
+struct qublk_dev {
+	int ctrl_fd;
+	int dev_id;
+	uint16_t nr_queues;
+	uint16_t depth;
+	uint32_t max_io_buf;
+	uint64_t flags;
+	struct xnvme_dev *xdev;
+	const struct xnvme_geo *geo;
+	uint8_t lba_shift;
+	uint8_t has_vwc;
+	struct qublk_queue *queues;
+	sem_t io_ready;
+	volatile sig_atomic_t stop;
+};
+
+#endif


### PR DESCRIPTION
This moves qublk — the ublk server backed by xNVMe — into the tree as `tools/qublk`, integrated with the xNVMe build system and the `xnvme_cli` framework, per the xnvmeperf pattern. It creates `/dev/ublkbN` and serves the kernel's READ/WRITE/FLUSH (and FUA writes) through the xNVMe async API, so any xNVMe backend can be exposed as a regular block device.

Eight commits, restructured per review:

1. **feat(tools/qublk): add ublk server backed by xnvme** — the server itself: control-path, per-queue I/O threads on io_uring cmd, FLUSH/FUA handling, defensive validation of I/O sizes.
2. **fix(tools/qublk): widen qdepth and nqueues to 32 bits** — the fields matched neither the UAPI nor the CLI width, so out-of-range values were silently narrowed into in-range ones; renamed to the xNVMe convention while at it.
3. **fix(tools/qublk): io-path and teardown robustness** — SQE-exhaustion no longer spins the dispatch-retry, the remote-flush wait is bounded on stop, teardown issues STOP_DEV before joining the I/O threads (matching ubdsrv) and the drain dispatches rather than discards, `_GNU_SOURCE` guarded.
4. **build(tools/qublk): skip the build on kernel headers without ioctl-encoded ublk commands** — probes for `UBLK_U_CMD_GET_FEATURES`; fixes the Debian bookworm jobs (kernel 6.1 headers).
5. **feat(cli): add dev-id and max-io-bytes options** — two new shared CLI options (LOPT), with range validation; queue count reuses the existing `--nqueues`.
6. **refactor(tools/qublk): use the xnvme_cli helpers** — replaces the standalone getopt CLI with `xnvme_cli`; validation now happens at full width before any narrowing.
7. **docs(tools/qublk): document the qublk tool** — usage page under `docs/tools/`.
8. **test(tools/qublk): add cijoe functional and filesystem tests** — block-level (dd, multi-queue, max-io-bytes) and XFS-level (format/mount/remount, file ops, persistence across a qublk restart) cases; the daemon runs with a fixed `--dev-id` and the session refuses a pre-existing node; skips where ublk or `mkfs.xfs` is unavailable.

**Dependency note**: the filesystem-level cases (commit 6) need NVMe FLUSH in the Linux async backends, i.e. #747 — mkfs on a served namespace makes the kernel issue FLUSH, which io_uring/libaio reject with -ENOSYS without it. With #747 merged first (or its branch merged in locally), the whole suite is green; without it, the fs cases fail on the Linux async backends. The block-level cases and the tool itself do not depend on it.

**CI coverage**: the trixie-based verify jobs do run the qublk cases (their guests have `ublk_drv`); the filesystem cases currently skip there for lack of `mkfs.xfs` in the guest image — adding `xfsprogs` to the provisioning would light them up, which I can do as a follow-up. The bookworm jobs skip the tool at configure-time per commit 4.

## Verification

On Ubuntu 24.04, kernel 6.8.12, as root against a Samsung SSD 970 EVO 1TB and the ramdisk backend:

- `meson test`: 41 pass (the two new CLI option cases included), failures identical to `main` on the same machine.
- cijoe run of `test_qublk.py` + `test_qublk_fs.py` on a build including #747: 88 passed, 47 skipped, 0 failed — including mkfs/mount/remount and the restart-persistence case.
- FUA path checked via ftrace `block_rq_issue`: with `fua=1` both io_uring and libaio issue the write followed by a flush to the device; without the fix only the bare write went down.
- `--dev-id` and `--max-io-bytes` out-of-range values are rejected at startup.
