### PR TITLE
ci(cijoe): install the test-suite dependencies when provisioning a guest

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -904,7 +904,7 @@ jobs:
         --monitor \
         --config "configs/${{ matrix.hostname }}.toml" \
         --output "${{ github.job }}-${{ matrix.hostname }}-provision-xnvme" \
-        xnvme_source_sync xnvme_build_prep xnvme_build xnvme_install \
+        xnvme_source_sync xnvme_build_prep test_deps xnvme_build xnvme_install \
         ldconfig xnvme_bindings_py_install_tgz fio_prep
 
     - name: CIJOE, run tests

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ guest-provision:
 		-l \
 		xnvme_source_sync \
 		xnvme_build_prep \
+		test_deps \
 		xnvme_build \
 		xnvme_install \
 		ldconfig \

--- a/cijoe/workflows/provision-maas-using-tgz.yaml
+++ b/cijoe/workflows/provision-maas-using-tgz.yaml
@@ -55,9 +55,11 @@ steps:
   run: |
     hostname
 
+# xfsprogs is a test-suite dependency, not a build/run one: the
+# filesystem-level qublk cases format with XFS
 - name: packages_extra
   run: |
-    apt-get install -qy dmidecode patchelf || true
+    apt-get install -qy dmidecode patchelf xfsprogs || true
     pkg install -y dmidecode patchelf || true
 
 - name: xnvme_source_sync

--- a/cijoe/workflows/provision-using-tgz.yaml
+++ b/cijoe/workflows/provision-using-tgz.yaml
@@ -55,6 +55,13 @@ steps:
   with:
     xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'
 
+# Dependencies of the test-suite, as opposed to the build/run dependencies
+# installed by xnvme_build_prep; the guard is for the FreeBSD guests this
+# workflow also provisions. The filesystem-level qublk cases format with XFS.
+- name: test_deps
+  run: |
+    if command -v apt-get > /dev/null; then apt-get -qy install xfsprogs; fi
+
 - name: xnvme_build
   uses: xnvme_build
   with:


### PR DESCRIPTION
Item 15 of #757 turns out to be further along than the issue text says: the block-level qublk cases already run and pass on the trixie-iommu_enabled guest (27 passed on main run 34320608759). What still skips is the filesystem level: all 45 test_qublk_fs.py cases, because the guest has no mkfs.xfs.

Reworked per the review: instead of adding xfsprogs to toolbox/pkgs (whose lists feed the toolchain documentation and describe build/run dependencies of the library and tools), a guarded test_deps step now follows xnvme_build_prep in provision-using-tgz.yaml and its MAAS twin, exactly as suggested. The apt-get guard covers the FreeBSD guests the same workflows provision.

Verified against a local guest booted from the same nosi image: with xfsprogs removed, running only the test_deps step of provision-using-tgz.yaml installs it (skipped steps confirmed inert -- the guest was not re-imaged), and mkfs.xfs is present afterwards, which is exactly the guard test_qublk_fs.py skips on. This PR's own verify jobs exercise the step for real.