### PR TITLE
Accept --shm_id to join a multi-process group

### DIFF
--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -207,6 +207,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_MAX_IO_BYTES, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_SHM_ID, XNVME_CLI_LOPT},
 		},
 	},
 };


### PR DESCRIPTION
qublk currently opens its device standalone. With no `shm_id` the upcie backend never joins an existing runtime, so qublk cannot forward to a controller a homi server owns. xnvme_cli_to_opts already copies the value. The option table entry was missing.