### PR TITLE
tests(cijoe): report the tool output when an ioworker case fails

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -808,7 +808,11 @@ jobs:
 
     - name: CIJOE, result-log-dump on error
       if: failure()
-      run: find cijoe -name "*.output" | xargs cat
+      run: |
+        find cijoe -name "*.output" | while read -r fpath; do
+          echo "=== ${fpath}"
+          cat "${fpath}"
+        done
 
     - name: CIJOE, upload report.html
       if: always()
@@ -912,7 +916,11 @@ jobs:
 
     - name: CIJOE, result-log-dump on error
       if: failure()
-      run: find cijoe -name "*.output" | xargs cat
+      run: |
+        find cijoe -name "*.output" | while read -r fpath; do
+          echo "=== ${fpath}"
+          cat "${fpath}"
+        done
 
     - name: CIJOE, upload report.html
       if: always()
@@ -999,7 +1007,11 @@ jobs:
 
     - name: CIJOE, result-log-dump on error
       if: failure()
-      run: find cijoe -name "*.output" | xargs cat
+      run: |
+        find cijoe -name "*.output" | while read -r fpath; do
+          echo "=== ${fpath}"
+          cat "${fpath}"
+        done
 
     - name: CIJOE, upload report.html
       if: always()

--- a/cijoe/tests/logic/test_xnvme_tests_ioworker.py
+++ b/cijoe/tests/logic/test_xnvme_tests_ioworker.py
@@ -5,30 +5,30 @@ from ..conftest import get_osname, xnvme_parametrize
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
 def test_verify(cijoe, device, be_opts, cli_args):
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args}")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify {cli_args}")
+    assert not err, state.output()
 
     # small nlb
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1")
+    assert not err, state.output()
 
     # large nlb
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7")
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
 def test_verify_sync(cijoe, device, be_opts, cli_args):
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args}")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args}")
+    assert not err, state.output()
 
     # small nlb
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1")
+    assert not err, state.output()
 
     # large nlb
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7")
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
@@ -42,24 +42,28 @@ def test_verify_iovec(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "driverkit":
         pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4")
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4")
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # small nlb: sub-page segments require an SGL, rejected on nosgl
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --vec-cnt 4")
+    err, state = cijoe.run(
+        f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --vec-cnt 4"
+    )
 
     if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # large nlb: page-sized segments are PRP-expressible
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7 --vec-cnt 4")
-    assert not err
+    err, state = cijoe.run(
+        f"xnvme_tests_ioworker verify {cli_args} --nlb 7 --vec-cnt 4"
+    )
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
@@ -71,60 +75,62 @@ def test_verify_sync_iovec(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "driverkit":
         pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4")
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4")
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # small nlb: sub-page segments require an SGL, rejected on nosgl
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1 --vec-cnt 4"
     )
 
     if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # large nlb: page-sized segments are PRP-expressible
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7 --vec-cnt 4"
     )
-    assert not err
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["bdev"], opts=["be", "sync", "async", "admin"])
 def test_verify_direct(cijoe, device, be_opts, cli_args):
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --direct 1")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --direct 1")
+    assert not err, state.output()
 
     # small nlb
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --direct 1")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --direct 1")
+    assert not err, state.output()
 
     # large nlb
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --nlb 7  --direct 1")
-    assert not err
+    err, state = cijoe.run(
+        f"xnvme_tests_ioworker verify {cli_args} --nlb 7  --direct 1"
+    )
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["bdev"], opts=["be", "sync", "admin"])
 def test_verify_sync_direct(cijoe, device, be_opts, cli_args):
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --direct 1")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --direct 1")
+    assert not err, state.output()
 
     # small nlb
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1 --direct 1"
     )
-    assert not err
+    assert not err, state.output()
 
     # large nlb
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7  --direct 1"
     )
-    assert not err
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
@@ -138,28 +144,30 @@ def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "driverkit":
         pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4 --direct 1")
+    err, state = cijoe.run(
+        f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4 --direct 1"
+    )
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # small nlb: sub-page segments require an SGL, rejected on nosgl
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify {cli_args} --nlb 1 --vec-cnt 4 --direct 1"
     )
 
     if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # large nlb: page-sized segments are PRP-expressible
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify {cli_args} --nlb 7 --vec-cnt 4 --direct 1"
     )
-    assert not err
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
@@ -171,30 +179,30 @@ def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
     if be_opts["admin"] == "driverkit":
         pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4 --direct 1"
     )
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # small nlb: sub-page segments require an SGL, rejected on nosgl
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 1 --vec-cnt 4 --direct 1"
     )
 
     if be_opts["be"] == "spdk" and "nosgl" in device["labels"]:
-        assert err
+        assert err, state.output()
     else:
-        assert not err
+        assert not err, state.output()
 
     # large nlb: page-sized segments are PRP-expressible
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --nlb 7 --vec-cnt 4 --direct 1"
     )
