### PR TITLE
qublk: correct the FLUSH scope and follow-ups from the #755 review

### DIFF
--- a/cijoe/tests/tools/test_qublk.py
+++ b/cijoe/tests/tools/test_qublk.py
@@ -51,6 +51,40 @@ def test_run_multi_queue(cijoe, device, be_opts, cli_args):
 
 
 @xnvme_parametrize(labels=["nvm"], opts=["be"])
+def test_del_leftover(cijoe, device, be_opts, cli_args):
+    """SIGKILL the server, then recover the leftover device with 'qublk del'"""
+
+    script = "\n".join(
+        [
+            "set -u",
+            "modprobe ublk_drv || echo MODPROBE-FAILED",
+            f"if [ -b {UBLK_NODE} ]; then echo PREEXISTING-DEVICE; exit 1; fi",
+            "log=$(mktemp)",
+            f"qublk run {device['uri']} --be {be_opts['be']} --dev-id 0 > $log 2>&1 &",
+            "pid=$!",
+            f"for i in $(seq 1 50); do [ -b {UBLK_NODE} ] && break; sleep 0.2; done",
+            f"if [ ! -b {UBLK_NODE} ]; then echo MISSING-DEVICE; cat $log; "
+            "kill -INT $pid 2>/dev/null; exit 1; fi",
+            "kill -KILL $pid",
+            "wait $pid 2>/dev/null",
+            # The control-side device outlives the killed server; 'del' must
+            # remove it, and the char-device is the observable for that
+            "qublk del --dev-id 0",
+            "rc=$?",
+            "for i in $(seq 1 25); do [ -c /dev/ublkc0 ] || break; sleep 0.2; done",
+            "if [ -c /dev/ublkc0 ]; then echo LEFTOVER-DEVICE; rc=1; fi",
+            # A nonexistent identifier must fail rather than report success
+            "if qublk del --dev-id 999; then echo DEL-BOGUS-ID-PASSED; rc=1; fi",
+            "cat $log",
+            "rm -f $log",
+            "exit $rc",
+        ]
+    )
+    err, state = cijoe.run(f"bash -c '{script}'")
+    assert not err, state.output()
+
+
+@xnvme_parametrize(labels=["nvm"], opts=["be"])
 def test_run_max_io_bytes(cijoe, device, be_opts, cli_args):
     err, _ = qublk_session(
         cijoe,

--- a/docs/tools/qublk/index.rst
+++ b/docs/tools/qublk/index.rst
@@ -52,3 +52,14 @@ Example — user space NVMe via uPCIe, with multiple hardware queues::
    qublk run 0000:01:00.0 --be upcie --qdepth 64 --nqueues 4
 
 While **qublk** is running, ``/dev/ublkb0`` is the resulting block device.
+
+``del`` — Delete a leftover device
+==================================
+
+A ``qublk run`` that is killed rather than signalled cleanly leaves its ublk
+device behind. ``del`` stops and deletes such a device by identifier::
+
+   qublk del --dev-id 0
+
+.. literalinclude:: qublk_del_usage.out
+   :language: bash

--- a/docs/tools/qublk/qublk_del_usage.cmd
+++ b/docs/tools/qublk/qublk_del_usage.cmd
@@ -1,0 +1,1 @@
+qublk del --help

--- a/docs/tools/qublk/qublk_del_usage.out
+++ b/docs/tools/qublk/qublk_del_usage.out
@@ -1,0 +1,12 @@
+Usage: qublk del [<args>]
+
+Delete a ublk device left behind by a killed server
+  
+Where <args> include:
+
+  [ --dev-id NUM ]              ; Use given 'NUM' as device identifier
+  [ --help ]                    ; Show usage / help
+
+See 'qublk --help' for other commands
+
+qublk - ublk server backed by xNVMe -- ver: {major: 0, minor: 7, patch: 5}

--- a/docs/tools/qublk/qublk_usage.out
+++ b/docs/tools/qublk/qublk_usage.out
@@ -3,6 +3,7 @@ Usage: qublk <command> [<args>]
 Where <command> is one of:
 
   run              | Serve a ublk block-device backed by the given xNVMe device
+  del              | Delete a ublk device left behind by a killed server
 
 See 'qublk <command> --help' for the description of [<args>]
 

--- a/tools/qublk/ctrl.c
+++ b/tools/qublk/ctrl.c
@@ -148,8 +148,8 @@ qublk_ctrl_set_params(struct qublk_dev *dev)
 		.types = UBLK_PARAM_TYPE_BASIC,
 		.basic =
 			{
-				.attrs = dev->has_vwc ? (UBLK_ATTR_VOLATILE_CACHE | UBLK_ATTR_FUA)
-						      : 0,
+				.attrs = (dev->has_vwc ? UBLK_ATTR_VOLATILE_CACHE : 0) |
+					 ((dev->has_vwc && dev->has_fua) ? UBLK_ATTR_FUA : 0),
 				.logical_bs_shift = lba_shift,
 				.physical_bs_shift = lba_shift,
 				.io_opt_shift = lba_shift,

--- a/tools/qublk/io.c
+++ b/tools/qublk/io.c
@@ -130,7 +130,14 @@ on_xnvme_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
 	}
 
 	xnvme_queue_put_cmd_ctx(q->xq, ctx);
-	submit_commit_and_fetch(q, io, result);
+	// The ring holds one SQE per tag and each tag has at most one commit
+	// pending, so this cannot fail by sizing; if it does anyway, stop the
+	// device rather than leave the request uncommitted and the block
+	// layer waiting on it forever
+	if (submit_commit_and_fetch(q, io, result) < 0) {
+		fprintf(stderr, "qublk: q%d tag %u: no SQE for commit\n", q->q_id, io->tag);
+		q->dev->stop = 1;
+	}
 }
 
 static int

