### PR TITLE
ci(cijoe): fail on a bad QEMU feature probe, wait longer for the benchmark guests

### DIFF
--- a/cijoe/scripts/xnvme_guest_start.py
+++ b/cijoe/scripts/xnvme_guest_start.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Start a qemu guest and wait for its login prompt
+================================================
+
+The same as cijoe's own qemu.guest_start, except that the time to wait for the
+guest is an argument rather than a fixed 180 seconds. A first boot of the
+FreeBSD image generates its host keys and lands within seconds of that limit
+on an idle host, and past it when another guest is booting alongside.
+
+Retargetable: False
+-------------------
+"""
+import errno
+import logging as log
+from argparse import ArgumentParser
+
+from cijoe.qemu.wrapper import Guest
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--guest_name", type=str, help="Name of the qemu guest.")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Seconds to wait for the guest to reach its login prompt.",
+    )
+
+
+def main(args, cijoe):
+    """Start a qemu guest and wait for it"""
+
+    if not args.guest_name:
+        log.error("missing argument: guest_name")
+        return errno.EINVAL
+
+    guest = Guest(cijoe, cijoe.config, args.guest_name)
+
+    err = guest.start()
+    if err:
+        log.error(f"guest.start() : err({err})")
+        return err
+
+    if not guest.is_up(timeout=args.timeout):
+        log.error("guest.is_up() : False")
+        return errno.EAGAIN
+
+    return 0

--- a/cijoe/scripts/xnvme_guest_start_nvme.py
+++ b/cijoe/scripts/xnvme_guest_start_nvme.py
@@ -37,7 +37,11 @@ def detect_qemu_nvme_features(qemu_bin):
     """
     Detect which NVMe features the QEMU binary supports by parsing device help.
 
-    Returns dict with feature flags: {kv, zns, fdp, pi}
+    Returns dict with feature flags: {kv, zns, fdp, pi}, or None when the probe
+    could not run or did not find both zoned and pi, which every supported QEMU
+    has. The caller must treat None as fatal: a guest built from a guessed
+    feature set has its controllers on other BDFs than the config describes,
+    and the test suite then runs against the wrong devices.
     """
     features = {"kv": False, "zns": False, "fdp": False, "pi": False}
 
@@ -47,7 +51,7 @@ def detect_qemu_nvme_features(qemu_bin):
             [qemu_bin, "-device", "nvme-ns,help"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=60,
         )
         ns_help = result.stdout + result.stderr
         features["kv"] = "kv=" in ns_help
@@ -59,13 +63,20 @@ def detect_qemu_nvme_features(qemu_bin):
             [qemu_bin, "-device", "nvme-subsys,help"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=60,
         )
         subsys_help = result.stdout + result.stderr
         features["fdp"] = "fdp=" in subsys_help
 
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
-        log.warning(f"Failed to detect QEMU features: {e}")
+        log.error(f"Failed to detect QEMU features ({qemu_bin}): {e}")
+        return None
+
+    # zoned and pi are in every QEMU since 6.0, the fork included; their
+    # absence means the probe read something other than the device help
+    if not (features["zns"] and features["pi"]):
+        log.error(f"QEMU feature probe ({qemu_bin}) is not credible: {features}")
+        return None
 
     return features
 
@@ -73,6 +84,12 @@ def detect_qemu_nvme_features(qemu_bin):
 def add_args(parser: ArgumentParser):
     parser.add_argument("--nvme_img_root", type=str, default=None)
     parser.add_argument("--guest_name", type=str, default=None)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Seconds to wait for the guest to reach its login prompt.",
+    )
 
 
 def qemu_nvme_args(nvme_img_root, features=None, vfu_socket=None):
@@ -380,6 +397,8 @@ def main(args, cijoe):
         f"qemu.systems.{system_label}.bin", f"qemu-system-{system_label}"
     )
     features = detect_qemu_nvme_features(qemu_bin)
+    if features is None:
+        return errno.EINVAL
     log.info(f"Detected QEMU NVMe features ({qemu_bin}): {features}")
 
     # KV source: native nvme-ns kv=on (fork) or external vfu_kvssd over vfio-user
@@ -412,7 +431,7 @@ def main(args, cijoe):
         log.error(f"guest.start() : err({err})")
         return err
 
-    started = guest.is_up()
+    started = guest.is_up(timeout=args.timeout)
     if not started:
         log.error("guest.is_up() : False")
         return errno.EAGAIN

--- a/cijoe/workflows/provision-maas-using-tgz.yaml
+++ b/cijoe/workflows/provision-maas-using-tgz.yaml
@@ -43,9 +43,10 @@ steps:
     guest_name: "{{ config.qemu.default_guest }}"
 
 - name: guest_start
-  uses: qemu.guest_start
+  uses: xnvme_guest_start
   with:
     guest_name: "{{ config.qemu.default_guest }}"
+    timeout: 600
 
 - name: root_unlock
   uses: root_unlock


### PR DESCRIPTION
Fixes the two jobs red on `main` since d707eb3c, neither of which is caused
by that commit.

The test_python job on trixie-iommu_enabled got a guest with four
controllers instead of eleven, because the qemu feature probe in
`xnvme_guest_start_nvme.py` failed and the script quietly built the guest
without ZNS, FDP and PI. That shifts every BDF after the first, so the suite
opened the wrong devices and hung in `xnvme-driver reset` on a vfio group
an spdk test had left open. The sibling jobs of the same run got eleven
controllers from the same image, so the probe is flaky rather than broken.
The first commit makes a failed or incredible probe fail the step.

The FreeBSD benchmark guest boots completely but reaches "login:" a little
past the 180 s that cijoe's `qemu.guest_start` hard-codes, and only when
another guest boots alongside it on the host. The second commit adds
`xnvme_guest_start`, the same step with the wait as an argument, and gives
the benchmark guests 600 s.

Worth a careful look: the credibility check in `detect_qemu_nvme_features()`
requires zoned and pi, not fdp, so the fork still passes; and the
600 s is a ceiling, not a delay, since `is_up()` returns as soon as the
prompt appears.

## Verification

The three probe outcomes were exercised locally against a missing binary,
a non-qemu binary and the system qemu, and take the intended paths. The
guest start itself is exercised only by this CI run: the trixie jobs cover
the probe on the real image, and benchmark-latency freebsd covers the longer
wait. The flaky probe was not reproduced, so the run proves the happy path,
not the failure path, and the FreeBSD fix rests on the timing read from the
logs of three runs rather than on a measured boot.

Assisted-by: Claude Code:claude-fable-5
