### PR TITLE
tests(cijoe): stop test_del_leftover from deadlocking the guest, and bound hung guest tests

### DIFF
--- a/cijoe/tests/tools/test_qublk.py
+++ b/cijoe/tests/tools/test_qublk.py
@@ -65,6 +65,17 @@ def test_del_leftover(cijoe, device, be_opts, cli_args):
             f"for i in $(seq 1 50); do [ -b {UBLK_NODE} ] && break; sleep 0.2; done",
             f"if [ ! -b {UBLK_NODE} ]; then echo MISSING-DEVICE; cat $log; "
             "kill -INT $pid 2>/dev/null; exit 1; fi",
+            # The node exists before the kernel is done with the new disk:
+            # add_disk() creates it and then reads its partition table, and
+            # that read goes through the ublk queue from the server's own
+            # io-wq thread, since START_DEV is a uring_cmd punted there. A
+            # server killed inside that window cannot serve the read, its
+            # exit waits for the thread, the thread waits for the read, and
+            # udev's probe waits for the disk: D state until the guest is
+            # rebooted. Wait for udev, whose probe queues behind the scan,
+            # and open the node once ourselves before pulling the plug.
+            "udevadm settle --timeout=10 || true",
+            f"blockdev --getsize64 {UBLK_NODE} > /dev/null",
             "kill -KILL $pid",
             "wait $pid 2>/dev/null",
             # The control-side device outlives the killed server; 'del' must

--- a/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
@@ -26,12 +26,12 @@ steps:
 - name: test_upcie
   uses: core.testrunner
   with:
-    args: '-k "(upcie or spdk) and not fabrics" tests'
+    args: '-k "(upcie or spdk) and not fabrics" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: test_mproc
   uses: core.testrunner
   with:
     # Excluded from multi-process mode: kvs, dual_be and qublk (have no --shm_id)
-    args: '-k "(upcie or spdk) and not (fabrics or kvs or dual_be or qublk)" tests --shm_id 1'
+    args: '-k "(upcie or spdk) and not (fabrics or kvs or dual_be or qublk)" tests --shm_id 1 --timeout=1800 --timeout-method=thread'
     random_order: false

--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
@@ -33,24 +33,24 @@ steps:
 - name: test_ramdisk
   uses: core.testrunner
   with:
-    args: '-k "ramdisk" tests'
+    args: '-k "ramdisk" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: test_os
   uses: core.testrunner
   with:
-    args: '-k "(not ramdisk) and (not pcie) and (not upcie) and (not fabrics)" tests'
+    args: '-k "(not ramdisk) and (not pcie) and (not upcie) and (not fabrics)" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
-    args: '-k "pcie" tests'
+    args: '-k "pcie" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: test_mproc
   uses: core.testrunner
   with:
     # Excluded from multi-process mode: kvs, dual_be and qublk (have no --shm_id)
-    args: '-k "pcie and not (upcie or fabrics or kvs or dual_be or qublk)" tests --shm_id 1'
+    args: '-k "pcie and not (upcie or fabrics or kvs or dual_be or qublk)" tests --shm_id 1 --timeout=1800 --timeout-method=thread'
     random_order: false

--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-tcp-spdk.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-tcp-spdk.yaml
@@ -17,7 +17,7 @@ steps:
 - name: test_transport_tcp
   uses: core.testrunner
   with:
-    args: '-k "fabrics" tests'
+    args: '-k "fabrics" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: nvme_target_stop

--- a/cijoe/workflows/test-freebsd-14-pcie.yaml
+++ b/cijoe/workflows/test-freebsd-14-pcie.yaml
@@ -19,17 +19,17 @@ steps:
 - name: test_ramdisk
   uses: core.testrunner
   with:
-    args: '-k "ramdisk" tests'
+    args: '-k "ramdisk" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: test_os
   uses: core.testrunner
   with:
-    args: '-k "(not ramdisk) and (not pcie) and (not fabrics)" tests'
+    args: '-k "(not ramdisk) and (not pcie) and (not fabrics)" tests --timeout=1800 --timeout-method=thread'
     random_order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
-    args: '-k "pcie" tests'
+    args: '-k "pcie" tests --timeout=1800 --timeout-method=thread'
     random_order: false


### PR DESCRIPTION
Two changes for the verify job that ran for two and a half hours on #777
before it was cancelled (run 34452089397, test_pcie on trixie-iommu_enabled).

The guest serial console in that run shows three tasks in D state: the
`qublk` server exiting after SIGKILL, waiting in `io_wq_put_and_exit()` for
its io-wq thread; that thread in `blkdev_release()` waiting for a folio of
the ublk disk; and a udev worker in `bdev_open()` waiting for
`disk->open_mutex`. That is `test_del_leftover`: it kills the server as soon
as `/dev/ublkb0` exists, and the node exists before `add_disk()` has scanned
the disk for partitions. The scan runs on the server's io-wq thread because
`UBLK_U_CMD_START_DEV` is punted there, and its read of the partition table
goes through the ublk queue, which only the killed server could serve.
The kernel guards the normal completion path against this (the bottom-half
trick in `__ublk_complete_rq()`, CVE-2025-68823) but not the abort path a
dying server takes. What to read closely is the barrier added before the
SIGKILL and whether waiting for udev plus one open of the node is enough of
one; the second commit bounds each guest test with pytest-timeout so a hang
of this kind fails the step in half an hour with the console attached.

Verification: the deadlock is a timing window of a few milliseconds after
device creation, so a full test_pcie pass does not reproduce it on demand.
It was reproduced in the trixie CI guest (kernel 6.12.94) with a loop over
the killed-server sequence polling for the node every 5 ms: without the
barrier the guest deadlocked within the first ten iterations, with the io-wq
thread in `read_part_sector()` under `disk_scan_partitions()` and the server
in `io_wq_put_and_exit()`, the same deadlock as the CI console one frame
earlier in the scan; with the barrier 100 of 100 iterations completed in
under a minute. CI does not exercise the timeout path; it was checked by
hand with a test that sleeps past the limit, which pytest-timeout ended at
the limit with the step failing. The FreeBSD workflow change is only read,
not run.