--- a/tools/qublk/io.c
+++ b/tools/qublk/io.c
@@ -25,36 +25,6 @@
 #define IORING_SETUP_DEFER_TASKRUN (1U << 13)
 #endif
 
-/*
- * io_uring CQE user_data convention:
- *   bit 63 clear -> ublk tag CQE; user_data is the tag (< depth)
- *   bit 63 set   -> cross-queue MSG_RING; encoded as:
- *                   bits 62-60: type (QUBLK_MSG_*)
- *                   bits 31-16: originating q_id
- *                   bits 15-0 : originating tag
- * The MSG_RING payload uses sqe->off (delivered as target cqe->user_data) for
- * the encoded id and sqe->len (delivered as target cqe->res) for status.
- */
-#define QUBLK_UD_MSG_BIT (1ULL << 63)
-#define QUBLK_MSG_TYPE_SHIFT 60
-#define QUBLK_MSG_TYPE_MASK 0x7ULL
-#define QUBLK_MSG_QID_SHIFT 16
-#define QUBLK_MSG_QID_MASK 0xFFFFULL
-#define QUBLK_MSG_TAG_MASK 0xFFFFULL
-
-enum {
-	QUBLK_MSG_SOURCE = 0,     /* source-side CQE for our outgoing MSG_RING */
-	QUBLK_MSG_DO_FLUSH = 1,   /* recipient: issue NVMe FLUSH for (orig_q, orig_tag) */
-	QUBLK_MSG_FLUSH_DONE = 2, /* originator: a remote FLUSH completed (res = status) */
-};
-
-static inline uint64_t
-ud_msg(unsigned type, uint16_t qid, uint16_t tag)
-{
-	return QUBLK_UD_MSG_BIT | ((uint64_t)type << QUBLK_MSG_TYPE_SHIFT) |
-	       ((uint64_t)qid << QUBLK_MSG_QID_SHIFT) | (uint64_t)tag;
-}
-
 static size_t
 page_round_up(size_t v)
 {
@@ -73,29 +43,13 @@ iod_stride(void)
 	return page_round_up((size_t)UBLK_MAX_QUEUE_DEPTH * sizeof(struct ublksrv_io_desc));
 }
 
