### PR TITLE
fix(be/linux): correct the debug message in the zone-capacity fallback

### DIFF
--- a/lib/xnvme_be_linux_block.c
+++ b/lib/xnvme_be_linux_block.c
@@ -108,7 +108,7 @@ _lzbd_zone_capacity(struct blk_zone_report *hdr, struct blk_zone *blkz)
 static uint64_t
 _lzbd_zone_capacity(struct blk_zone_report *XNVME_UNUSED(hdr), struct blk_zone *blkz)
 {
-	XNVME_DEBUG("FAILED: nosys ioctl(BLK_ZONE_REP_CAPACITY)");
+	XNVME_DEBUG("INFO: struct blk_zone has no capacity member; using len");
 	return blkz->len;
 }
 #endif


### PR DESCRIPTION
Follow-up to the #773 review (https://github.com/xnvme/xnvme/pull/773#discussion_r3955226906): since the guard became a meson probe for the capacity member of struct blk_zone, the fallback branch is taken when the build headers lack the member, not when an ioctl is missing. The message now says so, with the wording @safl suggested.

Verified by building with the guard inverted so the fallback branch actually compiles, then building normally; clang-format clean.