-    assert not err
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
@@ -213,8 +221,8 @@ def test_verify_flush(cijoe, device, be_opts, cli_args):
     if "fabrics" in device["labels"]:
         pytest.skip(reason="[fabrics] spdk backend sends no keep-alive during I/O")
 
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-flush {cli_args}")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-flush {cli_args}")
+    assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["bdev"], opts=["be", "sync", "async", "admin"])
@@ -228,8 +236,8 @@ def test_verify_sqpoll(cijoe, device, be_opts, cli_args):
         ("verify", "--poll_sq 1 --vec-cnt 8 --nlb 3 --qdepth 8"),
         ("verify-flush", "--poll_sq 1 --vec-cnt 4 --nlb 7"),
     ]:
-        err, _ = cijoe.run(f"xnvme_tests_ioworker {subcmd} {cli_args} {args}")
-        assert not err
+        err, state = cijoe.run(f"xnvme_tests_ioworker {subcmd} {cli_args} {args}")
+        assert not err, state.output()
 
 
 @xnvme_parametrize(labels=["bdev"], opts=["be", "sync", "async", "admin"])
@@ -239,12 +247,12 @@ def test_verify_flush_iopoll_rejected(cijoe, device, be_opts, cli_args):
 
     # Control: the same invocation without IOPOLL must succeed, so that the
     # failure below can only be the submission-time rejection
-    err, _ = cijoe.run(f"xnvme_tests_ioworker verify-flush {cli_args} --direct 1")
-    assert not err
+    err, state = cijoe.run(f"xnvme_tests_ioworker verify-flush {cli_args} --direct 1")
+    assert not err, state.output()
 
     # IORING_OP_FSYNC has no iopoll-handler; the backend rejects FLUSH on an
     # IOPOLL queue at submission-time, so the run must fail
-    err, _ = cijoe.run(
+    err, state = cijoe.run(
         f"xnvme_tests_ioworker verify-flush {cli_args} --poll_io 1 --direct 1"
     )
-    assert err
+    assert err, state.output()


### PR DESCRIPTION
Two fixes for the reporting gap found in #766: a failing ioworker case in CI
surfaced as a bare `assert not 1`, with no way to tell whether the FLUSH was
rejected, timed out, or completed with an error status.

## What

- **ci(cijoe): survive quoted paths in the result-log-dump** — the dump step
  piped `find` into `xargs cat`. `xargs` strips the single-quotes that
  pytest-parametrized directory-names carry (e.g. `label=['cdev']`), so `cat`
  was handed paths that do not exist and the failing command's output never
  made it into the log — the `cat: '.../cmd_02.output': No such file or
  directory` seen in #766. The file existed; the dump could not read it.
  Loop over the paths instead, and print each file's name before its content
  so a dump of many files can be attributed.
- **tests(cijoe): report the tool output when an ioworker assertion fails** —
  hand the command output to every assertion in
  `tests/logic/test_xnvme_tests_ioworker.py`, so the pytest failure itself
  carries what the tool printed, independent of the artifact steps. Combined
  with 13f582fa (print the completion when the FLUSH fails), the status code
  is in the failure message.

Together with 13f582fa and d707eb3c (both on `main`), this covers the
"failure records nothing" item of #766.

## Verification

The three failure modes produce distinct output, verified by provoking each:

| Failure mode | Output in the assertion message |
| --- | --- |
| FLUSH rejected at submission (IOPOLL) | `# ERR: 'iowork_flush()': {errno: -38}` — no completion print |
| FLUSH completed with error status (incl. a timed-out command aborted by the driver) | `# ERR: 'on_flush_completion()'` + `xnvme_cmd_ctx: {cdw0: .., sc: .., sct: ..}` |
| FUA-write completed with error status | `# ERR: 'on_completion()'` + `xnvme_cmd_ctx: {..}` + non-zero `ecount` in the stats |

Systems and runs:

- **cijoe, ramdisk** (Linux 6.8, x86_64, no root): the test-ramdisk selection
  (`-k "ramdisk and not hugepage"`) over the modified file — 18 passed,
  4 skipped (the io_uring-only cases), 0 failed.
- **Real NVMe** (Samsung 970 EVO 1TB, kernel-attached, `--be io_uring` /
  `--async io_uring --direct 1`): `verify-flush` control passes; the four
  SQPOLL `verify`/`verify-flush` variants pass; `verify-flush --poll_io 1`
  fails at submission-time with the ENOSYS line above.
- **dm-flakey over a loop device** (fault injection): a flakey window during
  the write phase produces the FUA-write signature; flipping the table to a
  down-interval right before `iowork_flush()` (paused under gdb) fails the
  FLUSH alone and produces the `on_flush_completion()` signature, with all
  32768 writes completed clean.
- The `xargs` quoting failure reproduces standalone: `find | xargs cat` on a
  path containing `label=['cdev']` reports No-such-file; the loop prints it.