-/*
- * Per iteration of io_loop we may queue, between submits: one
- * COMMIT_AND_FETCH per local tag, (nr_queues-1) outgoing MSG_RINGs per local
- * barrier op, and (nr_queues-1) FLUSH_DONE replies per remote-served flush.
- * Worst case is depth * (2 * nr_queues - 1) SQEs.
- */
-static unsigned
-ring_entries_for(const struct qublk_queue *q)
-{
-	unsigned nq = q->dev->nqueues;
-	unsigned entries = (unsigned)q->depth * (2 * nq - 1);
-
-	if (entries < (unsigned)q->depth) {
-		entries = q->depth;
-	}
-	return entries;
-}
-
 static int
 init_ring(struct qublk_queue *q)
 {
 	struct io_uring_params p = {0};
-	unsigned entries = ring_entries_for(q);
+	// Per iteration of io_loop we queue, between submits, at most one
+	// COMMIT_AND_FETCH per local tag
+	unsigned entries = q->depth;
 	int rc;
 
 	p.flags = IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN;
@@ -105,56 +59,6 @@ init_ring(struct qublk_queue *q)
 		rc = io_uring_queue_init_params(entries, &q->ring, &p);
 	}
 	return rc;
-}
-
-static int
-rflush_pool_init(struct qublk_dev *dev, struct qublk_queue *q)
-{
-	uint32_t n;
-
-	if (dev->nqueues <= 1) {
-		return 0;
-	}
-	n = (uint32_t)(dev->nqueues - 1) * q->depth;
-	q->rflush_pool = calloc(n, sizeof(*q->rflush_pool));
-	if (!q->rflush_pool) {
-		return -ENOMEM;
-	}
-	q->rflush_nr = n;
-	for (uint32_t i = 0; i < n; i++) {
-		q->rflush_pool[i].remote_q = q;
-		q->rflush_pool[i].next = q->rflush_free;
-		q->rflush_free = &q->rflush_pool[i];
-	}
-	return 0;
-}
-
-static void
-rflush_pool_fini(struct qublk_queue *q)
-{
-	free(q->rflush_pool);
-	q->rflush_pool = NULL;
-	q->rflush_free = NULL;
-	q->rflush_nr = 0;
-}
-
-static struct qublk_remote_flush *
-rflush_alloc(struct qublk_queue *q)
-{
-	struct qublk_remote_flush *rf = q->rflush_free;
-
-	if (rf) {
-		q->rflush_free = rf->next;
-		rf->next = NULL;
-	}
-	return rf;
-}
-
-static void
-rflush_release(struct qublk_queue *q, struct qublk_remote_flush *rf)
-{
-	rf->next = q->rflush_free;
-	q->rflush_free = rf;
 }
 
 static void
@@ -229,191 +133,6 @@ on_xnvme_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
 	submit_commit_and_fetch(q, io, result);
 }
 
