### PR TITLE
fix: zone-capacity reporting, zoned example error label, and direct I/O for the zoned example write tests

### DIFF
--- a/cijoe/tests/examples/test_zoned_io_async.py
+++ b/cijoe/tests/examples/test_zoned_io_async.py
@@ -11,7 +11,9 @@ def test_write(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    err, _ = cijoe.run(f"zoned_io_async write {cli_args}")
+    # Buffered writes to a zoned block device are flushed by the page cache with no
+    # write-pointer ordering guarantee; bypass it to keep the writes sequential.
+    err, _ = cijoe.run(f"zoned_io_async write {cli_args} --direct 1")
     assert not err
 
 

--- a/cijoe/tests/examples/test_zoned_io_sync.py
+++ b/cijoe/tests/examples/test_zoned_io_sync.py
@@ -14,7 +14,9 @@ def test_write(cijoe, device, be_opts, cli_args):
     if be_opts["sync"] == "psync":
         pytest.skip(reason="psync(pread/write) does not support mgmt. send/receive")
 
-    err, _ = cijoe.run(f"zoned_io_sync write {cli_args}")
+    # Buffered writes to a zoned block device are flushed by the page cache with no
+    # write-pointer ordering guarantee; bypass it to keep the writes sequential.
+    err, _ = cijoe.run(f"zoned_io_sync write {cli_args} --direct 1")
     assert not err
 
 

--- a/examples/zoned_io_sync.c
+++ b/examples/zoned_io_sync.c
@@ -152,7 +152,7 @@ sub_sync_write(struct xnvme_cli *cli)
 
 		err = xnvme_nvm_write(&ctx, nsid, zone.zslba + sect, 0, payload, NULL);
 		if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
-			xnvme_cli_perr("xnvme_cmd_append()", err);
+			xnvme_cli_perr("xnvme_nvm_write()", err);
 			xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 			err = err ? err : -EIO;
 			goto exit;

--- a/lib/xnvme_be_linux_block.c
+++ b/lib/xnvme_be_linux_block.c
@@ -94,7 +94,7 @@ xnvme_be_linux_sysfs_dev_attr_to_num(struct xnvme_dev *dev, const char *attr, ui
 	return 0;
 }
 
-#ifdef BLK_ZONE_REP_CAPACITY
+#ifdef XNVME_BE_LINUX_BLK_ZONE_CAPACITY_ENABLED
 static uint64_t
 _lzbd_zone_capacity(struct blk_zone_report *hdr, struct blk_zone *blkz)
 {

--- a/meson.build
+++ b/meson.build
@@ -144,6 +144,10 @@ conf_data.set('XNVME_BE_WINDOWS_ASYNC_ENABLED', conf_data.get('XNVME_PLATFORM_WI
 conf_data.set('XNVME_PLATFORM_LINUX_ENABLED', is_linux)
 conf_data.set('XNVME_BE_LINUX_BLOCK_ENABLED', is_linux ? cc.has_header('linux/blkzoned.h') : false)
 conf_data.set('XNVME_BE_LINUX_BLOCK_ZONED_ENABLED', is_linux ? cc.has_header('linux/blkzoned.h') : false)
+conf_data.set(
+  'XNVME_BE_LINUX_BLK_ZONE_CAPACITY_ENABLED',
+  is_linux ? cc.has_member('struct blk_zone', 'capacity', prefix: '#include <linux/blkzoned.h>') : false,
+)
 
 aio_dep = cc.find_library(
   'aio',


### PR DESCRIPTION
This addresses observation 2 of #766 (the nvme1n1 "Buffer I/O error ... lost async page write" storms in the guest kernel log). Full analysis and reproduction: https://github.com/xnvme/xnvme/issues/766#issuecomment-5577859243

Three commits, ordered so each builds and passes on its own:

1. fix(be/linux): report zone capacity instead of zone size via admin=block

BLK_ZONE_REP_CAPACITY is an enumerator in linux/blkzoned.h, not a macro, so the existing "#ifdef BLK_ZONE_REP_CAPACITY" never evaluates to true and the fallback returning blkz->len is always compiled in. Zone reports through the block-layer admin interface therefore return zcap equal to the zone size; consumers of zcap overrun the writable capacity wherever capacity < size, e.g. the QEMU ZNS namespace in CI (cap 28M, size 32M). The guard is replaced with a meson probe for the capacity member of struct blk_zone (present since Linux 5.9); the fallback for older headers remains.

2. fix(examples): correct error label in the zoned_io_sync write path

The write loop calls xnvme_nvm_write() but reports failures as "xnvme_cmd_append()".

3. tests(cijoe): open the zoned example writes without the host page cache

The zoned_io_sync/zoned_io_async write examples submit sequentially at the write pointer, but without --direct the writes land in the page cache and ordering is left to writeback. When two contexts flush the same dirty range concurrently (close-time sync_blockdev plus udev re-probing the device), a single submission inversion makes zone write plugging fail every queued bio behind it — the tests still pass via the page cache while the kernel logs the errors. --direct 1 keeps the examples' single-submitter ordering intact all the way to the device. Multi-writer regular writes to a zone would still be unsafe with O_DIRECT; that would call for Zone Append and is out of scope.

Note the ordering dependency: commit 3 requires commit 1 — with zcap over-reported, the direct writes run past the writable capacity and fail with EIO (this is also how the zcap bug was found; buffered I/O swallowed the overflow silently).

## Verification

QEMU guest, debian trixie, kernel 6.12.94, same guest definition as CI:

- Before: zoned_io_async write (be=io_uring, buffered) and zoned_io_sync write (be=io_uring_bdev, buffered) pass with rc=0 while dmesg logs Buffer I/O error storms, roughly 1 in 2-5 runs.
- After: zone reports via admin=block return zcap 7168 (previously 8192, the zone size); both write tests with --direct 1 pass 10/10 iterations with zero dmesg errors.
- Each commit builds individually; meson test failure set is unchanged from main (43 pass / 14 fail, all pre-existing: enum without root, ramdisk_nil-bound async_intf/ioworker entries, lblk-pi --pract parsing).
