### PR TITLE
tests(cijoe): reset a zoned block device through the block layer before writing it

### DIFF
--- a/cijoe/tests/apps/test_fio.py
+++ b/cijoe/tests/apps/test_fio.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from ..conftest import get_osname, get_shm_id, xnvme_parametrize
+from ..conftest import get_osname, get_shm_id, xnvme_parametrize, zoned_bdev_reset
 from .fio_fancy import fio_fancy
 
 FIO_OUTPUT_FPATH = (
@@ -95,6 +95,10 @@ def test_fio_engine_zns(cijoe, device, be_opts, cli_args):
 
     size = "64M"
     # size = "1G"
+
+    # fio resets the zones it writes through the NVMe admin path, which the
+    # block layer does not see; see zoned_bdev_reset()
+    zoned_bdev_reset(cijoe, device)
 
     err, _ = fio_fancy(
         cijoe,

--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -315,6 +315,33 @@ def device(cijoe, request):
     return request.param
 
 
+def zoned_bdev_reset(cijoe, device):
+    """
+    Reset the zones of a zoned block device through the block layer
+
+    Since Linux 6.10 the block layer keeps a write pointer per zone of its own
+    and fails a write that does not start at it. Tests reset and write zones
+    through the character device and through user-space drivers as well, which
+    the block layer does not see, so a zone can be empty on the device while the
+    kernel still holds the pointer from the last write it issued itself; the
+    next write through the block device at the zone's start then fails with EIO
+    although the device would take it. A reset through the block device brings
+    the two back in line; a test that writes a zoned block device calls this
+    first, so it starts from zones the kernel knows to be empty. Tests that only
+    read leave the zones as they find them, since what they read is what an
+    earlier test wrote. Nothing to do for a character device or a user-space
+    driver, whose writes never meet the block layer's pointers.
+    """
+
+    labels = device.get("labels", [])
+    if "zns" not in labels or "bdev" not in labels or get_osname() != "linux":
+        return
+
+    err, _ = cijoe.run(f"blkzone reset {device['uri']}")
+    if err:
+        pytest.fail(f"blkzone reset {device['uri']} failed: err({err})")
+
+
 def xnvme_parametrize(labels, opts):
     """
     This decorator provides all the pytest-parametrization magic in one.

--- a/cijoe/tests/examples/test_zoned_io_async.py
+++ b/cijoe/tests/examples/test_zoned_io_async.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import get_osname, xnvme_parametrize, zoned_bdev_reset
 
 
 @xnvme_parametrize(labels=["zns"], opts=["be", "admin", "async"])
@@ -13,6 +13,9 @@ def test_write(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="Freebsd kernel doesn't support zns")
     # Buffered writes to a zoned block device are flushed by the page cache with no
     # write-pointer ordering guarantee; bypass it to keep the writes sequential.
+    # The example resets the zone through the NVMe admin path where admin=nvme,
+    # which the block layer does not see; see zoned_bdev_reset()
+    zoned_bdev_reset(cijoe, device)
     err, _ = cijoe.run(f"zoned_io_async write {cli_args} --direct 1")
     assert not err
 

--- a/cijoe/tests/examples/test_zoned_io_sync.py
+++ b/cijoe/tests/examples/test_zoned_io_sync.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import get_osname, xnvme_parametrize, zoned_bdev_reset
 
 
 @xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
@@ -16,6 +16,9 @@ def test_write(cijoe, device, be_opts, cli_args):
 
     # Buffered writes to a zoned block device are flushed by the page cache with no
     # write-pointer ordering guarantee; bypass it to keep the writes sequential.
+    # The example resets the zone through the NVMe admin path where admin=nvme,
+    # which the block layer does not see; see zoned_bdev_reset()
+    zoned_bdev_reset(cijoe, device)
     err, _ = cijoe.run(f"zoned_io_sync write {cli_args} --direct 1")
     assert not err
 


### PR DESCRIPTION
One commit, for the `test_fio_engine_zns` failures that hit test_os on
trixie-iommu_enabled depending on test order, most recently three
parametrizations in one run on #770 (run 34536972409) with `fio: io_u error
on file /dev/nvme1n1: Input/output error: write offset=0` and its neighbours,
while the same job passed on main and on #777 the same hour.

The block layer since Linux 6.10 keeps a write pointer per zone in a zone
write plug and `blk_zone_wplug_prepare_bio()` fails a write that does not
start at it before the device sees the command. The suite resets and writes
zones of the same namespace through `/dev/ng1n1` and through user-space
drivers, which the block layer does not see, so after such a reset the
device reports the zone empty while the kernel still holds the pointer from
the last write it issued itself, and fio in zbd mode, which reads the write
pointers from the device and finds nothing to reset, has its first write
refused with EIO. What to look at is where the remedy sits:
`zoned_bdev_reset()` resets a zoned block device through the block device
itself, setting the kernel's pointers to zero along with the device's, and
the fio ZNS test and the two zoned write examples call it before writing.
A first cut put it in the `device` fixture ahead of every test on such a
device; that made the zoned examples' read tests fail, since they read what
the write tests before them left behind, so the call moved into the tests
that write.

Verification: reproduced by hand in the trixie CI guest (kernel 6.12.94): a
16 KiB write through `/dev/nvme1n1`, then `zoned mgmt-reset /dev/ng1n1
--slba 0`, after which `blkzone report` shows the zone empty and a 4 KiB
write at its start through the block device fails, and after
`blkzone reset /dev/nvme1n1` the same write succeeds. At the test level,
with stale pointers armed the same way on zones 0 and 1,
`test_fio_engine_zns` for `be=io_uring,mem=posix` on `/dev/nvme1n1` fails
without this change and passes with it; the whole zoned selection of the
suite, 261 cases in random order, then passed against the same guest with
the change. FreeBSD is excluded by the OS check and is only read;
there is no zone write plugging there.

Assisted-by: Claude Code:claude-fable-5