-static void
-barrier_complete_iod(struct qublk_queue *q, struct qublk_io *io)
-{
-	int result;
-
-	if (io->barrier_err) {
-		result = io->barrier_err;
-	} else if (ublksrv_get_op(io->iod) == UBLK_IO_OP_WRITE) {
-		result = (int)(io->iod->nr_sectors << 9);
-	} else {
-		result = 0;
-	}
-	submit_commit_and_fetch(q, io, result);
-}
-
-static void
-on_local_barrier_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
-{
-	struct qublk_io *io = opaque;
-	struct qublk_queue *q = io->q;
-	int status = xnvme_cmd_ctx_cpl_status(ctx) ? -EIO : 0;
-
-	xnvme_queue_put_cmd_ctx(q->xq, ctx);
-	if (status && io->barrier_err == 0) {
-		io->barrier_err = status;
-	}
-	if (--io->barrier_outstanding == 0) {
-		barrier_complete_iod(q, io);
-	}
-}
-
-static void
-msg_post_flush_done(struct qublk_queue *q, uint16_t orig_qid, uint16_t orig_tag, int status)
-{
-	struct qublk_queue *orig = &q->dev->queues[orig_qid];
-	struct io_uring_sqe *sqe;
-
-	sqe = io_uring_get_sqe(&q->ring);
-	if (!sqe) {
-		fprintf(stderr, "qublk: q%d no SQE for FLUSH_DONE reply\n", q->q_id);
-		q->dev->stop = 1;
-		return;
-	}
-	io_uring_prep_msg_ring(sqe, orig->ring.ring_fd, status,
-			       ud_msg(QUBLK_MSG_FLUSH_DONE, 0, orig_tag), 0);
-	sqe->user_data = ud_msg(QUBLK_MSG_SOURCE, 0, 0);
-}
-
-static void
-on_remote_flush_complete(struct xnvme_cmd_ctx *ctx, void *opaque)
-{
-	struct qublk_remote_flush *rf = opaque;
-	struct qublk_queue *q = rf->remote_q;
-	uint16_t orig_qid = rf->orig_q_id;
-	uint16_t orig_tag = rf->orig_tag;
-	int status = xnvme_cmd_ctx_cpl_status(ctx) ? -EIO : 0;
-
-	xnvme_queue_put_cmd_ctx(q->xq, ctx);
-	rflush_release(q, rf);
-	msg_post_flush_done(q, orig_qid, orig_tag, status);
-}
-
-static void
-handle_msg_do_flush(struct qublk_queue *q, uint16_t orig_qid, uint16_t orig_tag)
-{
-	struct qublk_dev *dev = q->dev;
-	uint32_t nsid = xnvme_dev_get_nsid(dev->xdev);
-	struct qublk_remote_flush *rf;
-	struct xnvme_cmd_ctx *ctx;
-	int rc;
-
-	rf = rflush_alloc(q);
-	if (!rf) {
-		fprintf(stderr, "qublk: q%d remote-flush pool exhausted\n", q->q_id);
-		msg_post_flush_done(q, orig_qid, orig_tag, -ENOMEM);
-		return;
-	}
-	rf->orig_q_id = orig_qid;
-	rf->orig_tag = orig_tag;
-
-	for (;;) {
-		ctx = xnvme_queue_get_cmd_ctx(q->xq);
-		if (ctx) {
-			break;
-		}
-		if (dev->stop) {
-			rflush_release(q, rf);
-			msg_post_flush_done(q, orig_qid, orig_tag, -ENODEV);
-			return;
-		}
-		xnvme_queue_poke(q->xq, 0);
-	}
-	memset(&ctx->cmd, 0, sizeof(ctx->cmd));
-	xnvme_cmd_ctx_set_cb(ctx, on_remote_flush_complete, rf);
-	xnvme_prep_nvm(ctx, XNVME_SPEC_NVM_OPC_FLUSH, nsid, 0, 0);
-	rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
-	while (rc == -EBUSY || rc == -EAGAIN) {
-		xnvme_queue_poke(q->xq, 0);
-		rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
-	}
-	if (rc < 0) {
-		xnvme_queue_put_cmd_ctx(q->xq, ctx);
-		rflush_release(q, rf);
-		msg_post_flush_done(q, orig_qid, orig_tag, rc);
-	}
-}
-
-static void
-handle_msg_flush_done(struct qublk_queue *q, uint16_t orig_tag, int status)
-{
-	struct qublk_io *io;
-
-	if (orig_tag >= q->depth) {
-		fprintf(stderr, "qublk: q%d FLUSH_DONE: bogus tag %u\n", q->q_id, orig_tag);
-		return;
-	}
-	io = &q->ios[orig_tag];
-	if (status && io->barrier_err == 0) {
-		io->barrier_err = status;
-	}
-	if (--io->barrier_outstanding == 0) {
-		barrier_complete_iod(q, io);
-	}
-}
-
-static int
-dispatch_barrier(struct qublk_queue *q, struct qublk_io *io, uint8_t op)
-{
-	struct qublk_dev *dev = q->dev;
-	const struct ublksrv_io_desc *iod = io->iod;
-	uint32_t nsid = xnvme_dev_get_nsid(dev->xdev);
-	uint8_t lba_shift = dev->lba_shift;
-	struct xnvme_cmd_ctx *ctx;
-	int rc;
-
-	ctx = xnvme_queue_get_cmd_ctx(q->xq);
-	if (!ctx) {
-		return -EBUSY;
-	}
-	memset(&ctx->cmd, 0, sizeof(ctx->cmd));
-	xnvme_cmd_ctx_set_cb(ctx, on_local_barrier_complete, io);
-
-	if (op == UBLK_IO_OP_FLUSH) {
-		xnvme_prep_nvm(ctx, XNVME_SPEC_NVM_OPC_FLUSH, nsid, 0, 0);
-		rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
-	} else {
-		uint64_t slba = iod->start_sector >> (lba_shift - 9);
-		uint16_t nlb = (uint16_t)(((iod->nr_sectors << 9) >> lba_shift) - 1);
-		ctx->cmd.nvm.fua = 1;
-		rc = xnvme_nvm_write(ctx, nsid, slba, nlb, io->buf, NULL);
-	}
-	if (rc == -EBUSY || rc == -EAGAIN) {
-		xnvme_queue_put_cmd_ctx(q->xq, ctx);
-		return rc;
-	}
-	if (rc < 0) {
-		xnvme_queue_put_cmd_ctx(q->xq, ctx);
-		return submit_commit_and_fetch(q, io, rc);
-	}
-
-	io->barrier_outstanding = 1;
-	io->barrier_err = 0;
-
-	for (uint16_t r = 0; r < dev->nqueues; r++) {
-		struct qublk_queue *rq;
-		struct io_uring_sqe *sqe;
-
-		if (r == q->q_id) {
-			continue;
-		}
-		rq = &dev->queues[r];
-		sqe = io_uring_get_sqe(&q->ring);
-		if (!sqe) {
-			fprintf(stderr, "qublk: q%d no SQE for MSG_RING fan-out\n", q->q_id);
-			dev->stop = 1;
-			return -ENOSPC;
-		}
-		io_uring_prep_msg_ring(sqe, rq->ring.ring_fd, 0,
-				       ud_msg(QUBLK_MSG_DO_FLUSH, q->q_id, io->tag), 0);
-		sqe->user_data = ud_msg(QUBLK_MSG_SOURCE, 0, 0);
-		io->barrier_outstanding++;
-	}
-	return 0;
-}
-
 static int
 dispatch(struct qublk_queue *q, struct qublk_io *io)
 {
@@ -444,11 +163,6 @@ dispatch(struct qublk_queue *q, struct qublk_io *io)
 		}
 	}
 
