### PR TITLE
fix(be): keep the nil stub from winning ramdisk auto-selection, and repair the meson test-suite

### DIFF
--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -1783,7 +1783,7 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 		args->pid = num;
 		break;
 	case XNVME_CLI_OPT_PRACT:
-		args->pract = true;
+		args->pract = num != 0;
 		break;
 	case XNVME_CLI_OPT_PRCHK:
 		args->prchk = num;

--- a/lib/xnvme_platform_freebsd.c
+++ b/lib/xnvme_platform_freebsd.c
@@ -273,9 +273,9 @@ struct xnvme_platform g_xnvme_platform_freebsd = {
 			&g_xnvme_be_freebsd_emu_nvme,
 			&g_xnvme_be_freebsd_nil_nvme,
 #ifdef XNVME_BE_RAMDISK_ENABLED
-			&g_xnvme_be_ramdisk_nil,
-			&g_xnvme_be_ramdisk_thrpool,
 			&g_xnvme_be_ramdisk_emu,
+			&g_xnvme_be_ramdisk_thrpool,
+			&g_xnvme_be_ramdisk_nil,
 #endif
 			NULL,
 		},

--- a/lib/xnvme_platform_linux.c
+++ b/lib/xnvme_platform_linux.c
@@ -398,9 +398,9 @@ struct xnvme_platform g_xnvme_platform_linux = {
 			&g_xnvme_be_linux_aio_file,
 #endif
 #ifdef XNVME_BE_RAMDISK_ENABLED
-			&g_xnvme_be_ramdisk_nil,
-			&g_xnvme_be_ramdisk_thrpool,
 			&g_xnvme_be_ramdisk_emu,
+			&g_xnvme_be_ramdisk_thrpool,
+			&g_xnvme_be_ramdisk_nil,
 #endif
 			NULL,
 		},

--- a/lib/xnvme_platform_macos.c
+++ b/lib/xnvme_platform_macos.c
@@ -180,9 +180,9 @@ struct xnvme_platform g_xnvme_platform_macos = {
 			&g_xnvme_be_driverkit_native,
 			&g_xnvme_be_driverkit_emu,
 #ifdef XNVME_BE_RAMDISK_ENABLED
-			&g_xnvme_be_ramdisk_nil,
-			&g_xnvme_be_ramdisk_thrpool,
 			&g_xnvme_be_ramdisk_emu,
+			&g_xnvme_be_ramdisk_thrpool,
+			&g_xnvme_be_ramdisk_nil,
 #endif
 			NULL,
 		},

--- a/lib/xnvme_platform_windows.c
+++ b/lib/xnvme_platform_windows.c
@@ -139,9 +139,9 @@ struct xnvme_platform g_xnvme_platform_windows = {
 			&g_xnvme_be_windows_thrpool_fs,
 #endif
 #ifdef XNVME_BE_RAMDISK_ENABLED
-			&g_xnvme_be_ramdisk_nil,
-			&g_xnvme_be_ramdisk_thrpool,
 			&g_xnvme_be_ramdisk_emu,
+			&g_xnvme_be_ramdisk_thrpool,
+			&g_xnvme_be_ramdisk_nil,
 #endif
 			NULL,
 		},

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -22,7 +22,7 @@ tools = {
     ['write', ['write', '1GB', '--slba', '0x0', '--nlb', '0']],
     ['write-zeros', ['write-zeros', '1GB', '--slba', '0x0', '--nlb', '0']],
     ['write-dir', ['write-dir', '1GB', '--slba', '0x0', '--nlb', '7']], 
-    ['write-read-pi, prchk not set', ['write-read-pi', '1GB', '--slba', '0x0', '--nlb', '8', '--pract', '0x0']], 
+    ['write-read-pi, prchk not set', ['write-read-pi', '1GB', '--slba', '0x0', '--nlb', '8', '--pract', '1']],
     ['write-read-pi, prchk=0x4', ['write-read-pi', '1GB', '--slba', '0x0', '--nlb', '0', '--pract', '1', '--prchk', '0x4']], 
     ['write-read-pi, prchk=0x5', ['write-read-pi', '1GB', '--slba', '0x0', '--nlb', '0', '--pract', '1', '--prchk', '0x5']], 
   ],


### PR DESCRIPTION
This picks up item 6 of #757: the default meson test-suite fails on every run, on unmodified main, and no CI job notices.

Root cause: every platform lists g_xnvme_be_ramdisk_nil first in its ramdisk group, so opening a ramdisk URI with no explicit backend options auto-selects the nil async interface -- a no-op stub that completes nothing. The async_intf and ioworker entries open "1GB" exactly that way, so 11 of the 14 standing failures are this one selection. The same arrays already handle this correctly for the NVMe char-device group, where emu probes first and the nil config sits last; commit 1 mirrors that order (emu, thrpool, nil) for the ramdisk group on all four platforms. Explicit selection is unaffected -- the cijoe combinations address ramdisk_emu and ramdisk_thrpool by name.

Chasing the remaining non-root failure surfaced two more small defects, fixed separately:

- fix(cli): --pract is declared as taking a number, but the handler set pract to true on mere presence, so "--pract 0" enabled PRACT instead of disabling it.
- tests(tools): the "prchk not set" lblk entry passed "--pract 0x0", which never parsed (the option is base-10) -- and pract 0 cannot run on the meson ramdisk at all, since the host-side PI path is rejected on a namespace without a PI format. The entry now passes "--pract 1" and exercises the same plain write-read path as its prchk siblings.

## Verification

meson test on main: 43 pass / 14 fail. With these three commits: 55 pass / 2 fail; the two remaining are the enum entries, which need root for device enumeration. xnvme library-info confirms auto-selection now resolves ramdisk_emu, and the ioworker verify entries do real data round-trips (write, read-back, compare) instead of EIO. Each commit builds individually; clang-format clean.

## Open question

Since no workflow runs meson test, this suite could regress again without anyone noticing. Do you want a CI job for it (it needs no privileges beyond what the failing enum entries want, which could stay excluded), or is the cijoe matrix considered the authoritative gate? Happy to follow up either way.