-	if (op == UBLK_IO_OP_FLUSH ||
-	    (op == UBLK_IO_OP_WRITE && (iod->op_flags & UBLK_IO_F_FUA))) {
-		return dispatch_barrier(q, io, op);
-	}
-
 	ctx = xnvme_queue_get_cmd_ctx(q->xq);
 	if (!ctx) {
 		return -EBUSY;
@@ -463,6 +177,18 @@ dispatch(struct qublk_queue *q, struct qublk_io *io)
 	xnvme_cmd_ctx_set_cb(ctx, on_xnvme_complete, io);
 
 	switch (op) {
+	case UBLK_IO_OP_FLUSH:
+		/*
+		 * A flush applies to all commands the controller completed
+		 * prior to its submission, regardless of which submission
+		 * queue carried them (NVMe Base Specification, "Flush"), and
+		 * the block layer issues a flush only after the writes it
+		 * covers have completed. One FLUSH on the local queue
+		 * therefore covers writes completed on every queue.
+		 */
+		xnvme_prep_nvm(ctx, XNVME_SPEC_NVM_OPC_FLUSH, nsid, 0, 0);
+		rc = xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
+		break;
 	case UBLK_IO_OP_READ:
 		slba = iod->start_sector >> (lba_shift - 9);
 		nlb = (uint16_t)(((iod->nr_sectors << 9) >> lba_shift) - 1);
@@ -471,6 +197,9 @@ dispatch(struct qublk_queue *q, struct qublk_io *io)
 	case UBLK_IO_OP_WRITE:
 		slba = iod->start_sector >> (lba_shift - 9);
 		nlb = (uint16_t)(((iod->nr_sectors << 9) >> lba_shift) - 1);
+		if (iod->op_flags & UBLK_IO_F_FUA) {
+			ctx->cmd.nvm.fua = 1;
+		}
 		rc = xnvme_nvm_write(ctx, nsid, slba, nlb, io->buf, NULL);
 		break;
 	default:
@@ -522,42 +251,6 @@ handle_ublk_cqe(struct qublk_queue *q, struct io_uring_cqe *cqe)
 	return 0;
 }
 
-static void
-handle_msg_cqe(struct qublk_queue *q, uint64_t ud, int res)
-{
-	unsigned type = (unsigned)((ud >> QUBLK_MSG_TYPE_SHIFT) & QUBLK_MSG_TYPE_MASK);
-	uint16_t qid = (uint16_t)((ud >> QUBLK_MSG_QID_SHIFT) & QUBLK_MSG_QID_MASK);
-	uint16_t tag = (uint16_t)(ud & QUBLK_MSG_TAG_MASK);
-
-	switch (type) {
-	case QUBLK_MSG_SOURCE:
-		if (res < 0) {
-			fprintf(stderr, "qublk: q%d MSG_RING source CQE err=%d\n", q->q_id, res);
-			q->dev->stop = 1;
-		}
-		break;
-	case QUBLK_MSG_DO_FLUSH:
-		handle_msg_do_flush(q, qid, tag);
-		break;
-	case QUBLK_MSG_FLUSH_DONE:
-		handle_msg_flush_done(q, tag, res);
-		break;
-	default:
-		fprintf(stderr, "qublk: q%d unknown msg type %u\n", q->q_id, type);
-		break;
-	}
-}
-
-static void
-handle_cqe(struct qublk_queue *q, struct io_uring_cqe *cqe)
-{
-	if (cqe->user_data & QUBLK_UD_MSG_BIT) {
-		handle_msg_cqe(q, cqe->user_data, cqe->res);
-	} else {
-		handle_ublk_cqe(q, cqe);
-	}
-}
-
 static int
 queue_init(struct qublk_dev *dev, struct qublk_queue *q, int q_id, int ublkc_fd)
 {
@@ -606,12 +299,6 @@ queue_init(struct qublk_dev *dev, struct qublk_queue *q, int q_id, int ublkc_fd)
 		return rc;
 	}
 
-	rc = rflush_pool_init(dev, q);
-	if (rc < 0) {
-		fprintf(stderr, "rflush_pool_init(q%d): %s\n", q_id, strerror(-rc));
-		return rc;
-	}
-
 	return 0;
 }
 
@@ -623,7 +310,6 @@ queue_fini(struct qublk_dev *dev, struct qublk_queue *q)
 		xnvme_queue_term(q->xq);
 		q->xq = NULL;
 	}
-	rflush_pool_fini(q);
 	if (q->ios) {
 		for (uint16_t t = 0; t < q->depth; t++) {
 			if (q->ios[t].buf) {
@@ -738,12 +424,12 @@ io_loop(struct qublk_queue *q)
 		 * NVMe completions can only arrive while commands are in flight,
 		 * and the upcie backend has no completion fd to wait on -- so we
 		 * must busy-poll the xnvme queue whenever it has outstanding work.
-		 * When it is empty, the only events that can wake us are a new
-		 * ublk request (FETCH) or a peer queue's barrier MSG_RING, both of
-		 * which post to this ring's fd; block on it instead of spinning so
-		 * an idle queue does not pin a core away from the application. The
-		 * wait is bounded so the loop re-checks dev->stop -- shutdown sets
-		 * the flag from another thread without posting a CQE here.
+		 * When it is empty, the only event that can wake us is a new
+		 * ublk request (FETCH), which posts to this ring's fd; block on
+		 * it instead of spinning so an idle queue does not pin a core
+		 * away from the application. The wait is bounded so the loop
+		 * re-checks dev->stop -- shutdown sets the flag from another
+		 * thread without posting a CQE here.
 		 */
 		if (xnvme_queue_get_outstanding(q->xq) == 0) {
 			io_uring_submit_and_wait_timeout(&q->ring, &cqe, 1, &idle_ts, NULL);
@@ -754,7 +440,7 @@ io_loop(struct qublk_queue *q)
 		count = 0;
 		io_uring_for_each_cqe(&q->ring, head, cqe)
 		{
-			handle_cqe(q, cqe);
+			handle_ublk_cqe(q, cqe);
 			count++;
 		}
 		if (count) {
@@ -775,7 +461,7 @@ io_loop(struct qublk_queue *q)
 			// Dispatch rather than discard; STOP_DEV waits on requests
 			// in flight, and one delivered after 'stop' was set would
 			// otherwise never be committed
-			handle_cqe(q, cqe);
+			handle_ublk_cqe(q, cqe);
 			count++;
 		}
 		if (count) {

--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -234,6 +234,40 @@ err_xdev:
 	return -EIO;
 }
 
+static int
+sub_del(struct xnvme_cli *cli)
+{
+	struct qublk_dev dev = {
+		.ctrl_fd = -1,
+	};
+	int rc;
+
+	if (!cli->given[XNVME_CLI_OPT_DEV_ID]) {
+		xnvme_cli_perr("Error: --dev-id is required", -EINVAL);
+		return -EINVAL;
+	}
+	if (cli->args.dev_id >= (1u << 20)) {
+		xnvme_cli_perr("Error: --dev-id is out of range", -EINVAL);
+		return -EINVAL;
+	}
+	dev.dev_id = (int)cli->args.dev_id;
+
+	rc = qublk_ctrl_open(&dev);
+	if (rc < 0) {
+		return rc;
+	}
+	// A device left behind by a killed server is usually still live; STOP_DEV
+	// makes the kernel abort its pending requests so DEL_DEV can proceed. On a
+	// device that is already stopped it fails, which is fine to ignore.
+	qublk_ctrl_stop_dev(&dev);
+	rc = qublk_ctrl_del_dev(&dev);
+	qublk_ctrl_close(&dev);
+	if (rc == 0) {
+		fprintf(stderr, "qublk: deleted ublk dev id=%d\n", dev.dev_id);
+	}
+	return rc;
+}
+
 static struct xnvme_cli_sub g_subs[] = {
 	{
 		"run",
@@ -251,6 +285,16 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_HOMI_ID, XNVME_CLI_LOPT},
+		},
+	},
+	{
+		"del",
+		"Delete a ublk device left behind by a killed server",
+		"Delete a ublk device left behind by a killed server",
+		sub_del,
+		{
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_DEV_ID, XNVME_CLI_LOPT},
 		},
 	},
 };

--- a/tools/qublk/main.c
+++ b/tools/qublk/main.c
@@ -25,6 +25,48 @@
 #define QUBLK_DEFAULT_DEV_ID (-1) ///< Let the kernel assign the ublk device identifier
 #define QUBLK_DEFAULT_MAX_IO_CAP (1u << 20)
 
+static int
+id_in(const char *id, const char **set, size_t n)
+{
+	for (size_t i = 0; id && i < n; i++) {
+		if (!strcmp(id, set[i])) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+/*
+ * Whether the resolved backend delivers the NVMe 'fua' bit to the device:
+ * io_uring and libaio map it to RWF_DSYNC, the passthru async backends carry
+ * the command verbatim, and emu/thrpool delegate each command to the sync
+ * layer, so there it depends on the sync implementation being a passthru --
+ * psync and block issue a plain pwrite() and drop the bit.
+ */
+static uint8_t
+backend_honours_fua(const struct xnvme_dev *xdev)
+{
+	static const char *async_honours[] = {
+		"io_uring", "libaio", "io_uring_cmd", "spdk", "libvfn", "upcie",
+	};
+	static const char *sync_passthru[] = {
+		"nvme",
+		"spdk",
+		"libvfn",
+		"upcie",
+	};
+	const struct xnvme_opts *opts = xnvme_dev_get_opts(xdev);
+
+	if (id_in(opts->async, async_honours, sizeof(async_honours) / sizeof(*async_honours))) {
+		return 1;
+	}
+	if (opts->async && (!strcmp(opts->async, "emu") || !strcmp(opts->async, "thrpool"))) {
+		return (uint8_t)id_in(opts->sync, sync_passthru,
+				      sizeof(sync_passthru) / sizeof(*sync_passthru));
+	}
+	return 0;
+}
+
 static uint8_t
 lba_shift_of(uint32_t lba_nbytes)
 {
@@ -112,6 +154,7 @@ sub_run(struct xnvme_cli *cli)
 		const struct xnvme_spec_idfy_ctrlr *ctrlr = xnvme_dev_get_ctrlr(dev.xdev);
 		dev.has_vwc = ctrlr ? (uint8_t)ctrlr->vwc.present : 1;
 	}
+	dev.has_fua = backend_honours_fua(dev.xdev);
 
 	cap_max = dev.geo->mdts_nbytes ? dev.geo->mdts_nbytes : QUBLK_DEFAULT_MAX_IO_CAP;
 	dev.max_io_buf = want_max_io

--- a/tools/qublk/qublk.h
+++ b/tools/qublk/qublk.h
@@ -51,6 +51,7 @@ struct qublk_dev {
 	const struct xnvme_geo *geo;
 	uint8_t lba_shift;
 	uint8_t has_vwc;
+	uint8_t has_fua;
 	struct qublk_queue *queues;
 	sem_t io_ready;
 	volatile sig_atomic_t stop;

--- a/tools/qublk/qublk.h
+++ b/tools/qublk/qublk.h
@@ -24,21 +24,6 @@ struct qublk_io {
 	void *buf;
 	const struct ublksrv_io_desc *iod;
 	struct qublk_queue *q;
-	/*
-	 * NVMe orders FLUSH/FUA only within a single submission queue, so
-	 * FLUSH and FUA writes fan a per-namespace FLUSH out to every xnvme
-	 * queue and the ublk IOD is committed only after all sub-ops have
-	 * landed. Touched only by the originating queue's I/O thread.
-	 */
-	int barrier_outstanding;
-	int barrier_err;
-};
-
-struct qublk_remote_flush {
-	struct qublk_queue *remote_q;
-	uint16_t orig_q_id;
-	uint16_t orig_tag;
-	struct qublk_remote_flush *next;
 };
 
 struct qublk_queue {
@@ -51,9 +36,6 @@ struct qublk_queue {
 	struct xnvme_queue *xq;
 	struct qublk_io *ios;
 	struct qublk_dev *dev;
-	struct qublk_remote_flush *rflush_pool;
-	struct qublk_remote_flush *rflush_free;
-	uint32_t rflush_nr;
 	pthread_t tid;
 	int init_rc;
 };


### PR DESCRIPTION
This picks up the qublk items deferred to #757 out of the #755 review: items 9 through 13. The headline change reverses the cross-queue FLUSH fan-out; as discussed offline with @karlowich, going with the simplification is the agreed direction.

Four commits, each building and passing on its own:

1. refactor(tools/qublk): flush only the local queue (item 9, and item 10 with it)

The fan-out assumed a FLUSH covers only writes submitted on the same NVMe submission queue. The NVMe Base Specification scopes it wider: a flush applies to all commands completed by the controller prior to the submission of the flush, with no submission-queue qualifier (Base Spec 2.3, section 7.2 "Flush command"). The block layer, in turn, issues a flush only after the writes it covers have completed. A single FLUSH on the queue that received the ublk request therefore gives the same guarantee the fan-out did. This removes the remote-flush pool, the MSG_RING encoding and handlers, and the barrier counters (-355 lines); FLUSH and FUA writes dispatch like any other command. With at most one COMMIT_AND_FETCH per local tag between submits, the ring drops the depth * (2 * nqueues - 1) worst-case sizing, which also dissolves item 10: the io_uring_setup() entry-limit overflow that --nqueues 16 --qdepth 2048 used to hit can no longer be constructed.

2. fix(tools/qublk): stop the device when a commit SQE cannot be queued (item 11)

on_xnvme_complete() discarded the return of submit_commit_and_fetch(). Unreachable with the ring sized at one SQE per tag, but if the invariant is ever broken, fail loudly instead of leaving a ublk request uncommitted and the block layer waiting forever.

3. fix(tools/qublk): advertise FUA only when the backend honours it (item 12)

UBLK_ATTR_FUA was gated on the namespace reporting a volatile write cache, but whether the fua bit reaches the device depends on the backend: io_uring and libaio map it to RWF_DSYNC, the passthru backends carry the command verbatim, while psync- and block-backed paths issue a plain pwrite() and drop it. The attribute now derives from the resolved async/sync implementations; UBLK_ATTR_VOLATILE_CACHE stays gated on the write cache alone.

4. feat(tools/qublk): add a del sub-command (item 13)

qublk del --dev-id N recovers a device left behind by a killed server: STOP_DEV so the kernel aborts requests pending against the dead daemon, then DEL_DEV. Documented in docs/tools/qublk.

## Verification

QEMU guest (debian trixie, kernel 6.12.94, /dev/nvme3n1), since the cijoe qublk suite still needs a ublk-capable CI environment (items 14/15, not in scope here):

- io_uring backend: /sys/block/ublkbN/queue/fua reads 1; 4 MiB O_DIRECT write/read round-trip compares equal; clean teardown on SIGTERM.
- FUA gating: thrpool_bdev (sync=block) advertises fua 0, thrpool (sync=nvme) advertises fua 1 — matching what each path delivers.
- Multi-queue FLUSH path: with --nqueues 4, mkfs.ext4, mount, 8 MiB write with fsync, sync, umount, remount and read back all pass.
- del: after kill -9 the control-side device remains (the kernel tears down the block node when the daemon dies); qublk del --dev-id N removes it, and a nonexistent id fails with No such device.
- All four commits build individually; clang-format clean.

After this lands, the #757 items still open are 3 (the live-IOPOLL half), 5, 6, 7, 8, 14 and 15.
